### PR TITLE
Fix two annoying open issues with docs and source maps!

### DIFF
--- a/docs/classes/_maybe_.just.html
+++ b/docs/classes/_maybe_.just.html
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L157">maybe.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L157">maybe.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L157">maybe.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L157">maybe.ts:157</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#variant">variant</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L154">maybe.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L154">maybe.ts:154</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#and">and</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L236">maybe.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L236">maybe.ts:236</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -292,7 +292,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L241">maybe.ts:241</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L241">maybe.ts:241</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -348,7 +348,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#ap">ap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L291">maybe.ts:291</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L291">maybe.ts:291</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L246">maybe.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L246">maybe.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -444,7 +444,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#equals">equals</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L286">maybe.ts:286</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L286">maybe.ts:286</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L251">maybe.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L251">maybe.ts:251</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -531,7 +531,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#get">get</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L335">maybe.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L335">maybe.ts:335</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -602,7 +602,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#isjust">isJust</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L196">maybe.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L196">maybe.ts:196</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -631,7 +631,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#isnothing">isNothing</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L201">maybe.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L201">maybe.ts:201</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -659,7 +659,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L206">maybe.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L206">maybe.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +714,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L211">maybe.ts:211</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L211">maybe.ts:211</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -772,7 +772,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L216">maybe.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L216">maybe.ts:216</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -843,7 +843,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#match">match</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L221">maybe.ts:221</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L221">maybe.ts:221</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -881,7 +881,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#or">or</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L226">maybe.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L226">maybe.ts:226</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -912,7 +912,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L231">maybe.ts:231</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L231">maybe.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -955,7 +955,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L276">maybe.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L276">maybe.ts:276</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1005,7 +1005,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#tookorerr">toOkOrErr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L271">maybe.ts:271</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L271">maybe.ts:271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1043,7 +1043,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L281">maybe.ts:281</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L281">maybe.ts:281</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1072,7 +1072,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#unsafelyunwrap">unsafelyUnwrap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L256">maybe.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L256">maybe.ts:256</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1094,7 +1094,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L261">maybe.ts:261</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L261">maybe.ts:261</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1125,7 +1125,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L266">maybe.ts:266</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L266">maybe.ts:266</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1168,7 +1168,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L149">maybe.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L149">maybe.ts:149</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_maybe_.nothing.html
+++ b/docs/classes/_maybe_.nothing.html
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L350">maybe.ts:350</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L350">maybe.ts:350</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#variant">variant</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L350">maybe.ts:350</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L350">maybe.ts:350</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -233,7 +233,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#and">and</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L422">maybe.ts:422</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L422">maybe.ts:422</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L427">maybe.ts:427</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L427">maybe.ts:427</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#ap">ap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L477">maybe.ts:477</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L477">maybe.ts:477</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -366,7 +366,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L432">maybe.ts:432</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L432">maybe.ts:432</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -422,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#equals">equals</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L472">maybe.ts:472</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L472">maybe.ts:472</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -453,7 +453,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L437">maybe.ts:437</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L437">maybe.ts:437</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -509,7 +509,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#get">get</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L521">maybe.ts:521</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L521">maybe.ts:521</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -580,7 +580,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#isjust">isJust</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L382">maybe.ts:382</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L382">maybe.ts:382</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -609,7 +609,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#isnothing">isNothing</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L387">maybe.ts:387</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L387">maybe.ts:387</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -637,7 +637,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L392">maybe.ts:392</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L392">maybe.ts:392</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -692,7 +692,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L397">maybe.ts:397</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L397">maybe.ts:397</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -750,7 +750,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L402">maybe.ts:402</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L402">maybe.ts:402</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -821,7 +821,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#match">match</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L407">maybe.ts:407</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L407">maybe.ts:407</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -859,7 +859,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#or">or</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L412">maybe.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L412">maybe.ts:412</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -890,7 +890,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L417">maybe.ts:417</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L417">maybe.ts:417</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -933,7 +933,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L462">maybe.ts:462</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L462">maybe.ts:462</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -983,7 +983,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#tookorerr">toOkOrErr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L457">maybe.ts:457</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L457">maybe.ts:457</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1021,7 +1021,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L467">maybe.ts:467</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L467">maybe.ts:467</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1050,7 +1050,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_maybe_.maybeshape.html">MaybeShape</a>.<a href="../interfaces/_maybe_.maybeshape.html#unsafelyunwrap">unsafelyUnwrap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L442">maybe.ts:442</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L442">maybe.ts:442</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1072,7 +1072,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L447">maybe.ts:447</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L447">maybe.ts:447</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1103,7 +1103,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L452">maybe.ts:452</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L452">maybe.ts:452</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_result_.err.html
+++ b/docs/classes/_result_.err.html
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L311">result.ts:311</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L311">result.ts:311</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">E</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L311">result.ts:311</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L311">result.ts:311</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#variant">variant</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L308">result.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L308">result.ts:308</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#and">and</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L401">result.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L401">result.ts:401</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L406">result.ts:406</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L406">result.ts:406</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#ap">ap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L456">result.ts:456</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L456">result.ts:456</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L411">result.ts:411</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L411">result.ts:411</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -454,7 +454,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#equals">equals</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L451">result.ts:451</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L451">result.ts:451</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -485,7 +485,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L416">result.ts:416</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L416">result.ts:416</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -541,7 +541,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#iserr">isErr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L361">result.ts:361</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L361">result.ts:361</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -570,7 +570,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#isok">isOk</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L356">result.ts:356</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L356">result.ts:356</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -598,7 +598,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L366">result.ts:366</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L366">result.ts:366</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -653,7 +653,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L386">result.ts:386</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L386">result.ts:386</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -708,7 +708,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L371">result.ts:371</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L371">result.ts:371</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -766,7 +766,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L376">result.ts:376</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L376">result.ts:376</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -843,7 +843,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#match">match</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L381">result.ts:381</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L381">result.ts:381</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -881,7 +881,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#or">or</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L391">result.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L391">result.ts:391</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -918,7 +918,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L396">result.ts:396</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L396">result.ts:396</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -974,7 +974,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#tomaybe">toMaybe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L441">result.ts:441</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L441">result.ts:441</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1003,7 +1003,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L446">result.ts:446</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L446">result.ts:446</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1032,7 +1032,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#unsafelyunwrap">unsafelyUnwrap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L421">result.ts:421</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L421">result.ts:421</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1055,7 +1055,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#unsafelyunwraperr">unsafelyUnwrapErr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L426">result.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L426">result.ts:426</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1078,7 +1078,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#unwrapor">unwrapOr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L431">result.ts:431</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L431">result.ts:431</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1109,7 +1109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L436">result.ts:436</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L436">result.ts:436</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1158,7 +1158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L303">result.ts:303</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L303">result.ts:303</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_result_.ok.html
+++ b/docs/classes/_result_.ok.html
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L126">result.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L126">result.ts:126</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L126">result.ts:126</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L126">result.ts:126</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#variant">variant</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L123">result.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L123">result.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#and">and</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L216">result.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L216">result.ts:216</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L221">result.ts:221</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L221">result.ts:221</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#ap">ap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L271">result.ts:271</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L271">result.ts:271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L226">result.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L226">result.ts:226</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -454,7 +454,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#equals">equals</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L266">result.ts:266</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L266">result.ts:266</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -485,7 +485,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L231">result.ts:231</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L231">result.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -541,7 +541,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#iserr">isErr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L176">result.ts:176</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L176">result.ts:176</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -570,7 +570,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#isok">isOk</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L171">result.ts:171</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L171">result.ts:171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -598,7 +598,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L181">result.ts:181</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L181">result.ts:181</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -653,7 +653,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L201">result.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L201">result.ts:201</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -708,7 +708,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L186">result.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L186">result.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -766,7 +766,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L191">result.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L191">result.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -843,7 +843,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#match">match</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L196">result.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L196">result.ts:196</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -881,7 +881,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#or">or</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L206">result.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L206">result.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -918,7 +918,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L211">result.ts:211</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L211">result.ts:211</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -974,7 +974,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#tomaybe">toMaybe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L256">result.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L256">result.ts:256</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1003,7 +1003,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L261">result.ts:261</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L261">result.ts:261</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1032,7 +1032,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#unsafelyunwrap">unsafelyUnwrap</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L236">result.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L236">result.ts:236</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1055,7 +1055,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#unsafelyunwraperr">unsafelyUnwrapErr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L241">result.ts:241</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L241">result.ts:241</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1078,7 +1078,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_result_.resultshape.html">ResultShape</a>.<a href="../interfaces/_result_.resultshape.html#unwrapor">unwrapOr</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L246">result.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L246">result.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1109,7 +1109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L251">result.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L251">result.ts:251</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1158,7 +1158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L118">result.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L118">result.ts:118</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_utils_._brand.html
+++ b/docs/classes/_utils_._brand.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/utils.ts#L17">utils.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/utils.ts#L17">utils.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">_brand<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Tag</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/utils.ts#L17">utils.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/utils.ts#L17">utils.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/_maybe_.variant.html
+++ b/docs/enums/_maybe_.variant.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Just<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Just&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L14">maybe.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L14">maybe.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Nothing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Nothing&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L15">maybe.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L15">maybe.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/_result_.variant.html
+++ b/docs/enums/_result_.variant.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Err<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Err&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L19">result.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L19">result.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ok<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;Ok&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L18">result.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L18">result.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_maybe_.maybeshape.html
+++ b/docs/interfaces/_maybe_.maybeshape.html
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">variant<span class="tsd-signature-symbol">:</span> <a href="../enums/_maybe_.variant.html" class="tsd-signature-type">Variant</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L21">maybe.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L21">maybe.ts:21</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L48">maybe.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L48">maybe.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L51">maybe.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L51">maybe.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -259,7 +259,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L78">maybe.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L78">maybe.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -296,7 +296,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L54">maybe.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L54">maybe.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L75">maybe.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L75">maybe.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -382,7 +382,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L57">maybe.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L57">maybe.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L120">maybe.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L120">maybe.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -507,7 +507,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L24">maybe.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L24">maybe.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -535,7 +535,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L27">maybe.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L27">maybe.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -563,7 +563,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L30">maybe.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L30">maybe.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -618,7 +618,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L33">maybe.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L33">maybe.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -676,7 +676,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L36">maybe.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L36">maybe.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -746,7 +746,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L39">maybe.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L39">maybe.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -783,7 +783,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L42">maybe.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L42">maybe.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -814,7 +814,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L45">maybe.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L45">maybe.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -857,7 +857,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L69">maybe.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L69">maybe.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -906,7 +906,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L66">maybe.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L66">maybe.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -943,7 +943,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L72">maybe.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L72">maybe.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -971,7 +971,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L60">maybe.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L60">maybe.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -996,7 +996,7 @@ deeperKeys: <span class="hljs-string">'like this'</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L63">maybe.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L63">maybe.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_result_.resultshape.html
+++ b/docs/interfaces/_result_.resultshape.html
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">variant<span class="tsd-signature-symbol">:</span> <a href="../enums/_result_.variant.html" class="tsd-signature-type">Variant</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L25">result.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L25">result.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L55">result.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L55">result.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L58">result.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L58">result.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L88">result.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L88">result.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -303,7 +303,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L61">result.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L61">result.ts:61</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -358,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L85">result.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L85">result.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -389,7 +389,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L64">result.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L64">result.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -444,7 +444,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L31">result.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L31">result.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -472,7 +472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L28">result.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L28">result.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -500,7 +500,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L34">result.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L34">result.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -555,7 +555,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L46">result.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L46">result.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -610,7 +610,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L37">result.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L37">result.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -668,7 +668,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L40">result.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L40">result.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -744,7 +744,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L43">result.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L43">result.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -781,7 +781,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L49">result.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L49">result.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -818,7 +818,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L52">result.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L52">result.ts:52</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -873,7 +873,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L79">result.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L79">result.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -901,7 +901,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L82">result.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L82">result.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -929,7 +929,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L67">result.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L67">result.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -954,7 +954,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L70">result.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L70">result.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -979,7 +979,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L73">result.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L73">result.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1010,7 +1010,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L76">result.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L76">result.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_maybe_.html
+++ b/docs/modules/_maybe_.html
@@ -69,7 +69,116 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>[[include:doc/maybe.md]]</p>
+						<h1 id="maybe">Maybe</h1>
+						<p>A <a href="#maybe"><code>Maybe&lt;T&gt;</code></a> represents a value of type <code>T</code> which may, or may not, be present.</p>
+						<p>If the value is present, it is <code>Just(value)</code>. If it&#39;s absent, it&#39;s <code>Nothing</code>. This provides a type-safe container for dealing with the possibility that there&#39;s nothing here – a container you can do many of the same things you might with an array – so that you can avoid nasty <code>null</code> and <code>undefined</code> checks throughout your codebase.</p>
+						<p>The behavior of this type is checked by TypeScript or Flow at compile time, and bears no runtime overhead other than the very small cost of the container object and some lightweight wrap/unwrap functionality.</p>
+						<p>The <code>Nothing</code> variant has a type parameter <code>&lt;T&gt;</code> so that type inference works correctly in TypeScript when operating on <code>Nothing</code> instances with functions which require a <code>T</code> to behave properly, e.g. <a href="https://chriskrycho.github.io/true-myth/modules/_maybe_.html#map"><code>map</code></a>, which cannot check that the map function satisfies the type constraints for <code>Maybe&lt;T&gt;</code> unless <code>Nothing</code> has a parameter <code>T</code> to constrain it on invocation.</p>
+						<p>Put simply: without the type parameter, if you had a <code>Nothing</code> variant of a <code>Maybe&lt;string&gt;</code>, and you tried to use it with a function which expected a <code>Maybe&lt;number&gt;</code> it would still type check – because TypeScript doesn&#39;t have enough information to check that it <em>doesn&#39;t</em> meet the requirements.</p>
+						<h2 id="using-maybe">Using <code>Maybe</code></h2>
+						<p>The library is designed to be used with a functional style, allowing you to compose operations easily. Thus, standalone pure function versions of every operation are supplied. However, the same operations also exist on the <code>Just</code> and <code>Nothing</code> types directly, so you may also write them in a more traditional &quot;fluent&quot; object style.</p>
+						<h3 id="examples-functional-style">Examples: functional style</h3>
+						<pre><code class="language-ts"><span class="hljs-keyword">import</span> Maybe <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/maybe'</span>;
+
+<span class="hljs-comment">// Construct a `Just` where you have a value to use, and the function accepts</span>
+<span class="hljs-comment">// a `Maybe`.</span>
+<span class="hljs-keyword">const</span> aKnownNumber = Maybe.just(<span class="hljs-number">12</span>);
+
+<span class="hljs-comment">// Construct a `Nothing` where you don't have a value to use, but the</span>
+<span class="hljs-comment">// function requires a value (and accepts a `Maybe`).</span>
+<span class="hljs-keyword">const</span> aKnownNothing = Maybe.nothing&lt;<span class="hljs-built_in">string</span>&gt;();
+
+<span class="hljs-comment">// Construct a `Maybe` where you don't know whether the value will exist or</span>
+<span class="hljs-comment">// not, using `of`.</span>
+<span class="hljs-keyword">type</span> WhoKnows = { mightBeAThing?: <span class="hljs-built_in">boolean</span>[] };
+
+<span class="hljs-keyword">const</span> whoKnows: WhoKnows = {};
+<span class="hljs-keyword">const</span> wrappedWhoKnows = Maybe.of(whoKnows.mightBeAThing);
+<span class="hljs-built_in">console</span>.log(toString(wrappedWhoKnows)); <span class="hljs-comment">// Nothing</span>
+
+<span class="hljs-keyword">const</span> whoElseKnows: WhoKnows = { mightBeAThing: [<span class="hljs-literal">true</span>, <span class="hljs-literal">false</span>] };
+<span class="hljs-keyword">const</span> wrappedWhoElseKnows = Maybe.of(whoElseKnows.mightBeAThing);
+<span class="hljs-built_in">console</span>.log(toString(wrappedWhoElseKnows)); <span class="hljs-comment">// "Just(true,false)"</span></code></pre>
+						<h3 id="examples-fluent-object-invocation">Examples: fluent object invocation</h3>
+						<p><strong>Note:</strong> in the &quot;class&quot;-style, if you are constructing a <code>Maybe</code> from an unknown source, you must either do the work to check the value yourself, or use <code>Maybe.of</code> – you can&#39;t know at that point whether it&#39;s safe to construct a <code>Just</code> without checking, but <code>of</code> will always work correctly!</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> { isVoid } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/utils'</span>;
+<span class="hljs-keyword">import</span> Maybe, { Just, Nothing } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/maybe'</span>;
+
+<span class="hljs-comment">// Construct a `Just` where you have a value to use, and the function accepts</span>
+<span class="hljs-comment">// a `Maybe`.</span>
+<span class="hljs-keyword">const</span> aKnownNumber = <span class="hljs-keyword">new</span> Just(<span class="hljs-number">12</span>);
+
+<span class="hljs-comment">// Once the item is constructed, you can apply methods directly on it.</span>
+<span class="hljs-keyword">const</span> fromMappedJust = aKnownNumber.map(<span class="hljs-function"><span class="hljs-params">x</span> =&gt;</span> x * <span class="hljs-number">2</span>).unwrapOr(<span class="hljs-number">0</span>);
+<span class="hljs-built_in">console</span>.log(fromMappedJust); <span class="hljs-comment">// 24</span>
+
+<span class="hljs-comment">// Construct a `Nothing` where you don't have a value to use, but the</span>
+<span class="hljs-comment">// function requires a value (and accepts a `Maybe&lt;string&gt;`).</span>
+<span class="hljs-keyword">const</span> aKnownNothing = <span class="hljs-keyword">new</span> Nothing();
+
+<span class="hljs-comment">// The same operations will behave safely on a `Nothing` as on a `Just`:</span>
+<span class="hljs-keyword">const</span> fromMappedNothing = aKnownNothing.map(<span class="hljs-function"><span class="hljs-params">x</span> =&gt;</span> x * <span class="hljs-number">2</span>).unwrapOr(<span class="hljs-number">0</span>);
+<span class="hljs-built_in">console</span>.log(fromMappedNothing); <span class="hljs-comment">// 0</span>
+
+<span class="hljs-comment">// Construct a `Maybe` where you don't know whether the value will exist or</span>
+<span class="hljs-comment">// not, using `isVoid` to decide which to construct.</span>
+<span class="hljs-keyword">type</span> WhoKnows = { mightBeAThing?: <span class="hljs-built_in">boolean</span>[] };
+
+<span class="hljs-keyword">const</span> whoKnows: WhoKnows = {};
+<span class="hljs-keyword">const</span> wrappedWhoKnows = !isVoid(whoKnows.mightBeAThing)
+  ? <span class="hljs-keyword">new</span> Just(whoKnows.mightBeAThing)
+  : <span class="hljs-keyword">new</span> Nothing();
+
+<span class="hljs-built_in">console</span>.log(wrappedWhoKnows.toString()); <span class="hljs-comment">// Nothing</span>
+
+<span class="hljs-keyword">const</span> whoElseKnows: WhoKnows = { mightBeAThing: [<span class="hljs-literal">true</span>, <span class="hljs-literal">false</span>] };
+<span class="hljs-keyword">const</span> wrappedWhoElseKnows = !isVoid(whoElseKnows.mightBeAThing)
+  ? <span class="hljs-keyword">new</span> Just(whoElseKnows.mightBeAThing)
+  : <span class="hljs-keyword">new</span> Nothing();
+
+<span class="hljs-built_in">console</span>.log(wrappedWhoElseKnows.toString()); <span class="hljs-comment">// "Just(true,false)"</span></code></pre>
+						<p>As you can see, it&#39;s often advantageous to use <code>Maybe.of</code> even if you&#39;re otherwise inclined to use the class method approach; it dramatically cuts down the boilerplate you have to write (since, under the hood, it&#39;s doing exactly this check!).</p>
+						<h3 id="prefer-maybe-of">Prefer <a href="https://chriskrycho.github.io/true-myth/modules/_maybe_.html#of"><code>Maybe.of</code></a></h3>
+						<p>In fact, if you&#39;re dealing with data you are not constructing directly yourself, <strong><em>always</em></strong> prefer to use [<code>Maybe.of</code>] to create a new <code>Maybe</code>. If an API lies to you for some reason and hands you an <code>undefined</code> or a <code>null</code> (even though you expect it to be an actual <code>T</code> in a specific scenario), the <code>.of()</code> function will still construct it correctly for you.</p>
+						<p>By contrast, if you do <code>Maybe.just(someVariable)</code> and <code>someVariable</code> is <code>null</code> or <code>undefined</code>, the program will throw at that point. This is a simple consequence of the need to make the <code>new Just()</code> constructor work; we cannot construct <code>Just</code> safely in a way that excludes a type of <code>Maybe&lt;null&gt;</code> or <code>Maybe&lt;undefined&gt;</code> otherwise – and that would defeat the whole purpose of using a <code>Maybe</code>!</p>
+						<h3 id="writing-type-constraints">Writing type constraints</h3>
+						<p>Especially when constructing a <code>Nothing</code>, you may need to specify what <em>kind</em> of <code>Nothing</code> it is. The TypeScript and Flow type systems can figure it out based on the value passed in for a <code>Just</code>, but there&#39;s no value to use with a <code>Nothing</code>, so you may have to specify it. In that case, you can write the type explicitly:</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> Maybe, { nothing } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/maybe'</span>;
+
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">takesAMaybeString</span>(<span class="hljs-params">thingItTakes: Maybe&lt;<span class="hljs-built_in">string</span>&gt;</span>) </span>{
+  <span class="hljs-built_in">console</span>.log(thingItTakes.unwrapOr(<span class="hljs-string">''</span>));
+}
+
+<span class="hljs-comment">// Via type definition</span>
+<span class="hljs-keyword">const</span> nothingHere: Maybe&lt;<span class="hljs-built_in">string</span>&gt; = nothing();
+takesAMaybeString(nothingHere);
+
+<span class="hljs-comment">// Via type coercion</span>
+<span class="hljs-keyword">const</span> nothingHereEither = nothing&lt;<span class="hljs-built_in">string</span>&gt;();
+takesAMaybeString(nothingHereEither);</code></pre>
+						<p>Note that this <em>is</em> necessary if you declare the <code>Maybe</code> in a statement inside a function, but is <em>not</em> necessary when you have an expression-bodied arrow function or when you return the item directly:</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> Maybe, { nothing } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/maybe'</span>;
+
+<span class="hljs-comment">// ERROR: Type 'Maybe&lt;{}&gt;' is not assignable to type 'Maybe&lt;number&gt;'.</span>
+<span class="hljs-keyword">const</span> getAMaybeNotAssignable = (): Maybe&lt;<span class="hljs-built_in">number</span>&gt; =&gt; {
+  <span class="hljs-keyword">const</span> theMaybe = nothing();
+  <span class="hljs-keyword">return</span> theMaybe;
+};
+
+<span class="hljs-comment">// Succeeds</span>
+<span class="hljs-keyword">const</span> getAMaybeExpression = (shouldBeJust: <span class="hljs-built_in">boolean</span>): Maybe&lt;<span class="hljs-built_in">number</span>&gt; =&gt; nothing();
+
+<span class="hljs-comment">// Succeeds</span>
+<span class="hljs-keyword">const</span> getAMaybeReturn = (shouldBeJust: <span class="hljs-built_in">boolean</span>): Maybe&lt;<span class="hljs-built_in">number</span>&gt; =&gt; {
+  <span class="hljs-keyword">return</span> nothing();
+};</code></pre>
+						<h2 id="using-maybe-effectively">Using <code>Maybe</code> Effectively</h2>
+						<p>The best times to create and safely unwrap <code>Maybe</code>s are at the <em>boundaries</em> of your application. When you are deserializing data from an API, or when you are handling user input, you can use a <code>Maybe</code> instance to handle the possibility that there&#39;s just nothing there, if there is no good default value to use <em>everywhere</em> in the application. Within the business logic of your application, you can then safely deal with the data by using the <code>Maybe</code> functions or method until you hit another boundary, and then you can choose how best to handle it at that point.</p>
+						<p>You won&#39;t normally need to unwrap it at any point <em>other</em> than the boundaries, because you can simply apply any transformations using the helper functions or methods, and be confident that you&#39;ll have either correctly transformed data, or a <code>Nothing</code>, at the end, depending on your inputs.</p>
+						<p>If you are handing data off to another API, for example, you might convert a <code>Nothing</code> right back into a <code>null</code> in a JSON payload, as that&#39;s a reasonable way to send the data across the wire – the consumer can then decide how to handle it as is appropriate in its own context.</p>
+						<p>If you are rendering a UI, having a <code>Nothing</code> when you need to render gives you an opportunity to provide default/fallback content – whether that&#39;s an explanation that there&#39;s nothing there, or a sensible substitute, or anything else that might be appropriate at that point in your app.</p>
+						<p>You may also be tempted to use <code>Maybe</code>s to replace boolean flags or similar approaches for defining branching behavior or output from a function. You should avoid that, in general. Reserve <code>Maybe</code> for modeling the possible <em>absence of data</em>, and nothing else. Prefer to use <code>Result</code> or <code>Either</code> for <em>fallible</em> or <em>disjoint</em> scenarios instead – or construct your own union types if you have more than two boundaries!</p>
+						<p>Finally, and along similar lines, if you find yourself building a data structure with a lot of <code>Maybe</code> types in it, you should consider it a &quot;code smell&quot; – something wrong with your model. It usually means you should find a way to refactor the data structure into a union of smaller data structures which more accurately capture the domain you&#39;re modeling.</p>
 					</div>
 				</div>
 			</section>
@@ -170,7 +279,7 @@
 					<div class="tsd-signature tsd-kind-icon">All<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">All&lt;T&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1554">maybe.ts:1554</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1554">maybe.ts:1554</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +289,7 @@
 					<div class="tsd-signature tsd-kind-icon">Matcher<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1121">maybe.ts:1121</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1121">maybe.ts:1121</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -236,7 +345,7 @@
 					<div class="tsd-signature tsd-kind-icon">Predicate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1403">maybe.ts:1403</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1403">maybe.ts:1403</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -276,7 +385,7 @@
 					<div class="tsd-signature tsd-kind-icon">cata<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#match" class="tsd-signature-type">match</a><span class="tsd-signature-symbol"> =&nbsp;match</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1185">maybe.ts:1185</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1185">maybe.ts:1185</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -291,7 +400,7 @@
 					<div class="tsd-signature tsd-kind-icon">chain<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#andthen" class="tsd-signature-type">andThen</a><span class="tsd-signature-symbol"> =&nbsp;andThen</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L877">maybe.ts:877</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L877">maybe.ts:877</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -306,7 +415,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#head" class="tsd-signature-type">head</a><span class="tsd-signature-symbol"> =&nbsp;head</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1492">maybe.ts:1492</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1492">maybe.ts:1492</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -321,7 +430,7 @@
 					<div class="tsd-signature tsd-kind-icon">flat<wbr>Map<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#andthen" class="tsd-signature-type">andThen</a><span class="tsd-signature-symbol"> =&nbsp;andThen</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L880">maybe.ts:880</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L880">maybe.ts:880</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -336,7 +445,7 @@
 					<div class="tsd-signature tsd-kind-icon">from<wbr>Nullable<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#of" class="tsd-signature-type">of</a><span class="tsd-signature-symbol"> =&nbsp;of</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L611">maybe.ts:611</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L611">maybe.ts:611</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -351,7 +460,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unwrapor" class="tsd-signature-type">unwrapOr</a><span class="tsd-signature-symbol"> =&nbsp;unwrapOr</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L996">maybe.ts:996</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L996">maybe.ts:996</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -366,7 +475,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unwraporelse" class="tsd-signature-type">unwrapOrElse</a><span class="tsd-signature-symbol"> =&nbsp;unwrapOrElse</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1035">maybe.ts:1035</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1035">maybe.ts:1035</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -381,7 +490,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsafe<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a><span class="tsd-signature-symbol"> =&nbsp;unsafelyUnwrap</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L964">maybe.ts:964</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L964">maybe.ts:964</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -396,7 +505,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a><span class="tsd-signature-symbol"> =&nbsp;unsafelyUnwrap</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L961">maybe.ts:961</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L961">maybe.ts:961</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -418,7 +527,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1540">maybe.ts:1540</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1540">maybe.ts:1540</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -471,7 +580,7 @@ Maybe.all(...invalid); <span class="hljs-comment">// =&gt; Nothing</span></code>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L804">maybe.ts:804</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L804">maybe.ts:804</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -534,7 +643,7 @@ Maybe.all(...invalid); <span class="hljs-comment">// =&gt; Nothing</span></code>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L805">maybe.ts:805</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L805">maybe.ts:805</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -585,7 +694,7 @@ Maybe.all(...invalid); <span class="hljs-comment">// =&gt; Nothing</span></code>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L866">maybe.ts:866</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L866">maybe.ts:866</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -677,7 +786,7 @@ Maybe.all(...invalid); <span class="hljs-comment">// =&gt; Nothing</span></code>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L867">maybe.ts:867</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L867">maybe.ts:867</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -746,7 +855,7 @@ Maybe.all(...invalid); <span class="hljs-comment">// =&gt; Nothing</span></code>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1379">maybe.ts:1379</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1379">maybe.ts:1379</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -904,7 +1013,7 @@ Maybe.of(toStr).ap(<span class="hljs-number">12</span>); <span class="hljs-comme
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1380">maybe.ts:1380</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1380">maybe.ts:1380</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -955,7 +1064,7 @@ Maybe.of(toStr).ap(<span class="hljs-number">12</span>); <span class="hljs-comme
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1205">maybe.ts:1205</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1205">maybe.ts:1205</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -998,7 +1107,7 @@ Maybe.equals(c, d); <span class="hljs-comment">// true</span></code></pre>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1206">maybe.ts:1206</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1206">maybe.ts:1206</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1046,7 +1155,7 @@ Maybe.equals(c, d); <span class="hljs-comment">// true</span></code></pre>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1461">maybe.ts:1461</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1461">maybe.ts:1461</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1118,7 +1227,7 @@ fetch(<span class="hljs-string">'https://arrays.example.com'</span>)
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1462">maybe.ts:1462</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1462">maybe.ts:1462</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1165,7 +1274,7 @@ fetch(<span class="hljs-string">'https://arrays.example.com'</span>)
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1092">maybe.ts:1092</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1092">maybe.ts:1092</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1210,7 +1319,7 @@ fetch(<span class="hljs-string">'https://arrays.example.com'</span>)
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1716">maybe.ts:1716</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1716">maybe.ts:1716</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1276,7 +1385,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1717">maybe.ts:1717</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1717">maybe.ts:1717</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1326,7 +1435,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1487">maybe.ts:1487</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1487">maybe.ts:1487</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1370,7 +1479,7 @@ Maybe.head(full); <span class="hljs-comment">// =&gt; Just(1)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1399">maybe.ts:1399</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1399">maybe.ts:1399</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1407,7 +1516,7 @@ Maybe.head(full); <span class="hljs-comment">// =&gt; Just(1)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L534">maybe.ts:534</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L534">maybe.ts:534</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1449,7 +1558,7 @@ Maybe.head(full); <span class="hljs-comment">// =&gt; Just(1)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L546">maybe.ts:546</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L546">maybe.ts:546</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1491,7 +1600,7 @@ Maybe.head(full); <span class="hljs-comment">// =&gt; Just(1)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L562">maybe.ts:562</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L562">maybe.ts:562</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1540,7 +1649,7 @@ Maybe.head(full); <span class="hljs-comment">// =&gt; Just(1)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1510">maybe.ts:1510</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1510">maybe.ts:1510</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1585,7 +1694,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L655">maybe.ts:655</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L655">maybe.ts:655</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1688,7 +1797,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L656">maybe.ts:656</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L656">maybe.ts:656</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1743,7 +1852,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L689">maybe.ts:689</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L689">maybe.ts:689</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1821,7 +1930,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L690">maybe.ts:690</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L690">maybe.ts:690</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1883,7 +1992,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L691">maybe.ts:691</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L691">maybe.ts:691</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1971,7 +2080,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L741">maybe.ts:741</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L741">maybe.ts:741</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2062,7 +2171,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L742">maybe.ts:742</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L742">maybe.ts:742</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2136,7 +2245,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L743">maybe.ts:743</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L743">maybe.ts:743</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2235,7 +2344,7 @@ Maybe.last(full); <span class="hljs-comment">// =&gt; Just(3)</span></code></pre
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1176">maybe.ts:1176</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1176">maybe.ts:1176</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2306,7 +2415,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1177">maybe.ts:1177</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1177">maybe.ts:1177</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2356,7 +2465,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L580">maybe.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L580">maybe.ts:580</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2398,7 +2507,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L606">maybe.ts:606</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L606">maybe.ts:606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2451,7 +2560,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L909">maybe.ts:909</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L909">maybe.ts:909</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2504,7 +2613,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L910">maybe.ts:910</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L910">maybe.ts:910</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2552,7 +2661,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L935">maybe.ts:935</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L935">maybe.ts:935</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2608,7 +2717,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L936">maybe.ts:936</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L936">maybe.ts:936</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2668,7 +2777,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1656">maybe.ts:1656</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1656">maybe.ts:1656</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2736,7 +2845,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1657">maybe.ts:1657</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1657">maybe.ts:1657</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2787,7 +2896,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1071">maybe.ts:1071</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1071">maybe.ts:1071</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2846,7 +2955,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1072">maybe.ts:1072</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1072">maybe.ts:1072</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2909,7 +3018,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1049">maybe.ts:1049</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1049">maybe.ts:1049</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2956,7 +3065,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1050">maybe.ts:1050</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1050">maybe.ts:1050</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3006,7 +3115,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1115">maybe.ts:1115</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1115">maybe.ts:1115</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3078,7 +3187,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1594">maybe.ts:1594</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1594">maybe.ts:1594</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3125,7 +3234,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1595">maybe.ts:1595</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1595">maybe.ts:1595</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3148,7 +3257,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1596">maybe.ts:1596</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1596">maybe.ts:1596</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3174,7 +3283,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1597">maybe.ts:1597</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1597">maybe.ts:1597</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3212,7 +3321,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L956">maybe.ts:956</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L956">maybe.ts:956</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3261,7 +3370,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L988">maybe.ts:988</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L988">maybe.ts:988</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3309,7 +3418,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L989">maybe.ts:989</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L989">maybe.ts:989</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3357,7 +3466,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1027">maybe.ts:1027</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1027">maybe.ts:1027</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3424,7 +3533,7 @@ player2: <span class="hljs-number">1</span>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1028">maybe.ts:1028</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1028">maybe.ts:1028</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3482,8 +3591,8 @@ player2: <span class="hljs-number">1</span>
 					<div class="tsd-signature tsd-kind-icon">Maybe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1726">maybe.ts:1726</a></li>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1727">maybe.ts:1727</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1726">maybe.ts:1726</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1727">maybe.ts:1727</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -3497,7 +3606,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">Just<span class="tsd-signature-symbol">:</span> <a href="../classes/_maybe_.just.html" class="tsd-signature-type">Just</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1729">maybe.ts:1729</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1729">maybe.ts:1729</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3507,7 +3616,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">Nothing<span class="tsd-signature-symbol">:</span> <a href="../classes/_maybe_.nothing.html" class="tsd-signature-type">Nothing</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1730">maybe.ts:1730</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1730">maybe.ts:1730</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3517,7 +3626,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">Variant<span class="tsd-signature-symbol">:</span> <a href="../enums/_maybe_.variant.html" class="tsd-signature-type">Variant</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1728">maybe.ts:1728</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1728">maybe.ts:1728</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3527,7 +3636,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">all<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#all-1" class="tsd-signature-type">all</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1731">maybe.ts:1731</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1731">maybe.ts:1731</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3537,7 +3646,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">and<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#and" class="tsd-signature-type">and</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1745">maybe.ts:1745</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1745">maybe.ts:1745</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3547,7 +3656,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">and<wbr>Then<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#andthen" class="tsd-signature-type">andThen</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1746">maybe.ts:1746</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1746">maybe.ts:1746</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3557,7 +3666,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">ap<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#ap" class="tsd-signature-type">ap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1766">maybe.ts:1766</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1766">maybe.ts:1766</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3567,7 +3676,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">cata<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#match" class="tsd-signature-type">match</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1764">maybe.ts:1764</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1764">maybe.ts:1764</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3577,7 +3686,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">chain<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#andthen" class="tsd-signature-type">andThen</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1747">maybe.ts:1747</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1747">maybe.ts:1747</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3587,7 +3696,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">equals<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#equals" class="tsd-signature-type">equals</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1765">maybe.ts:1765</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1765">maybe.ts:1765</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3597,7 +3706,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">find<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#find" class="tsd-signature-type">find</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1737">maybe.ts:1737</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1737">maybe.ts:1737</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3607,7 +3716,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">first<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#head" class="tsd-signature-type">head</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1738">maybe.ts:1738</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1738">maybe.ts:1738</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3617,7 +3726,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">flat<wbr>Map<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#andthen" class="tsd-signature-type">andThen</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1748">maybe.ts:1748</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1748">maybe.ts:1748</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3627,7 +3736,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">from<wbr>Nullable<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#of" class="tsd-signature-type">of</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1739">maybe.ts:1739</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1739">maybe.ts:1739</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3637,7 +3746,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">from<wbr>Result<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#fromresult" class="tsd-signature-type">fromResult</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1760">maybe.ts:1760</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1760">maybe.ts:1760</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3647,7 +3756,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#get" class="tsd-signature-type">get</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1769">maybe.ts:1769</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1769">maybe.ts:1769</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3657,7 +3766,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">get<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unwrapor" class="tsd-signature-type">unwrapOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1755">maybe.ts:1755</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1755">maybe.ts:1755</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3667,7 +3776,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">get<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unwraporelse" class="tsd-signature-type">unwrapOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1757">maybe.ts:1757</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1757">maybe.ts:1757</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3677,7 +3786,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">head<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#head" class="tsd-signature-type">head</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1740">maybe.ts:1740</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1740">maybe.ts:1740</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3687,7 +3796,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">is<wbr>Instance<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#isinstance" class="tsd-signature-type">isInstance</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1767">maybe.ts:1767</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1767">maybe.ts:1767</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3697,7 +3806,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">is<wbr>Just<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#isjust" class="tsd-signature-type">isJust</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1732">maybe.ts:1732</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1732">maybe.ts:1732</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3707,7 +3816,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">is<wbr>Nothing<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#isnothing" class="tsd-signature-type">isNothing</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1733">maybe.ts:1733</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1733">maybe.ts:1733</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3717,7 +3826,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">just<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#just-2" class="tsd-signature-type">just</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1734">maybe.ts:1734</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1734">maybe.ts:1734</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3727,7 +3836,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">last<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#last" class="tsd-signature-type">last</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1741">maybe.ts:1741</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1741">maybe.ts:1741</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3737,7 +3846,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">map<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#map" class="tsd-signature-type">map</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1742">maybe.ts:1742</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1742">maybe.ts:1742</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3747,7 +3856,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">map<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#mapor" class="tsd-signature-type">mapOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1743">maybe.ts:1743</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1743">maybe.ts:1743</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3757,7 +3866,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">map<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#maporelse" class="tsd-signature-type">mapOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1744">maybe.ts:1744</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1744">maybe.ts:1744</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3767,7 +3876,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">match<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#match" class="tsd-signature-type">match</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1763">maybe.ts:1763</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1763">maybe.ts:1763</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3777,7 +3886,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">nothing<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#nothing-2" class="tsd-signature-type">nothing</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1735">maybe.ts:1735</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1735">maybe.ts:1735</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3787,7 +3896,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">of<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#of" class="tsd-signature-type">of</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1736">maybe.ts:1736</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1736">maybe.ts:1736</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3797,7 +3906,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">or<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#or" class="tsd-signature-type">or</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1749">maybe.ts:1749</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1749">maybe.ts:1749</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3807,7 +3916,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">or<wbr>Else<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#orelse" class="tsd-signature-type">orElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1750">maybe.ts:1750</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1750">maybe.ts:1750</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3817,7 +3926,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">property<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#property" class="tsd-signature-type">property</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1768">maybe.ts:1768</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1768">maybe.ts:1768</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3827,7 +3936,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">to<wbr>OkOr<wbr>Else<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#tookorelseerr" class="tsd-signature-type">toOkOrElseErr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1759">maybe.ts:1759</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1759">maybe.ts:1759</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3837,7 +3946,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">to<wbr>OkOr<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#tookorerr" class="tsd-signature-type">toOkOrErr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1758">maybe.ts:1758</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1758">maybe.ts:1758</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3847,7 +3956,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">to<wbr>String<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#tostring" class="tsd-signature-type">toString</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1761">maybe.ts:1761</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1761">maybe.ts:1761</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3857,7 +3966,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">tuple<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#tuple" class="tsd-signature-type">tuple</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1762">maybe.ts:1762</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1762">maybe.ts:1762</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3867,7 +3976,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">unsafe<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1753">maybe.ts:1753</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1753">maybe.ts:1753</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3877,7 +3986,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1752">maybe.ts:1752</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1752">maybe.ts:1752</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3887,7 +3996,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Unwrap<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1751">maybe.ts:1751</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1751">maybe.ts:1751</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3897,7 +4006,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">unwrap<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unwrapor" class="tsd-signature-type">unwrapOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1754">maybe.ts:1754</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1754">maybe.ts:1754</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3907,7 +4016,7 @@ player2: <span class="hljs-number">1</span>
 						<div class="tsd-signature tsd-kind-icon">unwrap<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_maybe_.html#unwraporelse" class="tsd-signature-type">unwrapOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/maybe.ts#L1756">maybe.ts:1756</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/maybe.ts#L1756">maybe.ts:1756</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/modules/_result_.html
+++ b/docs/modules/_result_.html
@@ -69,7 +69,118 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>[[include:doc/result.md]]</p>
+						<h1 id="result">Result</h1>
+						<p>A <code>Result&lt;T, E&gt;</code> is a type representing the value result of an operation which may fail, with a successful value of type <code>T</code> or an error of type <code>E</code>.</p>
+						<p>If the value is present, it is <code>Ok(value)</code>. If it&#39;s absent, it&#39;s <code>Err(reason)</code>. This provides a type-safe container for dealing with the possibility that an error occurred, without needing to scatter <code>try</code>/<code>catch</code> blocks throughout your codebase. This has two major advantages:</p>
+						<ol>
+							<li>You <em>know</em> when an item may have a failure case, unlike exceptions (which may be thrown from any function with no warning and no help from the type system).</li>
+							<li>The error scenario is a first-class citizen, and the provided helper functions and methods allow you to deal with the type in much the same way as you might an array – transforming values if present, or dealing with errors instead if necessary.</li>
+						</ol>
+						<p>Having the possibility of an error handed to you as part of the type of an item gives you the flexibility to do the same kinds of things with it that you might with any other nice container type. For example, you can use <a href="https://chriskrycho.github.io/true-myth/modules/_result_.html#map"><code>map</code></a> to apply a transformation if the item represents a successful outcome, and even if the result was actually an error, it won&#39;t break under you.</p>
+						<p>To make that concrete, let&#39;s look at an example. In normal JavaScript, you might have something like this:</p>
+						<pre><code class="language-js"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">mightSucceed</span>(<span class="hljs-params">doesSucceed</span>) </span>{
+  <span class="hljs-keyword">if</span> (!doesSucceed) {
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'something went wrong!'</span>);
+  }
+
+  <span class="hljs-keyword">return</span> <span class="hljs-number">42</span>;
+}
+
+<span class="hljs-keyword">const</span> doubleTheAnswer = mightSucceed(<span class="hljs-literal">true</span>) * <span class="hljs-number">2</span>;
+<span class="hljs-built_in">console</span>.log(doubleTheAnswer); <span class="hljs-comment">// 84; this is fine</span>
+
+<span class="hljs-keyword">const</span> doubleAnError = mightSucceed(<span class="hljs-literal">false</span>) * <span class="hljs-number">2</span>; <span class="hljs-comment">// throws an uncaught exception</span>
+<span class="hljs-built_in">console</span>.log(doubleAnErr); <span class="hljs-comment">// never even gets here because of the exception</span></code></pre>
+						<p>If we wanted to <em>handle</em> that error, we&#39;d need to first of all know that the function could throw an error. Assuming we knew that – probably we&#39;d figure it out via painful discovery at runtime, or by documenting it in our JSDoc – then we&#39;d need to wrap it up in a <code>try</code>/<code>catch</code> block:</p>
+						<pre><code class="language-js"><span class="hljs-keyword">try</span> {
+  <span class="hljs-keyword">const</span> doubleTheAnswer = mightSucceed(<span class="hljs-literal">true</span>) * <span class="hljs-number">2</span>;
+  <span class="hljs-built_in">console</span>.log(doubleTheAnswer);
+
+  <span class="hljs-keyword">const</span> doubleAnError = mightSucceed(<span class="hljs-literal">false</span>) * <span class="hljs-number">2</span>;
+} <span class="hljs-keyword">catch</span> (ex) {
+  <span class="hljs-built_in">console</span>.log(ex.message);
+}</code></pre>
+						<p>This is a pain to work with!</p>
+						<p>The next thing we might try is returning an error code and mutating an object passed in. (This is the standard pattern for non-exception-based error handling in C, C++, Java, and C#, for example.) But that has a few problems:</p>
+						<ul>
+							<li><p>You have to mutate an object. This doesn&#39;t work for simple items like numbers, and it can also be pretty unexpected behavior at times – you want to <em>know</em> when something is going to change, and mutating freely throughout a library or application makes that impossible.</p>
+							</li>
+							<li><p>You have to make sure to actually check the return code to make sure it&#39;s valid. In theory, we&#39;re all disciplined enough to always do that. In practice, we often end up reasoning, <em>Well, this particular call can never fail...</em> (but of course, it probably can, just not in a way we expect).</p>
+							</li>
+							<li><p>We don&#39;t have a good way to return a <em>reason</em> for the error. We end up needing to introduce another parameter, designed to be mutated, to make sure that&#39;s possible.</p>
+							</li>
+							<li><p>Even if you go to all the trouble of doing all of that, you need to make sure – every time – that you use only the error value if the return code specified an error, and only the success value if the return code specified that it succeeded.</p>
+							</li>
+						</ul>
+						<p>(Note that in slightly varied form, this is also basically what the Node.js callback pattern gives you. It&#39;s just a conventional way of needing to check for an error on every callback invocation, since you don&#39;t actually have a return code in that case.)</p>
+						<p>Our way out is <code>Result</code>. It lets us just return one thing from a function, which encapsulates the possibility of failure in the very thing we return. We get:</p>
+						<ul>
+							<li>the simplicity of just dealing with the return value of a function (no <code>try</code>/<code>catch</code> to worry about!)</li>
+							<li>the ease of expressing an error we got with throwing an exception</li>
+							<li>the explicitness about success or failure that we got with a return code</li>
+						</ul>
+						<p>Here&#39;s what that same example from above would look like using <code>Result</code>:</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> Result, { ok, err, map, toString } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/result'</span>;
+
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">mightSucceed</span>(<span class="hljs-params">doesSucceed: <span class="hljs-built_in">boolean</span></span>): <span class="hljs-title">Result</span>&lt;<span class="hljs-title">number</span>, <span class="hljs-title">string</span>&gt; </span>{
+  <span class="hljs-keyword">return</span> doesSucceed ? ok(<span class="hljs-number">42</span>) : err(<span class="hljs-string">'something went wrong!'</span>);
+}
+
+<span class="hljs-keyword">const</span> double = <span class="hljs-function">(<span class="hljs-params">x: <span class="hljs-built_in">number</span></span>) =&gt;</span> x * <span class="hljs-number">2</span>;
+
+<span class="hljs-keyword">const</span> doubleTheAnswer = map(double, mightSucceed(<span class="hljs-literal">true</span>));
+<span class="hljs-built_in">console</span>.log(toString(doubleTheAnswer)); <span class="hljs-comment">// `Ok(84)`</span>
+
+<span class="hljs-keyword">const</span> doubleAnErr = map(double, mightSucceed(<span class="hljs-literal">false</span>));
+<span class="hljs-built_in">console</span>.log(toString(doubleAnErr)); <span class="hljs-comment">// `Err('something went wrong')`</span></code></pre>
+						<p>Note that if we tried to call <code>mightSucceed(true) * 2</code> here, we&#39;d get a type error – this wouldn&#39;t make it past the compile step. Instead, we need to use one of the helper functions (or methods) to manipulate the value in a safe way.</p>
+						<h2 id="using-result">Using <code>Result</code></h2>
+						<p>The library is designed to be used with a functional style, allowing you to compose operations easily. Thus, standalone pure function versions of every operation are supplied. However, the same operations also exist on the <code>Ok</code> and <code>Err</code> types directly, so you may also write them in a more traditional &quot;fluent&quot; object style.</p>
+						<h3 id="examples-functional-style">Examples: functional style</h3>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> { ok, err, map, toString } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/result'</span>;
+
+<span class="hljs-keyword">const</span> length = <span class="hljs-function">(<span class="hljs-params">s: <span class="hljs-built_in">string</span></span>) =&gt;</span> s.length;
+
+<span class="hljs-keyword">const</span> anOk = ok(<span class="hljs-string">'some string'</span>);
+<span class="hljs-keyword">const</span> okLength = map(length, anOk);
+<span class="hljs-built_in">console</span>.log(toString(okLength)); <span class="hljs-comment">// Ok(11)</span>
+
+<span class="hljs-keyword">const</span> anErr = err(<span class="hljs-string">'gah!'</span>);
+<span class="hljs-keyword">const</span> errLength = map(length, anErr);
+<span class="hljs-built_in">console</span>.log(toString(errLength)); <span class="hljs-comment">// Err(gah!)</span></code></pre>
+						<h3 id="examples-fluent-object-invocation">Examples: fluent object invocation</h3>
+						<p>You can also use a &quot;fluent&quot; method chaining style to apply the various helper functions to a <code>Result</code> instance:</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> { ok, err } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/result'</span>;
+
+<span class="hljs-keyword">const</span> length = <span class="hljs-function">(<span class="hljs-params">s: <span class="hljs-built_in">string</span></span>) =&gt;</span> s.length;
+
+<span class="hljs-keyword">const</span> hooray = ok(<span class="hljs-string">'yay'</span>);
+<span class="hljs-keyword">const</span> okLen = hooray.map(length).unwrapOr(<span class="hljs-number">0</span>); <span class="hljs-comment">// okLen = 3</span>
+
+<span class="hljs-keyword">const</span> muySad = err(<span class="hljs-string">'oh no'</span>);
+<span class="hljs-keyword">const</span> errLen = muySad.map(length).unwrapOr(<span class="hljs-number">0</span>); <span class="hljs-comment">// errLen = 0</span></code></pre>
+						<h3 id="writing-type-constraints">Writing type constraints</h3>
+						<p>When creating a <code>Result</code> instance, you&#39;ll nearly always be using <em>either</em> the <code>Ok</code> <em>or</em> the <code>Err</code> type, so the type system won&#39;t necessarily be able to infer the other type parameter.</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> { ok, err } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/result'</span>;
+
+<span class="hljs-keyword">const</span> anOk = ok(<span class="hljs-number">12</span>); <span class="hljs-comment">// TypeScript infers: `Result&lt;number, {}&gt;`</span>
+<span class="hljs-keyword">const</span> anErr = err(<span class="hljs-string">'sad'</span>); <span class="hljs-comment">// TypeScript infers: `Result&lt;{}, string&gt;`</span></code></pre>
+						<p>In TypeScript, because of the direction type inference happens, you will need to specify the type at declaration to make it type check when returning values from a function with a specified type. Note that this <em>only</em> applies when the instance is declared in its own statement and returned separately, <em>not</em> when it is the expression value of a single-expression arrow function or the explicit return value of any function.</p>
+						<pre><code class="language-typescript"><span class="hljs-keyword">import</span> Result, { ok } <span class="hljs-keyword">from</span> <span class="hljs-string">'true-myth/result'</span>;
+
+<span class="hljs-comment">// ERROR: Type 'Result&lt;number, {}&gt;' is not assignable to type 'Result&lt;number, string&gt;'.</span>
+<span class="hljs-keyword">const</span> getAResultNotAssignable = (): Result&lt;<span class="hljs-built_in">number</span>, <span class="hljs-built_in">string</span>&gt; =&gt; {
+  <span class="hljs-keyword">const</span> theResult = ok(<span class="hljs-number">12</span>);
+  <span class="hljs-keyword">return</span> theResult;
+};
+
+<span class="hljs-comment">// Succeeds</span>
+<span class="hljs-keyword">const</span> getAResultExpression = (): Result&lt;<span class="hljs-built_in">number</span>, <span class="hljs-built_in">string</span>&gt; =&gt; ok(<span class="hljs-number">12</span>);
+
+<span class="hljs-comment">// Succeeds</span>
+<span class="hljs-keyword">const</span> getAResultReturn = (): Result&lt;<span class="hljs-built_in">number</span>, <span class="hljs-built_in">string</span>&gt; =&gt; {
+  <span class="hljs-keyword">return</span> ok(<span class="hljs-number">12</span>);
+};</code></pre>
 					</div>
 				</div>
 			</section>
@@ -163,7 +274,7 @@
 					<div class="tsd-signature tsd-kind-icon">Matcher<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1261">result.ts:1261</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1261">result.ts:1261</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +339,7 @@
 					<div class="tsd-signature tsd-kind-icon">cata<span class="tsd-signature-symbol">:</span> <a href="_result_.html#match" class="tsd-signature-type">match</a><span class="tsd-signature-symbol"> =&nbsp;match</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1326">result.ts:1326</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1326">result.ts:1326</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -243,7 +354,7 @@
 					<div class="tsd-signature tsd-kind-icon">chain<span class="tsd-signature-symbol">:</span> <a href="_result_.html#andthen" class="tsd-signature-type">andThen</a><span class="tsd-signature-symbol"> =&nbsp;andThen</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1002">result.ts:1002</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1002">result.ts:1002</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -258,7 +369,7 @@
 					<div class="tsd-signature tsd-kind-icon">flat<wbr>Map<span class="tsd-signature-symbol">:</span> <a href="_result_.html#andthen" class="tsd-signature-type">andThen</a><span class="tsd-signature-symbol"> =&nbsp;andThen</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1005">result.ts:1005</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1005">result.ts:1005</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -273,7 +384,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unwrapor" class="tsd-signature-type">unwrapOr</a><span class="tsd-signature-symbol"> =&nbsp;unwrapOr</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1146">result.ts:1146</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1146">result.ts:1146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -288,7 +399,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unwraporelse" class="tsd-signature-type">unwrapOrElse</a><span class="tsd-signature-symbol"> =&nbsp;unwrapOrElse</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1189">result.ts:1189</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1189">result.ts:1189</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -303,7 +414,7 @@
 					<div class="tsd-signature tsd-kind-icon">of<span class="tsd-signature-symbol">:</span> <a href="_result_.html#ok-2" class="tsd-signature-type">ok</a><span class="tsd-signature-symbol"> =&nbsp;ok</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L532">result.ts:532</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L532">result.ts:532</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -318,7 +429,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsafe<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a><span class="tsd-signature-symbol"> =&nbsp;unsafelyUnwrap</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1095">result.ts:1095</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1095">result.ts:1095</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -333,7 +444,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a><span class="tsd-signature-symbol"> =&nbsp;unsafelyUnwrap</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1092">result.ts:1092</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1092">result.ts:1092</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -348,7 +459,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Get<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwraperr" class="tsd-signature-type">unsafelyUnwrapErr</a><span class="tsd-signature-symbol"> =&nbsp;unsafelyUnwrapErr</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1111">result.ts:1111</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1111">result.ts:1111</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -371,7 +482,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L930">result.ts:930</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L930">result.ts:930</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -440,7 +551,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L931">result.ts:931</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L931">result.ts:931</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -494,7 +605,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L986">result.ts:986</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L986">result.ts:986</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -587,7 +698,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L990">result.ts:990</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L990">result.ts:990</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -659,7 +770,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1544">result.ts:1544</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1544">result.ts:1544</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -833,7 +944,7 @@ Result.of(toStr).ap(<span class="hljs-number">12</span>); <span class="hljs-comm
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1545">result.ts:1545</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1545">result.ts:1545</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -887,7 +998,7 @@ Result.of(toStr).ap(<span class="hljs-number">12</span>); <span class="hljs-comm
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1346">result.ts:1346</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1346">result.ts:1346</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -933,7 +1044,7 @@ Result.equals(c, d) <span class="hljs-comment">// true</span></code></pre>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1347">result.ts:1347</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1347">result.ts:1347</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -984,7 +1095,7 @@ Result.equals(c, d) <span class="hljs-comment">// true</span></code></pre>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L580">result.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L580">result.ts:580</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1040,7 +1151,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L581">result.ts:581</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L581">result.ts:581</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1073,7 +1184,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1223">result.ts:1223</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1223">result.ts:1223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1112,7 +1223,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1224">result.ts:1224</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1224">result.ts:1224</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1162,7 +1273,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L475">result.ts:475</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L475">result.ts:475</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1200,7 +1311,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1566">result.ts:1566</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1566">result.ts:1566</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1240,7 +1351,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L466">result.ts:466</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L466">result.ts:466</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1279,7 +1390,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L717">result.ts:717</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L717">result.ts:717</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1381,7 +1492,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L718">result.ts:718</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L718">result.ts:718</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1453,7 +1564,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L885">result.ts:885</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L885">result.ts:885</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1537,7 +1648,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L886">result.ts:886</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L886">result.ts:886</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1610,7 +1721,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L751">result.ts:751</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L751">result.ts:751</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1687,7 +1798,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L752">result.ts:752</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L752">result.ts:752</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1752,7 +1863,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L753">result.ts:753</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L753">result.ts:753</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1843,7 +1954,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L816">result.ts:816</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L816">result.ts:816</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1954,7 +2065,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L821">result.ts:821</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L821">result.ts:821</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2037,7 +2148,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L825">result.ts:825</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L825">result.ts:825</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2145,7 +2256,7 @@ isValid(data) ? Result.ok(<span class="hljs-number">42</span>) : Result.err();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1315">result.ts:1315</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1315">result.ts:1315</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2215,7 +2326,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1316">result.ts:1316</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1316">result.ts:1316</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2269,7 +2380,7 @@ mightBeANumber
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L525">result.ts:525</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L525">result.ts:525</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2322,7 +2433,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L526">result.ts:526</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L526">result.ts:526</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2355,7 +2466,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1037">result.ts:1037</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1037">result.ts:1037</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2421,7 +2532,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1038">result.ts:1038</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1038">result.ts:1038</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2475,7 +2586,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1064">result.ts:1064</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1064">result.ts:1064</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2542,7 +2653,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1068">result.ts:1068</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1068">result.ts:1068</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2613,7 +2724,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1205">result.ts:1205</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1205">result.ts:1205</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2653,7 +2764,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1255">result.ts:1255</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1255">result.ts:1255</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2732,7 +2843,7 @@ isValid(data) ? Result.ok() : Result.err(<span class="hljs-string">'something wa
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L607">result.ts:607</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L607">result.ts:607</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2793,7 +2904,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L608">result.ts:608</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L608">result.ts:608</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2856,7 +2967,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L648">result.ts:648</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L648">result.ts:648</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2938,7 +3049,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L649">result.ts:649</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L649">result.ts:649</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3018,7 +3129,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1087">result.ts:1087</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1087">result.ts:1087</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3062,7 +3173,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1106">result.ts:1106</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1106">result.ts:1106</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3107,7 +3218,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1135">result.ts:1135</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1135">result.ts:1135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3160,7 +3271,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1136">result.ts:1136</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1136">result.ts:1136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3211,7 +3322,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1178">result.ts:1178</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1178">result.ts:1178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3290,7 +3401,7 @@ thisOperationThrows();
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1179">result.ts:1179</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1179">result.ts:1179</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3357,8 +3468,8 @@ thisOperationThrows();
 					<div class="tsd-signature tsd-kind-icon">Result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1576">result.ts:1576</a></li>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1577">result.ts:1577</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1576">result.ts:1576</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1577">result.ts:1577</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -3374,7 +3485,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">Err<span class="tsd-signature-symbol">:</span> <a href="../classes/_result_.err.html" class="tsd-signature-type">Err</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1580">result.ts:1580</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1580">result.ts:1580</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3384,7 +3495,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">Ok<span class="tsd-signature-symbol">:</span> <a href="../classes/_result_.ok.html" class="tsd-signature-type">Ok</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1579">result.ts:1579</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1579">result.ts:1579</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3394,7 +3505,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">Variant<span class="tsd-signature-symbol">:</span> <a href="../enums/_result_.variant.html" class="tsd-signature-type">Variant</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1578">result.ts:1578</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1578">result.ts:1578</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3404,7 +3515,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">and<span class="tsd-signature-symbol">:</span> <a href="_result_.html#and" class="tsd-signature-type">and</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1591">result.ts:1591</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1591">result.ts:1591</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3414,7 +3525,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">and<wbr>Then<span class="tsd-signature-symbol">:</span> <a href="_result_.html#andthen" class="tsd-signature-type">andThen</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1592">result.ts:1592</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1592">result.ts:1592</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3424,7 +3535,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">ap<span class="tsd-signature-symbol">:</span> <a href="_result_.html#ap" class="tsd-signature-type">ap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1612">result.ts:1612</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1612">result.ts:1612</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3434,7 +3545,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">cata<span class="tsd-signature-symbol">:</span> <a href="_result_.html#match" class="tsd-signature-type">match</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1610">result.ts:1610</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1610">result.ts:1610</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3444,7 +3555,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">chain<span class="tsd-signature-symbol">:</span> <a href="_result_.html#andthen" class="tsd-signature-type">andThen</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1593">result.ts:1593</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1593">result.ts:1593</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3454,7 +3565,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">equals<span class="tsd-signature-symbol">:</span> <a href="_result_.html#equals" class="tsd-signature-type">equals</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1611">result.ts:1611</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1611">result.ts:1611</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3464,7 +3575,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">err<span class="tsd-signature-symbol">:</span> <a href="_result_.html#err-2" class="tsd-signature-type">err</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1584">result.ts:1584</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1584">result.ts:1584</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3474,7 +3585,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">flat<wbr>Map<span class="tsd-signature-symbol">:</span> <a href="_result_.html#andthen" class="tsd-signature-type">andThen</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1594">result.ts:1594</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1594">result.ts:1594</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3484,7 +3595,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">from<wbr>Maybe<span class="tsd-signature-symbol">:</span> <a href="_result_.html#frommaybe" class="tsd-signature-type">fromMaybe</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1607">result.ts:1607</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1607">result.ts:1607</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3494,7 +3605,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">get<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unwrapor" class="tsd-signature-type">unwrapOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1603">result.ts:1603</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1603">result.ts:1603</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3504,7 +3615,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">get<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unwraporelse" class="tsd-signature-type">unwrapOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1605">result.ts:1605</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1605">result.ts:1605</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3514,7 +3625,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">is<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_result_.html#iserr" class="tsd-signature-type">isErr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1582">result.ts:1582</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1582">result.ts:1582</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3524,7 +3635,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">is<wbr>Instance<span class="tsd-signature-symbol">:</span> <a href="_result_.html#isinstance" class="tsd-signature-type">isInstance</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1613">result.ts:1613</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1613">result.ts:1613</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3534,7 +3645,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">is<wbr>Ok<span class="tsd-signature-symbol">:</span> <a href="_result_.html#isok" class="tsd-signature-type">isOk</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1581">result.ts:1581</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1581">result.ts:1581</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3544,7 +3655,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">map<span class="tsd-signature-symbol">:</span> <a href="_result_.html#map" class="tsd-signature-type">map</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1587">result.ts:1587</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1587">result.ts:1587</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3554,7 +3665,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">map<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_result_.html#maperr" class="tsd-signature-type">mapErr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1590">result.ts:1590</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1590">result.ts:1590</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3564,7 +3675,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">map<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_result_.html#mapor" class="tsd-signature-type">mapOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1588">result.ts:1588</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1588">result.ts:1588</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3574,7 +3685,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">map<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_result_.html#maporelse" class="tsd-signature-type">mapOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1589">result.ts:1589</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1589">result.ts:1589</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3584,7 +3695,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">match<span class="tsd-signature-symbol">:</span> <a href="_result_.html#match" class="tsd-signature-type">match</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1609">result.ts:1609</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1609">result.ts:1609</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3594,7 +3705,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">ok<span class="tsd-signature-symbol">:</span> <a href="_result_.html#ok-2" class="tsd-signature-type">ok</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1583">result.ts:1583</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1583">result.ts:1583</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3604,7 +3715,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">or<span class="tsd-signature-symbol">:</span> <a href="_result_.html#or" class="tsd-signature-type">or</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1595">result.ts:1595</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1595">result.ts:1595</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3614,7 +3725,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">or<wbr>Else<span class="tsd-signature-symbol">:</span> <a href="_result_.html#orelse" class="tsd-signature-type">orElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1596">result.ts:1596</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1596">result.ts:1596</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3624,7 +3735,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">to<wbr>Maybe<span class="tsd-signature-symbol">:</span> <a href="_result_.html#tomaybe" class="tsd-signature-type">toMaybe</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1606">result.ts:1606</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1606">result.ts:1606</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3634,7 +3745,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">to<wbr>String<span class="tsd-signature-symbol">:</span> <a href="" class="tsd-signature-type">toString</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1608">result.ts:1608</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1608">result.ts:1608</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3644,7 +3755,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">try<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_result_.html#tryor" class="tsd-signature-type">tryOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1585">result.ts:1585</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1585">result.ts:1585</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3654,7 +3765,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">try<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_result_.html#tryorelse" class="tsd-signature-type">tryOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1586">result.ts:1586</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1586">result.ts:1586</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3664,7 +3775,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unsafe<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1599">result.ts:1599</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1599">result.ts:1599</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3674,7 +3785,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Get<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1598">result.ts:1598</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1598">result.ts:1598</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3684,7 +3795,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Get<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwraperr" class="tsd-signature-type">unsafelyUnwrapErr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1601">result.ts:1601</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1601">result.ts:1601</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3694,7 +3805,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Unwrap<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwrap" class="tsd-signature-type">unsafelyUnwrap</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1597">result.ts:1597</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1597">result.ts:1597</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3704,7 +3815,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unsafely<wbr>Unwrap<wbr>Err<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unsafelyunwraperr" class="tsd-signature-type">unsafelyUnwrapErr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1600">result.ts:1600</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1600">result.ts:1600</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3714,7 +3825,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unwrap<wbr>Or<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unwrapor" class="tsd-signature-type">unwrapOr</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1602">result.ts:1602</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1602">result.ts:1602</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -3724,7 +3835,7 @@ thisOperationThrows();
 						<div class="tsd-signature tsd-kind-icon">unwrap<wbr>OrElse<span class="tsd-signature-symbol">:</span> <a href="_result_.html#unwraporelse" class="tsd-signature-type">unwrapOrElse</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/result.ts#L1604">result.ts:1604</a></li>
+								<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/result.ts#L1604">result.ts:1604</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/modules/_unit_.html
+++ b/docs/modules/_unit_.html
@@ -87,8 +87,8 @@
 					<div class="tsd-signature tsd-kind-icon">Unit<span class="tsd-signature-symbol">:</span> <a href="../classes/_utils_._brand.html" class="tsd-signature-type">_Brand</a><span class="tsd-signature-symbol"> =&nbsp;new _Brand(&#x27;unit&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/unit.ts#L10">unit.ts:10</a></li>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/unit.ts#L11">unit.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/unit.ts#L10">unit.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/unit.ts#L11">unit.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_.html
+++ b/docs/modules/_utils_.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">And<wbr>Then<wbr>Aliases<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"andThen"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"chain"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"flatMap"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/utils.ts#L12">utils.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/utils.ts#L12">utils.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/utils.ts#L8">utils.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/utils.ts#L8">utils.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/0eb55a5/src/utils.ts#L5">utils.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/true-myth/true-myth/blob/60ff9d8/src/utils.ts#L5">utils.ts:5</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 rm -rf docs && \
-  ./node_modules/.bin/typedoc --out docs --tsconfig ./ts/doc.tsconfig.json src && \
+  ./node_modules/.bin/typedoc \
+    --out docs \
+    --includes src \
+    --tsconfig ts/doc.tsconfig.json \
+    src && \
   touch docs/.nojekyll && \
 echo "true-myth.js.org" > docs/CNAME

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,9 @@
     "noImplicitReturns": true,
 
     "moduleResolution": "node",
-    "baseUrl": "./",
+    "baseUrl": ".",
 
-    "sourceRoot": "./",
+    "sourceRoot": ".",
     "sourceMap": true,
   },
   "include": ["src", "test"],


### PR DESCRIPTION
- Set `--include` flag for typedoc. Module-level docs pulling in the Markdown source now work correctly. (#34)
- Set TS paths to `"."` instead of `"./"`. Source maps now resolve correctly. (#36)