### PR TITLE
Add `Maybe.wrapReturn` for functions which return `null | undefined`.

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1722,11 +1722,15 @@ export function get<T, K extends keyof T>(
   return curry1(Maybe.andThen(property<T, K>(key)), maybeObj);
 }
 
-export function wrap<F extends (...args: any[]) => any>(
+export function wrapReturn<F extends (...args: any[]) => any>(
   fn: F
 ): (...args: Parameters<F>) => Maybe<NonNullable<ReturnType<F>>> {
   return (...args: Parameters<F>) => Maybe.of(fn(...args)) as Maybe<NonNullable<ReturnType<F>>>;
 }
+
+export const maybeify = wrapReturn;
+
+export const transmogrify = wrapReturn;
 
 /** A value which may (`Just<T>`) or may not (`Nothing`) be present. */
 export type Maybe<T> = Just<T> | Nothing<T>;
@@ -1773,7 +1777,8 @@ export const Maybe = {
   isInstance,
   property,
   get,
-  wrap,
+  wrapReturn,
+  ify: wrapReturn,
 };
 
 export default Maybe;

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1722,6 +1722,12 @@ export function get<T, K extends keyof T>(
   return curry1(Maybe.andThen(property<T, K>(key)), maybeObj);
 }
 
+export function wrap<F extends (...args: any[]) => any>(
+  fn: F
+): (...args: Parameters<F>) => Maybe<NonNullable<ReturnType<F>>> {
+  return (...args: Parameters<F>) => Maybe.of(fn(...args)) as Maybe<NonNullable<ReturnType<F>>>;
+}
+
 /** A value which may (`Just<T>`) or may not (`Nothing`) be present. */
 export type Maybe<T> = Just<T> | Nothing<T>;
 export const Maybe = {
@@ -1767,6 +1773,7 @@ export const Maybe = {
   isInstance,
   property,
   get,
+  wrap,
 };
 
 export default Maybe;

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -450,7 +450,7 @@ describe('`Maybe` pure functions', () => {
     expect(Maybe.get('wat', dict)).toEqual(Maybe.nothing());
   });
 
-  test('`wrap`', () => {
+  test('`wrapReturn`', () => {
     const empty = '';
     const emptyResult = Maybe.nothing();
 
@@ -458,18 +458,18 @@ describe('`Maybe` pure functions', () => {
     const fullResult = Maybe.just(full.length);
 
     const mayBeNull = (s: string): number | null => (s.length > 0 ? s.length : null);
-    const mayNotBeNull = Maybe.wrap(mayBeNull);
+    const mayNotBeNull = Maybe.wrapReturn(mayBeNull);
 
     expect(mayNotBeNull(empty)).toEqual(emptyResult);
     expect(mayNotBeNull(full)).toEqual(fullResult);
 
     const mayBeUndefined = (s: string): number | undefined => (s.length > 0 ? s.length : undefined);
-    const mayNotBeUndefined = Maybe.wrap(mayBeUndefined);
+    const mayNotBeUndefined = Maybe.wrapReturn(mayBeUndefined);
 
     expect(mayNotBeUndefined(empty)).toEqual(emptyResult);
     expect(mayNotBeUndefined(full)).toEqual(fullResult);
 
-    const querySelector = Maybe.wrap(document.querySelector.bind(document));
+    const querySelector = Maybe.wrapReturn(document.querySelector.bind(document));
     assertType<(selector: string) => Maybe<Element>>(querySelector);
   });
 });

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -468,6 +468,9 @@ describe('`Maybe` pure functions', () => {
 
     expect(mayNotBeUndefined(empty)).toEqual(emptyResult);
     expect(mayNotBeUndefined(full)).toEqual(fullResult);
+
+    const querySelector = Maybe.wrap(document.querySelector.bind(document));
+    assertType<(selector: string) => Maybe<Element>>(querySelector);
   });
 });
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -449,6 +449,26 @@ describe('`Maybe` pure functions', () => {
     expect(Maybe.get('quux', dict)).toEqual(Maybe.just('warble'));
     expect(Maybe.get('wat', dict)).toEqual(Maybe.nothing());
   });
+
+  test('`wrap`', () => {
+    const empty = '';
+    const emptyResult = Maybe.nothing();
+
+    const full = 'hello';
+    const fullResult = Maybe.just(full.length);
+
+    const mayBeNull = (s: string): number | null => (s.length > 0 ? s.length : null);
+    const mayNotBeNull = Maybe.wrap(mayBeNull);
+
+    expect(mayNotBeNull(empty)).toEqual(emptyResult);
+    expect(mayNotBeNull(full)).toEqual(fullResult);
+
+    const mayBeUndefined = (s: string): number | undefined => (s.length > 0 ? s.length : undefined);
+    const mayNotBeUndefined = Maybe.wrap(mayBeUndefined);
+
+    expect(mayNotBeUndefined(empty)).toEqual(emptyResult);
+    expect(mayNotBeUndefined(full)).toEqual(fullResult);
+  });
 });
 
 // We aren't even really concerned with the "runtime" behavior here, which we


### PR DESCRIPTION
Many JS libraries return `null` or `undefined` when they have invalid values; this convenience function allows a user to wrap those unsafe functions in a function which works identically but returns a `Maybe<T>` instead of `T | null | undefined`. For example:

```ts
const querySelector = Maybe.wrapReturn(document.querySelector.bind(document))
const isVisible = querySelector('#foo').map(el => el.style.display)
```

The original `Document#querySelector` function returns an `Element` for the first matching element in the document, or `null` if there are none. The wrapped function returns `Maybe<Element>` instead.