### PR TITLE
Make `Nothing` a singleton, to reduce needless allocations.

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -563,6 +563,8 @@ export function just<T>(value?: T | null): Maybe<T> {
   return new Just<T>(value);
 }
 
+let NOTHING: Nothing<any>;
+
 /**
   Create an instance of `Maybe.Nothing`.
 
@@ -578,7 +580,8 @@ export function just<T>(value?: T | null): Maybe<T> {
   @returns     An instance of `Maybe.Nothing<T>`.
  */
 export function nothing<T>(_?: null): Maybe<T> {
-  return new Nothing<T>(_);
+  if (!NOTHING) NOTHING = new Nothing();
+  return NOTHING;
 }
 
 /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -774,8 +774,8 @@ export function mapOr<T, U, E>(
   return mapFn === undefined
     ? partialOp
     : result === undefined
-      ? partialOp(mapFn)
-      : partialOp(mapFn, result);
+    ? partialOp(mapFn)
+    : partialOp(mapFn, result);
 }
 
 /**
@@ -848,8 +848,8 @@ export function mapOrElse<T, U, E>(
   return mapFn === undefined
     ? partialOp
     : result === undefined
-      ? partialOp(mapFn)
-      : partialOp(mapFn, result);
+    ? partialOp(mapFn)
+    : partialOp(mapFn, result);
 }
 
 /**


### PR DESCRIPTION
Currently targets #40 so the actual diff is clear. Will retarget against master once #40 is merged.