### PR TITLE
Use namespace imports internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,30 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Fixed :wrench:
+
+- Switched to using namespace-style imports (`import * as Maybe`) internally to enable users to tree-shake.
+
 ### Changed :boom:
 
 - Explicitly drop support for Node 8 (and specify it going forward)
 - Reverted the use of `NonNullable` to constraint the types of callbacks like that passed to `map` and `mapOr`, because they [broke][#54] in TypeScript 3.6. (If you have ideas about how to improve this, please let us know!)
 
 [#54]: https://github.com/true-myth/true-myth/issues/54
+
+### Upgrading :gear:
+
+With yarn:
+
+```sh
+yarn upgrade true-myth@latest
+```
+
+With npm:
+
+```sh
+npm install true-myth@latest
+```
 
 ## [3.1.0] (2019-10-08)
 

--- a/README.md
+++ b/README.md
@@ -98,17 +98,13 @@ import Result from 'true-myth/result';
 import { Maybe, Result } from 'true-myth';
 ```
 
-In Node.js, the TypeScript-generated CommonJS package cannot be imported as nested modules, but the modules still can be imported directly from the top-level module:
-
-```typescript
-const { Maybe, Result } = require('true-myth');
-```
-
-With the TypeScript Node-aware transforms, you can also write this in ES6 module-style imports for Node, but the same limitations apply about the nested module imports, i.e. you just can't use them. Use the top-level imports instead:
+In Node.js, the TypeScript-generated CommonJS package cannot be imported as nested modules, but the modules still can be imported directly from the top-level module when using TypeScript:
 
 ```typescript
 import { Maybe, Result } from 'true-myth';
 ```
+
+(Normal Node imports work if you are using the library in JavaScript, but that is not recommended for many reasons. See [comments on Folktale below](#folktale) if you’re interested in a similar library for consumption in JavaScript.)
 
 The build includes both ES6 modules and CommonJS modules, so you may reference them directly from their installation in the `node_modules` directory. (This may be helpful for using the library in different contexts, with the ES modules being supplied especially so you can do tree-shaking with e.g. Rollup.)
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ type Result<T, E> = import('true-myth/result').Result<T, E>;
 
 These are somewhat less convenient, but unlike the default exports are totally amenable to tree-shaking.
 
+Gzipped size without tree-shaking, for the ES Modules (the CJS modules are slightly larger but you should use the ES modules for targeting the web):
+
+|    file     | size  | size gzipped |
+| ----------- | ----- | ------------ |
+| `index.js`  | 404KB | 239B         |
+| `maybe.js`  | 27K   | 6.1KB        |
+| `result.js` | 20K   | 4.1KB        |
+| `unit.js`   | 482B  | 345B         |
+| `utils.js`  | 473B  | 333B         |
+
 ### Build output
 
 Note that the build target is ES2015, since all current evergreen browsers and the current LTS of Node support all ES2015 features. (Strictly speaking, Node 6 does not support *all* of ES2015, but this library goes nowhere near the couple features it has behind a flag.)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,30 @@ import { Maybe, Result } from 'true-myth';
 
 (Normal Node imports work if you are using the library in JavaScript, but that is not recommended for many reasons. See [comments on Folktale below](#folktale) if you’re interested in a similar library for consumption in JavaScript.)
 
-The build includes both ES6 modules and CommonJS modules, so you may reference them directly from their installation in the `node_modules` directory. (This may be helpful for using the library in different contexts, with the ES modules being supplied especially so you can do tree-shaking with e.g. Rollup.)
+The build includes both ES6 modules and CommonJS modules, so you may reference them directly from their installation in the `node_modules` directory. This may be helpful for using the library in different contexts, with the ES modules being supplied especially so you can do tree-shaking with e.g. Rollup.
+
+### Tree-Shaking-friendly imports
+
+If you want to use tools like Rollup, you may prefer to use a namespace-style import. Throughout the documentation, instead of using the default imports—
+
+```ts
+import Maybe from 'true-myth/maybe';
+import Result from 'true-myth/result';
+```
+
+—prefer to use the namespace and type-only imports:
+
+```ts
+import * as Maybe from 'true-myth/maybe';
+type Maybe<T> = import('true-myth/maybe').Maybe<T>;
+
+import * as Result from 'true-myth/result';
+type Result<T, E> = import('true-myth/result').Result<T, E>;
+```
+
+These are somewhat less convenient, but unlike the default exports are totally amenable to tree-shaking.
+
+### Build output
 
 Note that the build target is ES2015, since all current evergreen browsers and the current LTS of Node support all ES2015 features. (Strictly speaking, Node 6 does not support *all* of ES2015, but this library goes nowhere near the couple features it has behind a flag.)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,14 @@
   [`Result`](./_result_.html). It doesn't do anything else.
  */
 
-/** (keep typedoc from getting confused by the imports) */
-export { default as Maybe } from './maybe';
-export { default as Result } from './result';
-export { default as Unit } from './unit';
+import * as MaybeNamespace from './maybe';
+export type Maybe<T> = import('./maybe').Maybe<T>;
+export const Maybe = MaybeNamespace;
+
+import * as ResultNamespace from './result';
+export type Result<T, E> = import('./result').Result<T, E>;
+export const Result = ResultNamespace;
+
+import * as UnitNamespace from './unit';
+export type Unit = import('./unit').Unit;
+export const Unit = UnitNamespace;

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,7 +1,9 @@
 /** [[include:doc/result.md]] */
 
 /** (keep typedoc from getting confused by the import) */
-import Maybe, { isJust, just, nothing } from './maybe';
+import * as Maybe from './maybe';
+type Maybe<T> = import('./maybe').Maybe<T>;
+
 import Unit from './unit';
 import { _Brand, curry1, isVoid } from './utils';
 
@@ -1228,7 +1230,7 @@ export const getOrElse = unwrapOrElse;
   @returns      `Just` the value in `result` if it is `Ok`; otherwise `Nothing`
  */
 export function toMaybe<T>(result: Result<T, any>): Maybe<T> {
-  return isOk(result) ? just(result.value) : nothing();
+  return isOk(result) ? Maybe.just(result.value) : Maybe.nothing();
 }
 
 /**
@@ -1251,7 +1253,8 @@ export function fromMaybe<T, E>(
   errValue: E,
   maybe?: Maybe<T>
 ): Result<T, E> | ((maybe: Maybe<T>) => Result<T, E>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? ok<T, E>(Maybe.unsafelyUnwrap(m)) : err<T, E>(errValue));
+  const op = (m: Maybe<T>) =>
+    Maybe.isJust(m) ? ok<T, E>(Maybe.unsafelyUnwrap(m)) : err<T, E>(errValue);
   return curry1(op, maybe);
 }
 


### PR DESCRIPTION
Switching to namespace imports internally *allows* external users to use namespace imports if they so choose for the sake of tree-shaking. (Using the manual module export as we were previously prevents tools like Rollup from tree-shaking unused imports, because the export value is an object and it's not to the tools what kind of dynamic use of the object is intended by library authors.)