### PR TITLE
Add the ability to use different types for defaults in unwrapOr

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -274,7 +274,7 @@ export class Just<T> implements MaybeShape<T> {
   }
 
   /** Method variant for [`Maybe.unwrapOr`](../modules/_maybe_.html#unwrapor) */
-  unwrapOr(this: Maybe<T>, defaultValue: T): T {
+  unwrapOr<D>(this: Maybe<T>, defaultValue: D): T | D {
     return unwrapOr(defaultValue, this);
   }
 
@@ -478,7 +478,7 @@ export class Nothing<T> implements MaybeShape<T> {
   }
 
   /** Method variant for [`Maybe.unwrapOr`](../modules/_maybe_.html#unwrapor) */
-  unwrapOr(this: Maybe<T>, defaultValue: T): T {
+  unwrapOr<D>(this: Maybe<T>, defaultValue: D): T | D {
     return unwrapOr(defaultValue, this);
   }
 
@@ -1052,9 +1052,9 @@ export const unsafeGet = unsafelyUnwrap;
   @returns            The content of `maybe` if it is a `Just`, otherwise
                       `defaultValue`.
  */
-export function unwrapOr<T>(defaultValue: T, maybe: Maybe<T>): T;
-export function unwrapOr<T>(defaultValue: T): (maybe: Maybe<T>) => T;
-export function unwrapOr<T>(defaultValue: T, maybe?: Maybe<T>) {
+export function unwrapOr<T, D>(defaultValue: D, maybe: Maybe<T>): T | D;
+export function unwrapOr<T, D>(defaultValue: D): (maybe: Maybe<T>) => T | D;
+export function unwrapOr<T, D>(defaultValue: D, maybe?: Maybe<T>) {
   const op = (m: Maybe<T>) => (m.isJust() ? m.value : defaultValue);
   return curry1(op, maybe);
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -73,7 +73,7 @@ export interface MaybeShape<T> {
   unsafelyUnwrap(): T | never;
 
   /** Method variant for [`Maybe.unwrapOrElse`](../modules/_maybe_.html#unwraporelse) */
-  unwrapOrElse(this: Maybe<T>, elseFn: () => T): T;
+  unwrapOrElse<U>(this: Maybe<T>, elseFn: () => U): T | U;
 
   /** Method variant for [`Maybe.toOkOrErr`](../modules/_maybe_.html#tookorerr) */
   toOkOrErr<E>(this: Maybe<T>, error: E): Result<T, E>;
@@ -279,7 +279,7 @@ export class Just<T> implements MaybeShape<T> {
   }
 
   /** Method variant for [`Maybe.unwrapOrElse`](../modules/_maybe_.html#unwraporelse) */
-  unwrapOrElse(this: Maybe<T>, elseFn: () => T): T {
+  unwrapOrElse<U>(this: Maybe<T>, elseFn: () => U): T | U {
     return unwrapOrElse(elseFn, this);
   }
 
@@ -483,7 +483,7 @@ export class Nothing<T> implements MaybeShape<T> {
   }
 
   /** Method variant for [`Maybe.unwrapOrElse`](../modules/_maybe_.html#unwraporelse) */
-  unwrapOrElse(this: Maybe<T>, elseFn: () => T): T {
+  unwrapOrElse<U>(this: Maybe<T>, elseFn: () => U): T | U {
     return unwrapOrElse(elseFn, this);
   }
 
@@ -1091,9 +1091,9 @@ export const getOr = unwrapOr;
   @returns        Either the content of `maybe` or the value returned from
                   `orElseFn`.
  */
-export function unwrapOrElse<T>(orElseFn: () => T, maybe: Maybe<T>): T;
-export function unwrapOrElse<T>(orElseFn: () => T): (maybe: Maybe<T>) => T;
-export function unwrapOrElse<T>(orElseFn: () => T, maybe?: Maybe<T>): T | ((maybe: Maybe<T>) => T) {
+export function unwrapOrElse<T, U>(orElseFn: () => U, maybe: Maybe<T>): T | U;
+export function unwrapOrElse<T, U>(orElseFn: () => U): (maybe: Maybe<T>) => T | U;
+export function unwrapOrElse<T, U>(orElseFn: () => U, maybe?: Maybe<T>): (T | U) | ((maybe: Maybe<T>) => T | U) {
   const op = (m: Maybe<T>) => (m.isJust() ? m.value : orElseFn());
   return curry1(op, maybe);
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -274,7 +274,7 @@ export class Just<T> implements MaybeShape<T> {
   }
 
   /** Method variant for [`Maybe.unwrapOr`](../modules/_maybe_.html#unwrapor) */
-  unwrapOr<D>(this: Maybe<T>, defaultValue: D): T | D {
+  unwrapOr<U>(this: Maybe<T>, defaultValue: U): T | U {
     return unwrapOr(defaultValue, this);
   }
 
@@ -478,7 +478,7 @@ export class Nothing<T> implements MaybeShape<T> {
   }
 
   /** Method variant for [`Maybe.unwrapOr`](../modules/_maybe_.html#unwrapor) */
-  unwrapOr<D>(this: Maybe<T>, defaultValue: D): T | D {
+  unwrapOr<U>(this: Maybe<T>, defaultValue: U): T | U {
     return unwrapOr(defaultValue, this);
   }
 
@@ -1052,9 +1052,9 @@ export const unsafeGet = unsafelyUnwrap;
   @returns            The content of `maybe` if it is a `Just`, otherwise
                       `defaultValue`.
  */
-export function unwrapOr<T, D>(defaultValue: D, maybe: Maybe<T>): T | D;
-export function unwrapOr<T, D>(defaultValue: D): (maybe: Maybe<T>) => T | D;
-export function unwrapOr<T, D>(defaultValue: D, maybe?: Maybe<T>) {
+export function unwrapOr<T, U>(defaultValue: U, maybe: Maybe<T>): T | U;
+export function unwrapOr<T, U>(defaultValue: U): (maybe: Maybe<T>) => T | U;
+export function unwrapOr<T, U>(defaultValue: U, maybe?: Maybe<T>) {
   const op = (m: Maybe<T>) => (m.isJust() ? m.value : defaultValue);
   return curry1(op, maybe);
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -87,7 +87,7 @@ export interface ResultShape<T, E> {
   unwrapOr<U>(this: Result<T, E>, defaultValue: U): T | U;
 
   /** Method variant for [`Result.unwrapOrElse`](../modules/_result_.html#unwrapOrElse) */
-  unwrapOrElse(this: Result<T, E>, elseFn: (error: E) => T): T;
+  unwrapOrElse<U>(this: Result<T, E>, elseFn: (error: E) => U): T | U;
 
   /** Method variant for [`Result.toMaybe`](../modules/_result_.html#tomaybe) */
   toMaybe(this: Result<T, E>): Maybe<T>;
@@ -265,7 +265,7 @@ export class Ok<T, E> implements ResultShape<T, E> {
   }
 
   /** Method variant for [`Result.unwrapOrElse`](../modules/_result_.html#unwrapOrElse) */
-  unwrapOrElse(this: Result<T, E>, elseFn: (error: E) => T): T {
+  unwrapOrElse<U>(this: Result<T, E>, elseFn: (error: E) => U): T | U{
     return unwrapOrElse(elseFn, this);
   }
 
@@ -455,7 +455,7 @@ export class Err<T, E> implements ResultShape<T, E> {
   }
 
   /** Method variant for [`Result.unwrapOrElse`](../modules/_result_.html#unwraporelse) */
-  unwrapOrElse(this: Result<T, E>, elseFn: (error: E) => T): T {
+  unwrapOrElse<U>(this: Result<T, E>, elseFn: (error: E) => U): T | U {
     return unwrapOrElse(elseFn, this);
   }
 
@@ -1202,12 +1202,12 @@ export const getOr = unwrapOr;
   @returns        The value wrapped in `result` if it is `Ok` or the value
                   returned by `orElseFn` applied to the value in `Err`.
  */
-export function unwrapOrElse<T, E>(orElseFn: (error: E) => T, result: Result<T, E>): T;
-export function unwrapOrElse<T, E>(orElseFn: (error: E) => T): (result: Result<T, E>) => T;
-export function unwrapOrElse<T, E>(
-  orElseFn: (error: E) => T,
+export function unwrapOrElse<T, U, E>(orElseFn: (error: E) => U, result: Result<T, E>): T | U;
+export function unwrapOrElse<T, U, E>(orElseFn: (error: E) => U): (result: Result<T, E>) => T | U;
+export function unwrapOrElse<T, U, E>(
+  orElseFn: (error: E) => U,
   result?: Result<T, E>
-): T | ((result: Result<T, E>) => T) {
+): (T | U) | ((result: Result<T, E>) => T | U) {
   const op = (r: Result<T, E>) => (isOk(r) ? r.value : orElseFn(r.error));
   return curry1(op, result);
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -84,7 +84,7 @@ export interface ResultShape<T, E> {
   unsafelyUnwrapErr(): E | never;
 
   /** Method variant for [`Result.unwrapOr`](../modules/_result_.html#unwrapor) */
-  unwrapOr<D>(this: Result<T, E>, defaultValue: D): T | D;
+  unwrapOr<U>(this: Result<T, E>, defaultValue: U): T | U;
 
   /** Method variant for [`Result.unwrapOrElse`](../modules/_result_.html#unwrapOrElse) */
   unwrapOrElse(this: Result<T, E>, elseFn: (error: E) => T): T;
@@ -260,7 +260,7 @@ export class Ok<T, E> implements ResultShape<T, E> {
   }
 
   /** Method variant for [`Result.unwrapOr`](../modules/_result_.html#unwrapor) */
-  unwrapOr<D>(this: Result<T, E>, defaultValue: D): T | D {
+  unwrapOr<U>(this: Result<T, E>, defaultValue: U): T | U {
     return unwrapOr(defaultValue, this);
   }
 
@@ -450,7 +450,7 @@ export class Err<T, E> implements ResultShape<T, E> {
   }
 
   /** Method variant for [`Result.unwrapOr`](../modules/_result_.html#unwrapor) */
-  unwrapOr<D>(this: Result<T, E>, defaultValue: D): T | D {
+  unwrapOr<U>(this: Result<T, E>, defaultValue: U): T | U {
     return unwrapOr(defaultValue, this);
   }
 
@@ -1159,12 +1159,12 @@ export const unsafelyGetErr = unsafelyUnwrapErr;
   @returns            The content of `result` if it is an `Ok`, otherwise
                       `defaultValue`.
  */
-export function unwrapOr<T, D, E>(defaultValue: D, result: Result<T, E>): D | T;
-export function unwrapOr<T, D, E>(defaultValue: D): (result: Result<T, E>) => D | T;
-export function unwrapOr<T, D, E>(
-  defaultValue: D,
+export function unwrapOr<T, U, E>(defaultValue: U, result: Result<T, E>): U | T;
+export function unwrapOr<T, U, E>(defaultValue: U): (result: Result<T, E>) => U | T;
+export function unwrapOr<T, U, E>(
+  defaultValue: U,
   result?: Result<T, E>
-): (T | D) | ((result: Result<T, E>) => T | D) {
+): (T | U) | ((result: Result<T, E>) => T | U) {
   const op = (r: Result<T, E>) => (isOk(r) ? r.value : defaultValue);
   return curry1(op, result);
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -84,7 +84,7 @@ export interface ResultShape<T, E> {
   unsafelyUnwrapErr(): E | never;
 
   /** Method variant for [`Result.unwrapOr`](../modules/_result_.html#unwrapor) */
-  unwrapOr(this: Result<T, E>, defaultValue: T): T;
+  unwrapOr<D>(this: Result<T, E>, defaultValue: D): T | D;
 
   /** Method variant for [`Result.unwrapOrElse`](../modules/_result_.html#unwrapOrElse) */
   unwrapOrElse(this: Result<T, E>, elseFn: (error: E) => T): T;
@@ -260,7 +260,7 @@ export class Ok<T, E> implements ResultShape<T, E> {
   }
 
   /** Method variant for [`Result.unwrapOr`](../modules/_result_.html#unwrapor) */
-  unwrapOr(this: Result<T, E>, defaultValue: T): T {
+  unwrapOr<D>(this: Result<T, E>, defaultValue: D): T | D {
     return unwrapOr(defaultValue, this);
   }
 
@@ -450,7 +450,7 @@ export class Err<T, E> implements ResultShape<T, E> {
   }
 
   /** Method variant for [`Result.unwrapOr`](../modules/_result_.html#unwrapor) */
-  unwrapOr(this: Result<T, E>, defaultValue: T): T {
+  unwrapOr<D>(this: Result<T, E>, defaultValue: D): T | D {
     return unwrapOr(defaultValue, this);
   }
 
@@ -1159,12 +1159,12 @@ export const unsafelyGetErr = unsafelyUnwrapErr;
   @returns            The content of `result` if it is an `Ok`, otherwise
                       `defaultValue`.
  */
-export function unwrapOr<T, E>(defaultValue: T, result: Result<T, E>): T;
-export function unwrapOr<T, E>(defaultValue: T): (result: Result<T, E>) => T;
-export function unwrapOr<T, E>(
-  defaultValue: T,
+export function unwrapOr<T, D, E>(defaultValue: D, result: Result<T, E>): D | T;
+export function unwrapOr<T, D, E>(defaultValue: D): (result: Result<T, E>) => D | T;
+export function unwrapOr<T, D, E>(
+  defaultValue: D,
   result?: Result<T, E>
-): T | ((result: Result<T, E>) => T) {
+): (T | D) | ((result: Result<T, E>) => T | D) {
   const op = (r: Result<T, E>) => (isOk(r) ? r.value : defaultValue);
   return curry1(op, result);
 }

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -247,6 +247,15 @@ describe('`Maybe` pure functions', () => {
     expect(Maybe.unwrapOr(theDefaultValue)(theJust)).toEqual(
       Maybe.unwrapOr(theDefaultValue, theJust)
     );
+
+    // Make sure you can unwrap to a different type, like undefined
+    // For interop with "regular" code
+    assertType<Maybe<number[]>>(theJust);
+    const theJustOrUndefined = theJust.unwrapOr(undefined)
+    assertType<number[] | undefined>(theJustOrUndefined);
+    expect(theJustOrUndefined).toEqual(theValue);
+
+    
   });
 
   test('`unwrapOrElse`', () => {
@@ -258,6 +267,14 @@ describe('`Maybe` pure functions', () => {
     expect(Maybe.unwrapOrElse(getVal, Maybe.nothing())).toBe(val);
 
     expect(Maybe.unwrapOrElse(getVal)(just42)).toEqual(Maybe.unwrapOrElse(getVal, just42));
+
+    // test unwrapping to undefined
+    const noop = (): undefined => undefined;
+    const undefinedOr42 = Maybe.unwrapOrElse(noop, just42);
+    assertType<number | undefined>(undefinedOr42);
+    expect(undefinedOr42).toEqual(42);
+
+
   });
 
   test('`toOkOrErr`', () => {
@@ -819,14 +836,6 @@ describe('`Maybe.Nothing` class', () => {
     const theNothing = new Maybe.Nothing<number[]>();
     const theDefaultValue: number[] = [];
     expect(theNothing.unwrapOr(theDefaultValue)).toEqual(theDefaultValue);
-    // Make sure you can unwrap to a different type, like undefined
-    // For interop with "regular" code
-    assertType<Maybe<number[]>>(theNothing);
-    const theNothingOrUndefined = theNothing.unwrapOr(undefined)
-    assertType<number[] | undefined>(theNothingOrUndefined);
-    expect(theNothingOrUndefined).toEqual(undefined);
-
-    
   });
 
   test('`unwrapOrElse` method', () => {

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -819,6 +819,14 @@ describe('`Maybe.Nothing` class', () => {
     const theNothing = new Maybe.Nothing<number[]>();
     const theDefaultValue: number[] = [];
     expect(theNothing.unwrapOr(theDefaultValue)).toEqual(theDefaultValue);
+    // Make sure you can unwrap to a different type, like undefined
+    // For interop with "regular" code
+    assertType<Maybe<number[]>>(theNothing);
+    const theNothingOrUndefined = theNothing.unwrapOr(undefined)
+    assertType<number[] | undefined>(theNothingOrUndefined);
+    expect(theNothingOrUndefined).toEqual(undefined);
+
+    
   });
 
   test('`unwrapOrElse` method', () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -265,6 +265,18 @@ describe('`Result` pure functions', () => {
 
     const anErr = Result.err('pumpkins are not');
     expect(Result.unwrapOr(defaultValue, anErr)).toBe(defaultValue);
+    // make sure you can unwrap to a different type, like undefined
+    assertType<Result<string, unknown>>(anOk);
+    const anOkOrUndefined = Result.unwrapOr(undefined, anOk)
+    assertType<string | undefined>(anOkOrUndefined);
+    expect(anOkOrUndefined).toEqual(theValue);
+    // test the err variant too, though in this case it's not actually a
+    // different type because unknown ≡ unknown | undefined
+    assertType<Result<unknown, string>>(anErr);
+    const anErrOrUndefined = Result.unwrapOr(undefined, anErr)
+    assertType<unknown>(anErrOrUndefined); // unknown ≡ unknown | undefined
+    expect(anErrOrUndefined).toEqual(undefined);
+
   });
 
   test('`unwrapOrElse`', () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -291,6 +291,17 @@ describe('`Result` pure functions', () => {
     const theErrValue = { reason: 'bad thing' };
     const anErr = Result.err<string, LocalError>(theErrValue);
     expect(Result.unwrapOrElse(errToOk, anErr)).toBe(errToOk(theErrValue));
+
+    // test unwrapping to undefined
+    const noop = (): undefined => undefined;
+
+    const anOkOrUndefined = Result.unwrapOrElse(noop, anOk);
+    assertType<string | undefined>(anOkOrUndefined);
+    expect(anOkOrUndefined).toEqual(theValue);
+
+    const anErrOrUndefined = Result.unwrapOrElse(noop, anErr);
+    assertType<string | undefined>(anErrOrUndefined);
+    expect(anErrOrUndefined).toEqual(undefined);
   });
 
   test('`toMaybe`', () => {


### PR DESCRIPTION
See https://github.com/true-myth/true-myth/issues/63. I thought about adding some documentation to src/doc/maybe.md, but I wasn't really sure if it was worth it, or how to write it sensibly. The feature itself is fairly easy enough to discover on its that it might not need clear documentation.