### PR TITLE
[breaking] remove `*Shape` interface exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ tuple directly. While `tuple` is unchanged, it is also deprecated (see below).
 
 -   Support for versions of TypeScript before 4.0 have been removed, to enable the type-safe re-implementation of `Maybe.all`.
 
+-   The `MaybeShape` and `ResultShape` interfaces are no longer exported. These were never intended for public reimplementation, and there is accordingly no value in their continuing to be public.
+
 ### Deprecated :red-square:
 
 - `Maybe.tuple` is deprecated since `Maybe.all` now correctly handles both arrays and tuples. It will be removed not earlier than 6.0.0 (timeline not decided, certainly not before Node 10 leaves LTS on 2021-04-30).

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -29,7 +29,7 @@ interface NothingJSON {
 type MaybeJSON<T> = JustJSON<T> | NothingJSON;
 
 /** Simply defines the common shape for `Just` and `Nothing`. */
-export interface MaybeShape<T> {
+interface MaybeShape<T> {
   /** Distinguish between the `Just` and `Nothing` [variants](../enums/_maybe_.variant). */
   readonly variant: Variant;
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -34,7 +34,7 @@ interface ErrJSON<E> {
 type ResultJSON<T, E> = OkJSON<T> | ErrJSON<E>;
 
 /** Simply defines the common shape for `Ok` and `Err`. */
-export interface ResultShape<T, E> {
+interface ResultShape<T, E> {
   /** Distinguish between the `Ok` and `Err` variants. */
   readonly variant: Variant;
 


### PR DESCRIPTION
The `MaybeShape` and `ResultShape` interfaces are no longer exported. These were never intended for public reimplementation, and there is accordingly no value in their continuing to be public.