### PR TITLE
Remove all uses of `any` from the codebase

### DIFF
--- a/src/-private/utils.ts
+++ b/src/-private/utils.ts
@@ -6,7 +6,7 @@
  *
  * @internal
  */
-export const isVoid = (value: any): value is undefined | null =>
+export const isVoid = (value: unknown): value is undefined | null =>
   typeof value === 'undefined' || value === null;
 
 /** @internal */

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -365,6 +365,10 @@ export class Just<T> implements MaybeShape<T> {
 
   @private
  */
+// SAFETY: `any` is required here because the whole point is that we're going to
+// use this *everywhere* there is a `Nothing`, so that there is effectively no
+// overhead of having a `Nothing` in your system: there is only ever once
+// instance of it.
 let NOTHING: Nothing<any>;
 
 /**
@@ -1159,7 +1163,7 @@ export function toOkOrElseErr<T, E>(
   @param result The `Result` to construct a `Maybe` from.
   @returns      `Just` if `result` was `Ok` or `Nothing` if it was `Err`.
  */
-export function fromResult<T>(result: Result<T, any>): Maybe<T> {
+export function fromResult<T>(result: Result<T, unknown>): Maybe<T> {
   return result.isOk() ? just(result.value) : nothing<T>();
 }
 
@@ -1480,7 +1484,7 @@ export function ap<T, U>(
 
   @param item The item to check.
  */
-export function isInstance<T = any>(item: any): item is Maybe<T> {
+export function isInstance<T = unknown>(item: unknown): item is Maybe<T> {
   return item instanceof Just || item instanceof Nothing;
 }
 
@@ -1862,6 +1866,8 @@ export function get<T, K extends keyof T>(
   @param fn The function to transform; the resulting function will have the
             exact same signature except for its return type.
  */
+// SAFETY: assignability requires the use of `any` here instead of `unknown`,
+// which would otherwise be preferable.
 export function wrapReturn<F extends (...args: any[]) => any>(
   fn: F
 ): (...args: Parameters<F>) => Maybe<NonNullable<ReturnType<F>>> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -132,7 +132,7 @@ export class Ok<T, E> implements ResultShape<T, E> {
     }
     ```
    */
-  static unwrap<O>(theOk: Ok<O, any>): O {
+  static unwrap<O>(theOk: Ok<O, unknown>): O {
     return theOk.value;
   }
 
@@ -322,7 +322,7 @@ export class Err<T, E> implements ResultShape<T, E> {
     }
     ```
    */
-  static unwrapErr<F>(theErr: Err<F, any>): F {
+  static unwrapErr<F>(theErr: Err<unknown, F>): F {
     return theErr.error;
   }
 
@@ -960,7 +960,7 @@ export function and<T, U, E>(
   andResult: Result<U, E>,
   result?: Result<T, E>
 ): Result<U, E> | ((result: Result<T, E>) => Result<U, E>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? andResult : (r as Err<any, E>));
+  const op = (r: Result<T, E>) => (isOk(r) ? andResult : err<U, E>(r.error));
   return curry1(op, result);
 }
 
@@ -1021,7 +1021,7 @@ export function andThen<T, U, E>(
   thenFn: (t: T) => Result<U, E>,
   result?: Result<T, E>
 ): Result<U, E> | ((result: Result<T, E>) => Result<U, E>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? thenFn(r.value) : (r as Err<any, E>));
+  const op = (r: Result<T, E>) => (isOk(r) ? thenFn(r.value) : err<U, E>(r.error));
   return curry1(op, result);
 }
 
@@ -1067,7 +1067,7 @@ export function or<T, E, F>(
   defaultResult: Result<T, F>,
   result?: Result<T, E>
 ): Result<T, F> | ((result: Result<T, E>) => Result<T, F>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? (r as Ok<T, any>) : defaultResult);
+  const op = (r: Result<T, E>) => (isOk(r) ? ok<T, F>(r.value) : defaultResult);
   return curry1(op, result);
 }
 
@@ -1099,7 +1099,7 @@ export function orElse<T, E, F>(
   elseFn: (err: E) => Result<T, F>,
   result?: Result<T, E>
 ): Result<T, F> | ((result: Result<T, E>) => Result<T, F>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? (r as Ok<T, any>) : elseFn(r.unsafelyUnwrapErr()));
+  const op = (r: Result<T, E>) => (isOk(r) ? ok<T, F>(r.value) : elseFn(r.unsafelyUnwrapErr()));
   return curry1(op, result);
 }
 
@@ -1229,7 +1229,7 @@ export const getOrElse = unwrapOrElse;
   @param result The `Result` to convert to a `Maybe`
   @returns      `Just` the value in `result` if it is `Ok`; otherwise `Nothing`
  */
-export function toMaybe<T>(result: Result<T, any>): Maybe<T> {
+export function toMaybe<T>(result: Result<T, unknown>): Maybe<T> {
   return isOk(result) ? Maybe.just(result.value) : Maybe.nothing();
 }
 
@@ -1607,7 +1607,7 @@ export function ap<T, U, E>(
 
   @param item The item to check.
  */
-export function isInstance<T = any, E = any>(item: any): item is Result<T, E> {
+export function isInstance<T = unknown, E = unknown>(item: unknown): item is Result<T, E> {
   return item instanceof Ok || item instanceof Err;
 }
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -360,7 +360,7 @@ describe('`Maybe` pure functions', () => {
   });
 
   test('isInstance', () => {
-    const something: any = Maybe.just('yay');
+    const something: unknown = Maybe.just('yay');
     expect(Maybe.isInstance(something)).toBe(true);
 
     const nothing = Maybe.nothing();

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -439,7 +439,7 @@ describe('`Result.Ok` class', () => {
     expectTypeOf(fullyQualifiedOk).toMatchTypeOf<Result<number, string>>();
 
     const unqualifiedOk = new Result.Ok('string');
-    expectTypeOf(unqualifiedOk).toMatchTypeOf<Result<string, any>>();
+    expectTypeOf(unqualifiedOk).toMatchTypeOf<Result<string, unknown>>();
 
     expect(() => new Result.Ok(null)).toThrow();
     expect(() => new Result.Ok(undefined)).toThrow();
@@ -612,7 +612,7 @@ describe('`Result.Err` class', () => {
     expectTypeOf(fullyQualifiedErr).toMatchTypeOf<Result<string, number>>();
 
     const unqualifiedErr = new Result.Err('string');
-    expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<any, string>>();
+    expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<unknown, string>>();
 
     expect(() => new Result.Err(null)).toThrow();
     expect(() => new Result.Err(undefined)).toThrow();
@@ -701,7 +701,7 @@ describe('`Result.Err` class', () => {
     const getAnOk = (strings: string[]) => Result.ok<number, number>(length(strings));
     expect(theErr[method](getAnOk)).toEqual(theErr);
 
-    const getAnErr = (_: any) => Result.err(0);
+    const getAnErr = (_: unknown) => Result.err(0);
     expect(theErr[method](getAnErr)).toEqual(theErr);
   };
 


### PR DESCRIPTION
(It'd also be great to lint against this so any would-be contributors don't get tripped up by it on accident.)