### PR TITLE
Strip internal types *only* for typedoc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "declaration": true,
-    "stripInternal": true,
+    "stripInternal": false,
 
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Fixes #96 by making sure that `stripInteral` is *false* for emit, while leaving it as `true` for docs purposes.