### PR TITLE
Reenable macOS in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        # macOS runners are slow (at best) this week
-        # os: [macOS, windows]
-        os: [windows]
+        os: [macOS, windows]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
Closes #80 .

I'm not sure how bad the MacOS job queue / run times were before, but now they seem to begin immediately, and the durations _average_ about the same as Windows..

..but individual times are much more volatile. Here are Mac/Windows times from five runs:

0:57 / 2:28
1:05 / 2:04
4:50 / 2:23
3:32 / 2:01
1:01 / 2:29

( https://github.com/jrr/true-myth/actions )

### More Detail

- Most of the time goes into the `yarn install` step. 
- I tried [caching](https://github.com/actions/cache/blob/main/examples.md#node---yarn), but it didn't seem much faster.
- Interestingly, when yarn install takes a long time, GHA reports a much longer duration than yarn does. (e.g. in the [4:50 run](https://github.com/jrr/true-myth/runs/2074064858?check_suite_focus=true), GH reports 4m4s while yarn says 69s)

So I suspect this is a data center filesystem performance thing, rather than a limitation of the network connection to the registry.

Side note - do you have any thoughts on Yarn 2? If you can get by without its legacy `node_modules` compatibility mode, it's purported to be much easier on the filesystem, so much that you can even [check the files in to git](https://yarnpkg.com/features/zero-installs).