### PR TITLE
Update badge for TS supported versions: 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img src='https://img.shields.io/badge/Node-10%20LTS%20%7C%2012%20LTS%20%7C%2014%20LTS-darkgreen' alt='supported Node versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L59'>
-    <img src='https://img.shields.io/badge/TypeScript-4.0%20%7C%204.1%20%7C%20next-3178c6' alt='supported TypeScript versions'>
+    <img src='https://img.shields.io/badge/TypeScript-4.0%20%7C%204.1%20%7C%204.2%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/true-myth/true-myth/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>


### PR DESCRIPTION
Been testing this for a while, just forgot to specify it on the badge when I added it (61289ab).