### PR TITLE
Add export map to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,16 @@
     "src",
     "ember-addon.js"
   ],
+  "exports": {
+    "./maybe": {
+      "node": "./dist/cjs/maybe.js",
+      "default": "./dist/es/maybe.js"
+    },
+    "./result": {
+      "node": "./dist/cjs/result.js",
+      "default": "./dist/es/result.js"
+    }
+  },
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^26.0.19",


### PR DESCRIPTION
As stated in #102, it's currently not possible to import true-myth in some environments, such as SvelteKit. Even with aliases, SSR fails when trying to import the module using Node.js' ESM resolver.

My understanding is that export maps (added in 2020) can be used to correctly assign a source file to a subpath import, like `true-myth/maybe` and `true-myth/result`. My only workaround is to monkey-patch the package.json in node_modules.

I know that a proper ES version is in the works, would it be possible to patch this until that happens? Thanks for the library!