### PR TITLE
Update TS support range

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        ts-version: ['4.0', '4.1', '4.2', 'next']
+        ts-version: ['4.2', '4.3', '4.4', '4.5', 'next']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
     <img src='https://img.shields.io/npm/v/true-myth.svg' alt='npm'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L25'>
-    <img src='https://img.shields.io/badge/Node-10%20LTS%20%7C%2012%20LTS%20%7C%2014%20LTS-darkgreen' alt='supported Node versions'>
+    <img src='https://img.shields.io/badge/Node-12%20LTS%20%7C%2014%20LTS%20%7C%2016%20LTS-darkgreen' alt='supported Node versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L59'>
-    <img src='https://img.shields.io/badge/TypeScript-4.0%20%7C%204.1%20%7C%204.2%20%7C%20next-3178c6' alt='supported TypeScript versions'>
+    <img src='https://img.shields.io/badge/TypeScript-4.2%20%7C%204.3%20%7C%204.4%20%7C%204.5%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/true-myth/true-myth/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,24 +4,31 @@ module.exports = {
   command: './node_modules/.bin/jest',
   scenarios: [
     {
-      name: 'ts-4.0',
-      allowedToFail: false,
-      npm: {
-        devDependencies: { typescript: '4.0' },
-      },
-    },
-    {
-      name: 'ts-4.1',
-      allowedToFail: false,
-      npm: {
-        devDependencies: { typescript: '4.1' },
-      },
-    },
-    {
       name: 'ts-4.2',
       allowedToFail: false,
       npm: {
         devDependencies: { typescript: '4.2' },
+      },
+    },
+    {
+      name: 'ts-4.3',
+      allowedToFail: false,
+      npm: {
+        devDependencies: { typescript: '4.3' },
+      },
+    },
+    {
+      name: 'ts-4.4',
+      allowedToFail: false,
+      npm: {
+        devDependencies: { typescript: '4.4' },
+      },
+    },
+    {
+      name: 'ts-4.5',
+      allowedToFail: false,
+      npm: {
+        devDependencies: { typescript: '4.5' },
       },
     },
     {


### PR DESCRIPTION
Since I originally set up our TS support range, a *lot* of time has passed.

- bump minimum supported TS version to 4.2 (~2 years ago)
- update Node and TS support versions info in the README badges