### PR TITLE
Revert array utilities removal

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1152,6 +1152,194 @@ export function isInstance<T>(item: unknown): item is Maybe<T> {
   return item instanceof Maybe;
 }
 
+type Predicate<T> = (element: T, index: number, array: T[]) => boolean;
+
+// NOTE: documentation is lightly adapted from the MDN and TypeScript docs for
+// `Array.prototype.find`.
+/**
+  Safely search for an element in an array.
+  
+  This function behaves like `Array.prototype.find`, but returns `Maybe<T>`
+  instead of `T | undefined`.
+  
+  ## Examples
+
+  The basic form is:
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+
+  let array = [1, 2, 3];
+  Maybe.find(v => v > 1, array); // Just(2)
+  Maybe.find(v => v < 1, array); // Nothing
+  ```
+
+  The function is curried so you can use it in a functional chain. For example
+  (leaving aside error handling on a bad response for simplicity), suppose the
+  url `https://arrays.example.com` returned a JSON payload with the type
+  `Array<{ count: number, name: string }>`, and we wanted to get the first
+  of these where `count` was at least 100. We could write this:
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+
+  type Item = { count: number; name: string };
+  type Response = Array<Item>;
+
+  // curried variant!
+  const findAtLeast100 = Maybe.find(({ count }: Item) => count > 100);
+
+  fetch('https://arrays.example.com')
+    .then(response => response.json() as Response)
+    .then(findAtLeast100)
+    .then(found => {
+      if (found.isJust()) {
+        console.log(`The matching value is ${found.value.name}!`);
+      }
+    });
+  ```
+  
+  @param predicate  A function to execute on each value in the array, returning
+                    `true` when the item in the array matches the condition. The
+                    signature for `predicate` is identical to the signature for
+                    the first argument to `Array.prototype.find`. The function
+                    is called once for each element of the array, in ascending
+                    order, until it finds one where predicate returns true. If
+                    such an element is found, find immediately returns that
+                    element value wrapped in `Just`. Otherwise, `Maybe.find`
+                    returns `Nothing`.
+ * @param array     The array to search using the predicate.
+ */
+export function find<T>(predicate: Predicate<T>, array: T[]): Maybe<T>;
+export function find<T>(predicate: Predicate<T>): (array: T[]) => Maybe<T>;
+export function find<T>(
+  predicate: Predicate<T>,
+  array?: T[]
+): Maybe<T> | ((array: T[]) => Maybe<T>) {
+  const op = (a: T[]) => maybe(a.find(predicate));
+  return curry1(op, array);
+}
+
+/**
+  Safely get the first item from a list, returning `Just` the first item if the
+  array has at least one item in it, or `Nothing` if it is empty.
+
+  ## Examples
+
+  ```ts
+  let empty = [];
+  Maybe.head(empty); // => Nothing
+
+  let full = [1, 2, 3];
+  Maybe.head(full); // => Just(1)
+  ```
+
+  @param array The array to get the first item from.
+ */
+export function head<T>(array: Array<T | null | undefined>): Maybe<T> {
+  return maybe(array[0]);
+}
+
+/** A convenience alias for `Maybe.head`. */
+export const first = head;
+
+/**
+  Safely get the last item from a list, returning `Just` the last item if the
+  array has at least one item in it, or `Nothing` if it is empty.
+
+  ## Examples
+
+  ```ts
+  let empty = [];
+  Maybe.last(empty); // => Nothing
+
+  let full = [1, 2, 3];
+  Maybe.last(full); // => Just(3)
+  ```
+
+  @param array The array to get the first item from.
+ */
+export function last<T>(array: Array<T | null | undefined>): Maybe<T> {
+  return maybe(array[array.length - 1]);
+}
+
+/**
+  Given an array or tuple of `Maybe`s, return a `Maybe` of the array or tuple
+  values.
+
+  -   Given an array of type `Array<Maybe<A> | Maybe<B>>`, the resulting type is
+      `Maybe<Array<A | B>>`.
+  -   Given a tuple of type `[Maybe<A>, Maybe<B>]`, the resulting type is
+      `Maybe<[A, B]>`.
+
+  If any of the items in the array or tuple are `Nothing`, the whole result is
+  `Nothing`. If all items in the array or tuple are `Just`, the whole result is
+  `Just`.
+      
+  ## Examples
+
+  Given an array with a mix of `Maybe` types in it, both `allJust` and `mixed`
+  here will have the type `Maybe<Array<string | number>>`, but will be `Just`
+  and `Nothing` respectively.
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+
+  let valid = [Maybe.just(2), Maybe.just('three')];
+  let allJust = Maybe.arrayTranspose(valid); // => Just([2, 'three']);
+
+  let invalid = [Maybe.just(2), Maybe.nothing<string>()];
+  let mixed = Maybe.arrayTranspose(invalid); // => Nothing
+  ```
+
+  When working with a tuple type, the structure of the tuple is preserved. Here,
+  for example, `result` has the type `Maybe<[string, number]>` and will be
+  `Nothing`:
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+
+  type Tuple = [Maybe<string>, Maybe<number>];
+
+  let invalid: Tuple = [Maybe.just('wat'), Maybe.nothing()];
+  let result = Maybe.arrayTranspose(invalid);  // => Nothing
+  ```
+
+  If all of the items in the tuple are `Just`, the result is `Just` wrapping the
+  tuple of the values of the items. Here, for example, `result` again has the
+  type `Maybe<[string, number]>` and will be `Just(['hey', 12]`:
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+
+  type Tuple = [Maybe<string>, Maybe<number>];
+
+  let valid: Tuple = [Maybe.just('hey'), Maybe.just(12)];
+  let result = Maybe.arrayTranspose(valid);  // => Just(['hey', 12])
+  ```
+
+  __Note:__ this does not work with `ReadonlyArray`. If you have a
+  `ReadonlyArray` you wish to operate on, you must cast it to `Array` insetad.
+  This cast is always safe here, because `Array` is a *wider* type than
+  `ReadonlyArray`.
+
+  @param maybes The `Maybe`s to resolve to a single `Maybe`.
+ */
+export function arrayTranspose<T extends Array<Maybe<unknown>>>(m: T): TransposedArray<T> {
+  // The slightly odd-seeming use of `[...ms, m]` here instead of `concat` is
+  // necessary to preserve the structure of the value passed in. The goal is for
+  // `[Maybe<string>, [Maybe<number>, Maybe<boolean>]]` not to be flattened into
+  // `Maybe<[string, number, boolean]>` (as `concat` would do) but instead to
+  // produce `Maybe<[string, [number, boolean]]>`.
+  return m.reduce(
+    (acc: Maybe<unknown[]>, m) => acc.andThen((ms) => m.map((m) => [...ms, m])),
+    just([] as unknown[]) as TransposedArray<T>
+  ) as TransposedArray<T>;
+}
+
+type Unwrapped<T> = T extends Maybe<infer U> ? U : T;
+type TransposedArray<T extends Array<Maybe<unknown>>> = Maybe<{ [K in keyof T]: Unwrapped<T[K]> }>;
+
 /**
   Transposes a `Maybe` of a `Result` into a `Result` of a `Maybe`.
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -373,6 +373,88 @@ describe('`Maybe` pure functions', () => {
     expect(MaybeNS.isInstance(obj)).toBe(false);
   });
 
+  test('`find`', () => {
+    const theValue = 4;
+    const pred = (v: number) => v === theValue;
+
+    const empty: number[] = [];
+
+    expect(MaybeNS.find(pred, empty).variant).toBe(MaybeNS.Variant.Nothing);
+
+    const missingTheValue = [1, 2, 3];
+    expect(MaybeNS.find(pred, missingTheValue).variant).toBe(MaybeNS.Variant.Nothing);
+
+    const hasTheValue = [1, 2, 3, theValue];
+    const result = MaybeNS.find(pred, hasTheValue);
+    expect(result.variant).toBe(MaybeNS.Variant.Just);
+    expect((result as Just<number>).value).toBe(theValue);
+
+    type Item = { count: number; name: string };
+    type Response = Array<Item>;
+
+    // This is more about testing the types with the currying; it's functionally
+    // covered already.
+    const array: Response = [
+      { count: 1, name: 'potato' },
+      { count: 10, name: 'waffles' },
+    ];
+    const findAtLeast5 = MaybeNS.find(({ count }: Item) => count > 5);
+    const found = findAtLeast5(array);
+    expect(found.variant).toBe(MaybeNS.Variant.Just);
+    expect((found as Just<Item>).value).toEqual(array[1]);
+  });
+
+  test('`head`', () => {
+    expect(MaybeNS.head([])).toEqual(MaybeNS.nothing());
+    expect(MaybeNS.head([1])).toEqual(MaybeNS.just(1));
+    expect(MaybeNS.head([1, 2, 3])).toEqual(MaybeNS.just(1));
+  });
+
+  test('`last`', () => {
+    expect(MaybeNS.last([])).toEqual(MaybeNS.nothing());
+    expect(MaybeNS.last([1])).toEqual(MaybeNS.just(1));
+    expect(MaybeNS.last([1, 2, 3])).toEqual(MaybeNS.just(3));
+  });
+
+  describe('`arrayTranspose`', () => {
+    test('with basic types', () => {
+      type ExpectedOutputType = Maybe<Array<string | number>>;
+
+      let onlyJusts = [MaybeNS.just(2), MaybeNS.just('three')];
+      let onlyJustsAll = MaybeNS.arrayTranspose(onlyJusts);
+      expectTypeOf(onlyJustsAll).toEqualTypeOf<ExpectedOutputType>();
+      expect(onlyJustsAll).toEqual(MaybeNS.just([2, 'three']));
+
+      let hasNothing = [MaybeNS.just(2), MaybeNS.nothing<string>()];
+      let hasNothingAll = MaybeNS.arrayTranspose(hasNothing);
+      expectTypeOf(hasNothingAll).toEqualTypeOf<ExpectedOutputType>();
+      expect(hasNothingAll).toEqual(MaybeNS.nothing());
+    });
+
+    test('with arrays', () => {
+      type ExpectedOutputType = Maybe<Array<number | string[]>>;
+
+      let nestedArrays = [MaybeNS.just(1), MaybeNS.just(['two', 'three'])];
+      let nestedArraysAll = MaybeNS.arrayTranspose(nestedArrays);
+
+      expectTypeOf(nestedArraysAll).toEqualTypeOf<ExpectedOutputType>();
+      expect(nestedArraysAll).toEqual(MaybeNS.just([1, ['two', 'three']]));
+    });
+
+    test('`tuple`', () => {
+      type Tuple2 = [Maybe<string>, Maybe<number>];
+      let invalid: Tuple2 = [MaybeNS.just('wat'), MaybeNS.nothing()];
+      const invalidResult = MaybeNS.arrayTranspose(invalid);
+      expect(invalidResult).toEqual(MaybeNS.nothing());
+
+      type Tuple3 = [Maybe<string>, Maybe<number>, Maybe<{ neat: string }>];
+      let valid: Tuple3 = [MaybeNS.just('hey'), MaybeNS.just(4), MaybeNS.just({ neat: 'yeah' })];
+      const result = MaybeNS.arrayTranspose(valid);
+      expect(result).toEqual(MaybeNS.just(['hey', 4, { neat: 'yeah' }]));
+      expectTypeOf(result).toEqualTypeOf<Maybe<[string, number, { neat: string }]>>();
+    });
+  });
+
   describe('transpose', () => {
     test('Just(Ok(T))', () => {
       let maybe = MaybeNS.just(ok<number, string>(12));


### PR DESCRIPTION
This reverts commit ef77aef (part of #119). This is still a useful thing to do in the future, but since we haven't given anyone any heads-up that this is coming, it's better to leave it in place for now -- especially since it's going to be a bit before anyone has time to actually break the whole thing apart into a monorepo with `@true-myth/*` packages!