### PR TITLE
Revert removal of `all` and `tuple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
     let allJustArray = [just("hello"), just(12)];
     let allJustArrayResult: ArrayResult = arrayTranspose(allJustArray);
     
-    // Tuples now work with `all` as well.
+    // Tuples now work with `arrayTranspose` as well.
     type Tuple = [Maybe<number>, Maybe<string>];
     type TupleResult = Maybe<[number, string]>;
 
@@ -80,7 +80,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Deprecated :red-square:
 
-- `Maybe.tuple` is deprecated since `Maybe.all` now correctly handles both arrays and tuples. It will be removed not earlier than 6.0.0 (timeline not decided, certainly not before Node 10 leaves LTS on 2021-04-30).
+- `Maybe.tuple` and `Maybe.all` are deprecated in favor of `Maybe.arrayTranspose` now correctly handles both arrays and tuples. They will be removed not earlier than 6.0.0 (timeline not decided, but not sooner than when Node 12 LTS reaches end of life on April 30, 2022).
+
 
 ## [4.1.0] (2020-12-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed :boom:
 
-- We introduced a new `Maybe.transposeArray`, which is a type-safe, renamed, merged version of `Maybe.tuple` and `Maybe.all` which can correctly handle both array and tuple types. To support this change, it now accepts arrays or tuples directly, and the variadic/spread arguments to `all` have been replaced with taking an array or tuple directly. While `tuple` is unchanged, it is also deprecated (see below).
+- Support for versions of TypeScript before 4.0 have been removed, to enable the type-safe re-implementation of `Maybe.all`.
+
+- The `MaybeShape` and `ResultShape` interfaces are no longer exported. These were never intended for public reimplementation, and there is accordingly no value in their continuing to be public.
+
+### Added :star:
+
+- We introduced a new `Maybe.transposeArray`, which is a type-safe, renamed, merged version of `Maybe.tuple` and `Maybe.all` which can correctly handle both array and tuple types. To support this change, it now accepts arrays or tuples directly, and the variadic/spread arguments to `all` have been replaced with taking an array or tuple directly. While `tuple` and `all` are unchanged, they are also deprecated (see below).
 
     **Before:**
 
@@ -53,30 +59,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
     let mixedTupleResult: TupleResult = arrayTranspose(mixedTuple);
     ```
 
--   Support for versions of TypeScript before 4.0 have been removed, to enable the type-safe re-implementation of `Maybe.all`.
-
--   The `MaybeShape` and `ResultShape` interfaces are no longer exported. These were never intended for public reimplementation, and there is accordingly no value in their continuing to be public.
-
-### Added :star:
-
 -   `Maybe.transpose` and `Result.transpose`: for when you have a `Maybe<Result<T, E>>` or a `Result<Maybe<T>, E>` and need to invert them.
 
     ```ts
     import Maybe, { just, nothing } from 'true-myth/maybe';
     import Result, { ok, err } from 'true-myth/result';
 
-    let aJustOk: Maybe<Result<number, string>> = just(ok(12));
-    let result: Result<Maybe<number>, string> = Maybe.transpose(aJustOk);
+    let anOkJust: Result<Maybe<number>, string> = ok(just(12));
+    let maybe: Maybe<number>, string> = Maybe.transposeResult(anOkJust);
+    console.log(maybe); // Just(Ok(12))
 
-    let anOkNone: Result<Maybe<number>, string> = ok(just(12));
-    let maybe: Maybe<Result<number, string>> = Result.transpose(anOkNone);
+    let aJustOk: Maybe<Result<number, string>> = just(ok(12));
+    let result: Maybe<Result<number, string>> = Result.transposeMaybe(aJustOk);
+    console.log(result); // Ok(Just(12))
     ```
 
     See the docs for further details!
 
     **Note:** these are standalone functions, not methods, because TypeScript
     does not support conditionally supplying a method only for one specific type
-    parameterization. (Rust, the direct inspiration for the name of this method, *does* allow that.)
+    parameterization.
 
 ### Deprecated :red-square:
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1325,13 +1325,13 @@ export function last<T>(array: Array<T | null | undefined>): Maybe<T> {
 
   @param maybes The `Maybe`s to resolve to a single `Maybe`.
  */
-export function arrayTranspose<T extends Array<Maybe<unknown>>>(m: T): TransposedArray<T> {
+export function transposeArray<T extends Array<Maybe<unknown>>>(maybes: T): TransposedArray<T> {
   // The slightly odd-seeming use of `[...ms, m]` here instead of `concat` is
   // necessary to preserve the structure of the value passed in. The goal is for
   // `[Maybe<string>, [Maybe<number>, Maybe<boolean>]]` not to be flattened into
   // `Maybe<[string, number, boolean]>` (as `concat` would do) but instead to
   // produce `Maybe<[string, [number, boolean]]>`.
-  return m.reduce(
+  return maybes.reduce(
     (acc: Maybe<unknown[]>, m) => acc.andThen((ms) => m.map((m) => [...ms, m])),
     just([] as unknown[]) as TransposedArray<T>
   ) as TransposedArray<T>;
@@ -1353,22 +1353,23 @@ export const all = transposeArray;
 export const tuple = transposeArray;
 
 /**
+  Transposes a `Result` of a `Maybe` into a `Maybe` of a `Result`.
 
-  | Input          | Output        |
-  | -------------- | ------------- |
-  | `Just(Ok(T))`  | `Ok(Just(T))` |
-  | `Just(Err(E))` | `Err(E)`      |
-  | `Nothing`      | `Ok(Nothing)` |
+  | Input         | Output         |
+  | ------------- | -------------- |
+  | `Ok(Just(T))` | `Just(Ok(T))`  |
+  | `Err(E)`      | `Just(Err(E))` |
+  | `Ok(Nothing)` | `Nothing`      |
 
-  @param maybe a `Maybe<Result<T, E>>` to transform to a `Result<Maybe<T>, E>>`.
+  @param result a `Result<Maybe<T>, E>` to transform to a `Maybe<Result<T, E>>`.
  */
-export function transpose<T, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T>, E> {
-  return maybe.match({
-    Just: Result.match({
-      Ok: (v) => Result.ok<Maybe<T>, E>(just(v)),
-      Err: (e) => Result.err<Maybe<T>, E>(e),
+export function transposeResult<T, E>(result: Result<Maybe<T>, E>): Maybe<Result<T, E>> {
+  return result.match({
+    Ok: match({
+      Just: (v) => just(Result.ok<T, E>(v)),
+      Nothing: () => nothing<Result<T, E>>(),
     }),
-    Nothing: () => Result.ok<Maybe<T>, E>(nothing()),
+    Err: (e) => Maybe.just(Result.err<T, E>(e)),
   });
 }
 
@@ -1567,7 +1568,7 @@ export function wrapReturn<F extends (...args: any[]) => any>(
 
 // The public interface for the Maybe class *as a value*: a constructor and the
 // single associated static property.
-interface M {
+interface MaybeConstructor {
   new <T>(value?: T | null | undefined): Maybe<T>;
   of: typeof _Maybe.of;
   just: typeof _Maybe.just;
@@ -1576,5 +1577,5 @@ interface M {
 
 /** A value which may (`Just<T>`) or may not (`Nothing`) be present. */
 export type Maybe<T> = Just<T> | Nothing<T>;
-export const Maybe = _Maybe as M;
+export const Maybe = _Maybe as MaybeConstructor;
 export default Maybe;

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1341,7 +1341,18 @@ type Unwrapped<T> = T extends Maybe<infer U> ? U : T;
 type TransposedArray<T extends Array<Maybe<unknown>>> = Maybe<{ [K in keyof T]: Unwrapped<T[K]> }>;
 
 /**
-  Transposes a `Maybe` of a `Result` into a `Result` of a `Maybe`.
+ * Legacy alias for `arrayTranspose`.
+ * @deprecated
+ */
+export const all = transposeArray;
+
+/**
+ * Legacy alias for `arrayTranspose`.
+ * @deprecated
+ */
+export const tuple = transposeArray;
+
+/**
 
   | Input          | Output        |
   | -------------- | ------------- |

--- a/src/result.ts
+++ b/src/result.ts
@@ -1309,23 +1309,23 @@ export function isInstance<T, E>(item: unknown): item is Result<T, E> {
 }
 
 /**
-  Transposes a `Result` of a `Maybe` into a `Maybe` of a `Result`.
+  Transposes a `Maybe` of a `Result` into a `Result` of a `Maybe`.
 
-  | Input         | Output         |
-  | ------------- | -------------- |
-  | `Ok(Just(T))` | `Just(Ok(T))`  |
-  | `Err(E)`      | `Just(Err(E))` |
-  | `Ok(Nothing)` | `Nothing`      |
+  | Input          | Output        |
+  | -------------- | ------------- |
+  | `Just(Ok(T))`  | `Ok(Just(T))` |
+  | `Just(Err(E))` | `Err(E)`      |
+  | `Nothing`      | `Ok(Nothing)` |
 
-  @param result a `Result<Maybe<T>, E>` to transform to a `Maybe<Result<T, E>>`.
+  @param maybe a `Maybe<Result<T, E>>` to transform to a `Result<Maybe<T>, E>>`.
  */
-export function transpose<T, E>(result: Result<Maybe<T>, E>): Maybe<Result<T, E>> {
-  return result.match({
-    Ok: Maybe.match({
-      Just: (v) => Maybe.just(ok<T, E>(v)),
-      Nothing: () => Maybe.nothing<Result<T, E>>(),
+export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T>, E> {
+  return maybe.match({
+    Just: match({
+      Ok: (v) => Result.ok(Maybe.just(v)),
+      Err: (e) => Result.err(e),
     }),
-    Err: (e) => Maybe.just(err<T, E>(e)),
+    Nothing: () => Result.ok(Maybe.nothing()),
   });
 }
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -416,17 +416,17 @@ describe('`Maybe` pure functions', () => {
     expect(MaybeNS.last([1, 2, 3])).toEqual(MaybeNS.just(3));
   });
 
-  describe('`arrayTranspose`', () => {
+  describe('`transposeArray`', () => {
     test('with basic types', () => {
       type ExpectedOutputType = Maybe<Array<string | number>>;
 
       let onlyJusts = [MaybeNS.just(2), MaybeNS.just('three')];
-      let onlyJustsAll = MaybeNS.arrayTranspose(onlyJusts);
+      let onlyJustsAll = MaybeNS.transposeArray(onlyJusts);
       expectTypeOf(onlyJustsAll).toEqualTypeOf<ExpectedOutputType>();
       expect(onlyJustsAll).toEqual(MaybeNS.just([2, 'three']));
 
       let hasNothing = [MaybeNS.just(2), MaybeNS.nothing<string>()];
-      let hasNothingAll = MaybeNS.arrayTranspose(hasNothing);
+      let hasNothingAll = MaybeNS.transposeArray(hasNothing);
       expectTypeOf(hasNothingAll).toEqualTypeOf<ExpectedOutputType>();
       expect(hasNothingAll).toEqual(MaybeNS.nothing());
     });
@@ -435,7 +435,7 @@ describe('`Maybe` pure functions', () => {
       type ExpectedOutputType = Maybe<Array<number | string[]>>;
 
       let nestedArrays = [MaybeNS.just(1), MaybeNS.just(['two', 'three'])];
-      let nestedArraysAll = MaybeNS.arrayTranspose(nestedArrays);
+      let nestedArraysAll = MaybeNS.transposeArray(nestedArrays);
 
       expectTypeOf(nestedArraysAll).toEqualTypeOf<ExpectedOutputType>();
       expect(nestedArraysAll).toEqual(MaybeNS.just([1, ['two', 'three']]));
@@ -444,37 +444,37 @@ describe('`Maybe` pure functions', () => {
     test('`tuple`', () => {
       type Tuple2 = [Maybe<string>, Maybe<number>];
       let invalid: Tuple2 = [MaybeNS.just('wat'), MaybeNS.nothing()];
-      const invalidResult = MaybeNS.arrayTranspose(invalid);
+      const invalidResult = MaybeNS.tuple(invalid);
       expect(invalidResult).toEqual(MaybeNS.nothing());
 
       type Tuple3 = [Maybe<string>, Maybe<number>, Maybe<{ neat: string }>];
       let valid: Tuple3 = [MaybeNS.just('hey'), MaybeNS.just(4), MaybeNS.just({ neat: 'yeah' })];
-      const result = MaybeNS.arrayTranspose(valid);
+      const result = MaybeNS.tuple(valid);
       expect(result).toEqual(MaybeNS.just(['hey', 4, { neat: 'yeah' }]));
       expectTypeOf(result).toEqualTypeOf<Maybe<[string, number, { neat: string }]>>();
     });
   });
 
-  describe('transpose', () => {
-    test('Just(Ok(T))', () => {
-      let maybe = MaybeNS.just(ok<number, string>(12));
-      let transposed = MaybeNS.transpose(maybe);
-      expect(transposed).toStrictEqual(ok(MaybeNS.just(12)));
-      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
+  describe('transposeResult', () => {
+    test('Ok(Just(T))', () => {
+      let result = Result.ok<Maybe<number>, string>(Maybe.just(12));
+      let transposed = MaybeNS.transposeResult(result);
+      expect(transposed).toStrictEqual(Maybe.just(Result.ok(12)));
+      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
     });
 
-    test('Just(Err(E))', () => {
-      let maybe = MaybeNS.just(err<number, string>('whoops'));
-      let transposed = MaybeNS.transpose(maybe);
-      expect(transposed).toStrictEqual(err('whoops'));
-      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
+    test('Ok(Nothing)', () => {
+      let result = Result.ok<Maybe<number>, string>(Maybe.nothing<number>());
+      let transposed = MaybeNS.transposeResult(result);
+      expect(transposed).toStrictEqual(Maybe.nothing());
+      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
     });
 
-    test('Nothing', () => {
-      let maybe = MaybeNS.nothing<Result<number, string>>();
-      let transposed = MaybeNS.transpose(maybe);
-      expect(transposed).toStrictEqual(ok(MaybeNS.nothing()));
-      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
+    test('Err(E)', () => {
+      let result = Result.err<Maybe<number>, string>('hello');
+      let transposed = MaybeNS.transposeResult(result);
+      expect(transposed).toStrictEqual(Maybe.just(Result.err('hello')));
+      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
     });
   });
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -388,26 +388,26 @@ describe('`Result` pure functions', () => {
     expect(ResultNS.isInstance(obj)).toBe(false);
   });
 
-  describe('transpose', () => {
-    test('Ok(Just(T))', () => {
-      let result = ResultNS.ok<Maybe<number>, string>(just(12));
-      let transposed = ResultNS.transpose(result);
-      expect(transposed).toStrictEqual(just(ResultNS.ok(12)));
-      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
+  describe('transposeMaybe', () => {
+    test('Just(Ok(T))', () => {
+      let maybe = Maybe.just(Result.ok<number, string>(12));
+      let transposed = ResultNS.transposeMaybe(maybe);
+      expect(transposed).toStrictEqual(Result.ok(Maybe.just(12)));
+      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
     });
 
-    test('Ok(Nothing)', () => {
-      let result = ResultNS.ok<Maybe<number>, string>(nothing<number>());
-      let transposed = ResultNS.transpose(result);
-      expect(transposed).toStrictEqual(nothing());
-      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
+    test('Just(Err(E))', () => {
+      let maybe = Maybe.just(Result.err<number, string>('whoops'));
+      let transposed = ResultNS.transposeMaybe(maybe);
+      expect(transposed).toStrictEqual(Result.err('whoops'));
+      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
     });
 
-    test('Err(E)', () => {
-      let result = ResultNS.err<Maybe<number>, string>('hello');
-      let transposed = ResultNS.transpose(result);
-      expect(transposed).toStrictEqual(just(ResultNS.err('hello')));
-      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
+    test('Nothing', () => {
+      let maybe = Maybe.nothing<Result<number, string>>();
+      let transposed = ResultNS.transposeMaybe(maybe);
+      expect(transposed).toStrictEqual(Result.ok(Maybe.nothing()));
+      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
     });
   });
 });


### PR DESCRIPTION
Supply deprecated versions of them as aliases for `transposeArray`, with a commitment not to drop before 6.0.0 in April 2022, and update the CHANGELOG accordingly.