### PR TITLE
Remove a few more needless aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
     - `maybeify` and `transmogrify`: use `wrapReturn`
     - `unsafelyGet` and `unsafeGet`: use `.isJust`/`.isOk` then `.value`
     - `unsafelyGetErr` and `unsafelyUnwrapErr`: use `.isErr` then `.error`
+    - `getOr`: use `unwrapOr`
+    - `getOrElse`: use `unwrapOrElse`
+    - `fromNullable` and `maybe`:
+        - import `Maybe` and use its static constructor `Maybe.of`
+        - import the module as namespace and use `Maybe.of`
+        - import `of` and alias it as you like
 
 ### :star: Added
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -375,33 +375,6 @@ export const nothing = MaybeClass.nothing;
 export const of = MaybeClass.of;
 
 /**
-  Alias for {@link of}, convenient for a standalone import:
-
-  ```ts
-  import { maybe } from 'true-myth/maybe';
-  
-  interface Dict<T> {
-    [key: string]: T | null | undefined;
-  }
-
-  interface StrictDict<T> {
-    [key: string]: Maybe<T>;
-  }
-
-  function wrapNullables<T>(dict: Dict<T>): StrictDict<T> {
-    return Object.keys(dict).reduce((strictDict, key) => {
-      strictDict[key] = maybe(dict[key]);
-      return strictDict;
-    }, {} as StrictDict<T>);
-  }
-  ```
- */
-export const maybe = of;
-
-/** Alias for {@link of}, primarily for compatibility with Folktale. */
-export const fromNullable = of;
-
-/**
   Map over a {@linkcode Maybe} instance: apply the function to the wrapped value
   if the instance is {@linkcode Just}, and return {@linkcode Nothing} if the
   instance is `Nothing`.
@@ -760,9 +733,6 @@ export function unwrapOr<T, U>(defaultValue: U, maybe?: Maybe<T>) {
   return curry1(op, maybe);
 }
 
-/** Alias for {@linkcode unwrapOr} */
-export const getOr = unwrapOr;
-
 /**
   Safely get the value out of a {@linkcode Maybe} by returning the wrapped value
   if it is {@linkcode Just}, or by applying `orElseFn` if it is
@@ -802,9 +772,6 @@ export function unwrapOrElse<T, U>(
   const op = (m: Maybe<T>) => (m.isJust ? m.value : orElseFn());
   return curry1(op, maybe);
 }
-
-/** Alias for {@linkcode unwrapOrElse} */
-export const getOrElse = unwrapOrElse;
 
 /**
   Transform the {@linkcode Maybe} into a {@linkcode Result.Result Result}, using
@@ -1235,7 +1202,7 @@ export function find<T>(
   predicate: Predicate<T>,
   array?: T[]
 ): Maybe<T> | ((array: T[]) => Maybe<T>) {
-  const op = (a: T[]) => maybe(a.find(predicate));
+  const op = (a: T[]) => Maybe.of(a.find(predicate));
   return curry1(op, array);
 }
 
@@ -1257,7 +1224,7 @@ export function find<T>(
   @param array The array to get the first item from.
  */
 export function head<T>(array: Array<T | null | undefined>): Maybe<T> {
-  return maybe(array[0]);
+  return Maybe.of(array[0]);
 }
 
 /** A convenience alias for `Maybe.head`. */
@@ -1281,7 +1248,7 @@ export const first = head;
   @param array The array to get the first item from.
  */
 export function last<T>(array: Array<T | null | undefined>): Maybe<T> {
-  return maybe(array[array.length - 1]);
+  return Maybe.of(array[array.length - 1]);
 }
 
 /**
@@ -1455,7 +1422,7 @@ export function property<T, K extends keyof T>(
   key: K,
   obj?: T
 ): Maybe<NonNullable<T[K]>> | ((obj: T) => Maybe<NonNullable<T[K]>>) {
-  const op = (a: T) => maybe(a[key]) as Maybe<NonNullable<T[K]>>;
+  const op = (a: T) => Maybe.of(a[key]) as Maybe<NonNullable<T[K]>>;
   return curry1(op, obj);
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -898,9 +898,6 @@ export function unwrapOr<T, U, E>(
   return curry1(op, result);
 }
 
-/** Alias for {@linkcode unwrapOr} */
-export const getOr = unwrapOr;
-
 /**
   Safely get the value out of a {@linkcode Result} by returning the wrapped
   value if it is {@linkcode Ok}, or by applying `orElseFn` to the value in the
@@ -941,9 +938,6 @@ export function unwrapOrElse<T, U, E>(
   const op = (r: Result<T, E>) => (r.isOk ? r.value : orElseFn(r.error));
   return curry1(op, result);
 }
-
-/** Alias for [`unwrapOrElse`](#unwraporelse) */
-export const getOrElse = unwrapOrElse;
 
 /**
   Convert a {@linkcode Result} to a {@linkcode Maybe.Maybe Maybe}.

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -76,37 +76,6 @@ describe('`Maybe` pure functions', () => {
     });
   });
 
-  describe('`fromNullable`', () => {
-    test('with `null', () => {
-      const nothingFromNull = MaybeNS.fromNullable<string>(null);
-      expectTypeOf(nothingFromNull).toEqualTypeOf<Maybe<string>>();
-      expect(nothingFromNull.isJust).toBe(false);
-      expect(nothingFromNull.isNothing).toBe(true);
-      expect(() => nothingFromNull.value).toThrow();
-    });
-
-    test('with `undefined`', () => {
-      const nothingFromUndefined = MaybeNS.fromNullable<number>(undefined);
-      expectTypeOf(nothingFromUndefined).toEqualTypeOf<Maybe<number>>();
-      expect(nothingFromUndefined.isJust).toBe(false);
-      expect(nothingFromUndefined.isNothing).toBe(true);
-      expect(() => nothingFromUndefined.value).toThrow();
-    });
-
-    test('with values', () => {
-      const aJust = MaybeNS.fromNullable<Neat>({ neat: 'strings' });
-      expectTypeOf(aJust).toEqualTypeOf<Maybe<Neat>>();
-      const aNothing = MaybeNS.fromNullable<Neat>(null);
-      expectTypeOf(aNothing).toEqualTypeOf<Maybe<Neat>>();
-
-      const justANumber = MaybeNS.fromNullable(42);
-      expectTypeOf(justANumber).toEqualTypeOf<Maybe<number>>();
-      expect(justANumber.isJust).toBe(true);
-      expect(justANumber.isNothing).toBe(false);
-      expect(justANumber.value).toBe(42);
-    });
-  });
-
   test('`map`', () => {
     const justAString = MaybeNS.just('string');
     const itsLength = MaybeNS.map(length, justAString);


### PR DESCRIPTION
- `getOr`: use `unwrapOr`
- `getOrElse`: use `unwrapOrElse`
- `fromNullable` and `maybe`:
    - import `Maybe` and use its static constructor `Maybe.of`
    - import the module as namespace and use `Maybe.of`
    - import `of` and alias it as you like