### PR TITLE
Deprecate non-Toolbelt versions of toolbelt utils

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -218,6 +218,8 @@ class MaybeImpl<T> {
     ```ts
     import { toOkOrErr } from 'true-myth/toolbelt';
     ```
+
+    @deprecated until 6.0
    */
   toOkOrErr<E>(this: Maybe<T>, error: E): Result<T, E> {
     return Toolbelt.toOkOrErr(error, this);
@@ -230,6 +232,8 @@ class MaybeImpl<T> {
     ```ts
     import { toOkOrElseErr } from 'true-myth/toolbelt';
     ```
+
+    @deprecated until 6.0
    */
   toOkOrElseErr<E>(this: Maybe<T>, elseFn: () => E): Result<T, E> {
     return Toolbelt.toOkOrElseErr(elseFn, this);
@@ -795,6 +799,8 @@ export function unwrapOrElse<T, U>(
   ```ts
   import type { transposeResult } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function fromResult<T>(result: Result<T, unknown>): Maybe<T> {
   return Toolbelt.fromResult(result);
@@ -1319,6 +1325,8 @@ export const tuple = transposeArray;
   ```ts
   import type { transposeResult } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function transposeResult<T, E>(result: Result<Maybe<T>, E>) {
   return Toolbelt.transposeResult(result);
@@ -1332,6 +1340,8 @@ export function transposeResult<T, E>(result: Result<Maybe<T>, E>) {
   ```ts
   import type { toOkOrErr } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function toOkOrErr<T, E>(error: E, maybe: Maybe<T>): Result<T, E>;
 export function toOkOrErr<T, E>(error: E): (maybe: Maybe<T>) => Result<T, E>;
@@ -1351,6 +1361,8 @@ export function toOkOrErr<T, E>(
   ```ts
   import type { toOkOrElseErr } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function toOkOrElseErr<T, E>(elseFn: () => E, maybe: Maybe<T>): Result<T, E>;
 export function toOkOrElseErr<T, E>(elseFn: () => E): (maybe: Maybe<T>) => Result<T, E>;

--- a/src/result.ts
+++ b/src/result.ts
@@ -218,6 +218,8 @@ class ResultImpl<T, E> {
     ```ts
     import { toMaybe } from 'true-myth/toolbelt';
     ```
+
+    @deprecated until 6.0
    */
   toMaybe(this: Result<T, E>): Maybe<T> {
     return Toolbelt.toMaybe(this);
@@ -956,6 +958,8 @@ export function unwrapOrElse<T, U, E>(
   ```ts
   import type { toOkOrErr } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function fromMaybe<T, E>(errValue: E, maybe: Maybe<T>): Result<T, E>;
 export function fromMaybe<T, E>(errValue: E): (maybe: Maybe<T>) => Result<T, E>;
@@ -1314,6 +1318,8 @@ export function isInstance<T, E>(item: unknown): item is Result<T, E> {
   ```ts
   import type { transposeMaybe } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>) {
   return Toolbelt.transposeMaybe(maybe);
@@ -1327,6 +1333,8 @@ export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>) {
   ```ts
   import type { toMaybe } from 'true-myth/toolbelt';
   ```
+
+  @deprecated until 6.0
  */
 export function toMaybe<T, E>(result: Result<T, E>): Maybe<T> {
   return Toolbelt.toMaybe(result);


### PR DESCRIPTION
In 6.0 (targeted for May 2022), we will remove these deprecated versions of the `toolbelt` utils, enabling *much* better tree-shaking, since the `Maybe` and `Result` classes will no longer reference each other and the modules will be totally decoupled.