### PR TITLE
Enable tree-shaking by removing deprecated code

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -4,11 +4,7 @@
   @module
  */
 
-import Result from './result.js';
 import { curry1, isVoid } from './-private/utils.js';
-
-// Import for backwards-compatibility re-export
-import * as Toolbelt from './toolbelt.js';
 
 /**
   Discriminant for the {@linkcode Just} and {@linkcode Nothing} type instances.
@@ -209,34 +205,6 @@ class MaybeImpl<T> {
   /** Method variant for {@linkcode unwrapOrElse} */
   unwrapOrElse<U>(elseFn: () => U): T | U {
     return this.repr[0] === 'Just' ? this.repr[1] : elseFn();
-  }
-
-  /**
-    Method variant for {@linkcode Toolbelt.toOkOrErr toOkOrErr} from
-    {@linkcode Toolbelt}. Prefer to import and use it directly instead:
-
-    ```ts
-    import { toOkOrErr } from 'true-myth/toolbelt';
-    ```
-
-    @deprecated until 6.0
-   */
-  toOkOrErr<E>(this: Maybe<T>, error: E): Result<T, E> {
-    return Toolbelt.toOkOrErr(error, this);
-  }
-
-  /**
-    Method variant for {@linkcode Toolbelt.toOkOrElseErr toOkOrElseErr} from
-    {@linkcode Toolbelt}. Prefer to import and use it directly instead:
-
-    ```ts
-    import { toOkOrElseErr } from 'true-myth/toolbelt';
-    ```
-
-    @deprecated until 6.0
-   */
-  toOkOrElseErr<E>(this: Maybe<T>, elseFn: () => E): Result<T, E> {
-    return Toolbelt.toOkOrElseErr(elseFn, this);
   }
 
   /** Method variant for {@linkcode toString} */
@@ -800,21 +768,6 @@ export function unwrapOrElse<T, U>(
 }
 
 /**
-  Re-export of {@linkcode Toolbelt.transposeResult transposeResult} from
-  {@linkcode Toolbelt} for backwards compatibility. Prefer to import it from
-  there instead:
-
-  ```ts
-  import { transposeResult } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function fromResult<T>(result: Result<T, unknown>): Maybe<T> {
-  return Toolbelt.fromResult(result);
-}
-
-/**
   Create a `String` representation of a {@linkcode Maybe} instance.
 
   A {@linkcode Just} instance will be `Just(<representation of the value>)`,
@@ -1197,12 +1150,6 @@ export function first<T>(array: Array<T | null | undefined>): Maybe<T> {
 }
 
 /**
-  A convenience alias for `Maybe.first`.
-  @deprecated until 6.0
- */
-export const head = first;
-
-/**
   Safely get the last item from a list, returning {@linkcode Just} the last item
   if the array has at least one item in it, or {@linkcode Nothing} if it is
   empty.
@@ -1302,77 +1249,6 @@ export type Unwrapped<T> = T extends Maybe<infer U> ? U : T;
 export type TransposedArray<T extends Array<Maybe<unknown>>> = Maybe<{
   [K in keyof T]: Unwrapped<T[K]>;
 }>;
-
-/**
-  Legacy alias for {@linkcode transposeArray}.
-
-  @deprecated
- */
-export const all = transposeArray;
-
-/**
-  Legacy alias for {@linkcode transposeArray}.
-
-  @deprecated
- */
-export const tuple = transposeArray;
-
-/**
-  Re-export of {@linkcode Toolbelt.transposeResult transposeResult} from
-  {@linkcode Toolbelt} for backwards compatibility. Prefer to import it from
-  there instead:
-
-  ```ts
-  import { transposeResult } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function transposeResult<T, E>(result: Result<Maybe<T>, E>) {
-  return Toolbelt.transposeResult(result);
-}
-
-/**
-  Local implementation of {@linkcode Toolbelt.toOkOrErr toOkOrErr} from
-  {@linkcode Toolbelt} for backwards compatibility. Prefer to import it from
-  there instead:
-
-  ```ts
-  import { toOkOrErr } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function toOkOrErr<T, E>(error: E, maybe: Maybe<T>): Result<T, E>;
-export function toOkOrErr<T, E>(error: E): (maybe: Maybe<T>) => Result<T, E>;
-export function toOkOrErr<T, E>(
-  error: E,
-  maybe?: Maybe<T>
-): Result<T, E> | ((maybe: Maybe<T>) => Result<T, E>) {
-  const op = (m: Maybe<T>) => (m.isJust ? Result.ok<T, E>(m.value) : Result.err<T, E>(error));
-  return maybe !== undefined ? op(maybe) : op;
-}
-
-/**
-  Local implementation of {@linkcode Toolbelt.toOkOrElseErr toOkOrElseErr} from
-  {@linkcode Toolbelt} for backwards compatibility. Prefer to import it from
-  there instead:
-
-  ```ts
-  import { toOkOrElseErr } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function toOkOrElseErr<T, E>(elseFn: () => E, maybe: Maybe<T>): Result<T, E>;
-export function toOkOrElseErr<T, E>(elseFn: () => E): (maybe: Maybe<T>) => Result<T, E>;
-export function toOkOrElseErr<T, E>(
-  elseFn: () => E,
-  maybe?: Maybe<T>
-): Result<T, E> | ((maybe: Maybe<T>) => Result<T, E>) {
-  const op = (m: Maybe<T>) => (m.isJust ? Result.ok<T, E>(m.value) : Result.err<T, E>(elseFn()));
-  return curry1(op, maybe);
-}
 
 /**
   Safely extract a key from an object, returning {@linkcode Just} if the key has

--- a/src/result.ts
+++ b/src/result.ts
@@ -4,13 +4,8 @@
   @module
  */
 
-import type Maybe from './maybe.js';
-
 import Unit from './unit.js';
 import { curry1, isVoid } from './-private/utils.js';
-
-// Import for backwards-compatibility re-export
-import * as Toolbelt from './toolbelt.js';
 
 /**
   Discriminant for {@linkcode Ok} and {@linkcode Err} variants of the
@@ -210,20 +205,6 @@ class ResultImpl<T, E> {
   /** Method variant for {@linkcode unwrapOrElse} */
   unwrapOrElse<U>(elseFn: (error: E) => U): T | U {
     return this.repr[0] === 'Ok' ? this.repr[1] : elseFn(this.repr[1]);
-  }
-
-  /**
-    Method variant for {@linkcode Toolbelt.toMaybe toMaybe} from
-    {@linkcode Toolbelt}. Prefer to import and use it directly instead:
-
-    ```ts
-    import { toMaybe } from 'true-myth/toolbelt';
-    ```
-
-    @deprecated until 6.0
-   */
-  toMaybe(this: Result<T, E>): Maybe<T> {
-    return Toolbelt.toMaybe(this);
   }
 
   /** Method variant for {@linkcode toString} */
@@ -953,27 +934,6 @@ export function unwrapOrElse<T, U, E>(
 }
 
 /**
-  Local implementation of {@linkcode Toolbelt.toOkOrErr toOkOrErr} from
-  {@linkcode Toolbelt} for backwards compatibility. Prefer to import it from
-  there instead:
-
-  ```ts
-  import type { toOkOrErr } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function fromMaybe<T, E>(errValue: E, maybe: Maybe<T>): Result<T, E>;
-export function fromMaybe<T, E>(errValue: E): (maybe: Maybe<T>) => Result<T, E>;
-export function fromMaybe<T, E>(
-  errValue: E,
-  maybe?: Maybe<T>
-): Result<T, E> | ((maybe: Maybe<T>) => Result<T, E>) {
-  const op = (m: Maybe<T>) => (m.isJust ? ok<T, E>(m.value) : err<T, E>(errValue));
-  return curry1(op, maybe);
-}
-
-/**
   Create a `String` representation of a {@linkcode Result} instance.
 
   An {@linkcode Ok} instance will be `Ok(<representation of the value>)`, and an
@@ -1297,36 +1257,6 @@ export function ap<A, B, E>(
  */
 export function isInstance<T, E>(item: unknown): item is Result<T, E> {
   return item instanceof ResultImpl;
-}
-
-/**
-  Re-export of {@linkcode Toolbelt.transposeMaybe transposeMaybe} from
-  {@linkcode Toolbelt} for backwards compatibility.Prefer to import it from
-  there instead:
-
-  ```ts
-  import type { transposeMaybe } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>) {
-  return Toolbelt.transposeMaybe(maybe);
-}
-
-/**
-  Re-export of {@linkcode Toolbelt.toMaybe toMaybe} from
-  {@linkcode Toolbelt} for backwards compatibility.Prefer to import it from
-  there instead:
-
-  ```ts
-  import type { toMaybe } from 'true-myth/toolbelt';
-  ```
-
-  @deprecated until 6.0
- */
-export function toMaybe<T, E>(result: Result<T, E>): Maybe<T> {
-  return Toolbelt.toMaybe(result);
 }
 
 // The public interface for the {@linkcode Result} class *as a value*: a constructor and the

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -1,7 +1,6 @@
 import { expectTypeOf } from 'expect-type';
 import Maybe, { Variant, Nothing, Just, Matcher } from 'true-myth/maybe';
 import * as MaybeNS from 'true-myth/maybe';
-import Result, { err, ok } from 'true-myth/result';
 import { Unit } from 'true-myth/unit';
 
 type Neat = { neat: string };
@@ -241,42 +240,6 @@ describe('`Maybe` pure functions', () => {
     expect(undefinedOr42).toEqual(42);
   });
 
-  test('`toOkOrErr`', () => {
-    const theValue = 'string';
-    const theJust = MaybeNS.of(theValue);
-    const errValue = { reason: 'such badness' };
-
-    expect(MaybeNS.toOkOrErr(errValue, theJust)).toEqual(ok(theValue));
-    expect(MaybeNS.toOkOrErr(errValue, MaybeNS.nothing())).toEqual(err(errValue));
-
-    expect(MaybeNS.toOkOrErr<string, typeof errValue>(errValue)(theJust)).toEqual(
-      MaybeNS.toOkOrErr(errValue, theJust)
-    );
-  });
-
-  test('`toOkOrElseErr`', () => {
-    const theJust = MaybeNS.of(12);
-    const errValue = 24;
-    const getErrValue = () => errValue;
-
-    expect(MaybeNS.toOkOrElseErr(getErrValue, theJust)).toEqual(ok(12));
-    expect(MaybeNS.toOkOrElseErr(getErrValue, MaybeNS.nothing())).toEqual(err(errValue));
-
-    expect(MaybeNS.toOkOrElseErr<number, number>(getErrValue)(theJust)).toEqual(
-      MaybeNS.toOkOrElseErr(getErrValue, theJust)
-    );
-  });
-
-  test('`fromResult`', () => {
-    const value = 1000;
-    const anOk = ok(value);
-    expect(MaybeNS.fromResult(anOk)).toEqual(MaybeNS.just(value));
-
-    const reason = 'oh teh noes';
-    const anErr = err(reason);
-    expect(MaybeNS.fromResult(anErr)).toEqual(MaybeNS.nothing());
-  });
-
   describe('`toString`', () => {
     test('with simple values', () => {
       expect(MaybeNS.toString(MaybeNS.of(42))).toEqual('Just(42)');
@@ -390,10 +353,10 @@ describe('`Maybe` pure functions', () => {
       expect((found as Just<Item>).value).toEqual(array[1]);
     });
 
-    test('`head`', () => {
-      expect(MaybeNS.head([])).toEqual(MaybeNS.nothing());
-      expect(MaybeNS.head([1])).toEqual(MaybeNS.just(1));
-      expect(MaybeNS.head([1, 2, 3])).toEqual(MaybeNS.just(1));
+    test('`first`', () => {
+      expect(MaybeNS.first([])).toEqual(MaybeNS.nothing());
+      expect(MaybeNS.first([1])).toEqual(MaybeNS.just(1));
+      expect(MaybeNS.first([1, 2, 3])).toEqual(MaybeNS.just(1));
     });
 
     test('`last`', () => {
@@ -426,42 +389,6 @@ describe('`Maybe` pure functions', () => {
         expectTypeOf(nestedArraysAll).toEqualTypeOf<ExpectedOutputType>();
         expect(nestedArraysAll).toEqual(MaybeNS.just([1, ['two', 'three']]));
       });
-
-      test('`tuple`', () => {
-        type Tuple2 = [Maybe<string>, Maybe<number>];
-        let invalid: Tuple2 = [MaybeNS.just('wat'), MaybeNS.nothing()];
-        const invalidResult = MaybeNS.tuple(invalid);
-        expect(invalidResult).toEqual(MaybeNS.nothing());
-
-        type Tuple3 = [Maybe<string>, Maybe<number>, Maybe<{ neat: string }>];
-        let valid: Tuple3 = [MaybeNS.just('hey'), MaybeNS.just(4), MaybeNS.just({ neat: 'yeah' })];
-        const result = MaybeNS.tuple(valid);
-        expect(result).toEqual(MaybeNS.just(['hey', 4, { neat: 'yeah' }]));
-        expectTypeOf(result).toEqualTypeOf<Maybe<[string, number, { neat: string }]>>();
-      });
-    });
-  });
-
-  describe('deprecated transposeResult re-export', () => {
-    test('Ok(Just(T))', () => {
-      let result = Result.ok<Maybe<number>, string>(Maybe.just(12));
-      let transposed = MaybeNS.transposeResult(result);
-      expect(transposed).toStrictEqual(Maybe.just(Result.ok(12)));
-      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
-    });
-
-    test('Ok(Nothing)', () => {
-      let result = Result.ok<Maybe<number>, string>(Maybe.nothing<number>());
-      let transposed = MaybeNS.transposeResult(result);
-      expect(transposed).toStrictEqual(Maybe.nothing());
-      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
-    });
-
-    test('Err(E)', () => {
-      let result = Result.err<Maybe<number>, string>('hello');
-      let transposed = MaybeNS.transposeResult(result);
-      expect(transposed).toStrictEqual(Maybe.just(Result.err('hello')));
-      expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
     });
   });
 
@@ -704,22 +631,6 @@ describe('`Maybe` class', () => {
       expect(theJust.unwrapOrElse(() => 'other value')).toEqual(value);
     });
 
-    test('`toOkOrErr` method', () => {
-      const value = 'string';
-      const theJust = new Maybe(value);
-      const errValue = { reason: 'such badness' };
-      expect(theJust.toOkOrErr(errValue)).toEqual(ok(value));
-    });
-
-    test('`toOkOrElseErr` method', () => {
-      const value = ['neat'];
-      const theJust = new Maybe(value);
-      const errValue = 24;
-      const getErrValue = () => errValue;
-
-      expect(theJust.toOkOrElseErr(getErrValue)).toEqual(ok(value));
-    });
-
     test('`toString` method', () => {
       expect(MaybeNS.of(42).toString()).toEqual('Just(42)');
     });
@@ -891,20 +802,6 @@ describe('`Maybe` class', () => {
       const theNothing = new Maybe();
       const theDefaultValue = 'it be all fine tho';
       expect(theNothing.unwrapOrElse(() => theDefaultValue)).toEqual(theDefaultValue);
-    });
-
-    test('`toOkOrErr` method', () => {
-      const theNothing = new Maybe();
-      const errValue = { reason: 'such badness' };
-      expect(theNothing.toOkOrErr(errValue)).toEqual(err(errValue));
-    });
-
-    test('`toOkOrElseErr` method', () => {
-      const theNothing = new Maybe();
-      const errValue = 24;
-      const getErrValue = () => errValue;
-
-      expect(theNothing.toOkOrElseErr(getErrValue)).toEqual(err(errValue));
     });
 
     test('`toString` method', () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,5 +1,4 @@
 import { expectTypeOf } from 'expect-type';
-import Maybe, { just, nothing } from 'true-myth/maybe';
 import Result, { Ok, Variant, Err } from 'true-myth/result';
 import * as ResultNS from 'true-myth/result';
 import Unit from 'true-myth/unit';
@@ -287,28 +286,6 @@ describe('`Result` pure functions', () => {
     expect(anErrOrUndefined).toEqual(undefined);
   });
 
-  test('`toMaybe`', () => {
-    const theValue = 'huzzah';
-    const anOk = ResultNS.ok(theValue);
-    expect(ResultNS.toMaybe(anOk)).toEqual(just(theValue));
-
-    const anErr = ResultNS.err('uh uh');
-    expect(ResultNS.toMaybe(anErr)).toEqual(nothing());
-  });
-
-  test('fromMaybe', () => {
-    const theValue = 'something';
-    const errValue = 'what happened?';
-
-    const aJust = just(theValue);
-    const anOk = ResultNS.ok(theValue);
-    expect(ResultNS.fromMaybe(errValue, aJust)).toEqual(anOk);
-
-    const aNothing = nothing();
-    const anErr = ResultNS.err(errValue);
-    expect(ResultNS.fromMaybe(errValue, aNothing)).toEqual(anErr);
-  });
-
   test('toString', () => {
     const theValue = { thisIsReally: 'something' };
     const errValue = ['oh', 'no'];
@@ -386,29 +363,6 @@ describe('`Result` pure functions', () => {
 
     const obj: unknown = { random: 'nonsense' };
     expect(ResultNS.isInstance(obj)).toBe(false);
-  });
-
-  describe('deprecated transposeMaybe re-export', () => {
-    test('Just(Ok(T))', () => {
-      let maybe = Maybe.just(Result.ok<number, string>(12));
-      let transposed = ResultNS.transposeMaybe(maybe);
-      expect(transposed).toStrictEqual(Result.ok(Maybe.just(12)));
-      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
-    });
-
-    test('Just(Err(E))', () => {
-      let maybe = Maybe.just(Result.err<number, string>('whoops'));
-      let transposed = ResultNS.transposeMaybe(maybe);
-      expect(transposed).toStrictEqual(Result.err('whoops'));
-      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
-    });
-
-    test('Nothing', () => {
-      let maybe = Maybe.nothing<Result<number, string>>();
-      let transposed = ResultNS.transposeMaybe(maybe);
-      expect(transposed).toStrictEqual(Result.ok(Maybe.nothing()));
-      expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
-    });
   });
 });
 
@@ -588,12 +542,6 @@ describe('`Ok` instance', () => {
     expect(theOk.unwrapOrElse(getDefault)).toBe(theValue);
   });
 
-  test('`toMaybe` method', () => {
-    const theValue = { something: 'fun' };
-    const theOk = Result.ok(theValue);
-    expect(theOk.toMaybe()).toEqual(just(theValue));
-  });
-
   test('`toString` method', () => {
     const theValue = 42;
     const theOk = Result.ok(theValue);
@@ -751,11 +699,6 @@ describe('`ResultNS.Err` class', () => {
     const theReason = 'alas';
     const theErr = Result.err<number, string>(theReason);
     expect(theErr.unwrapOrElse(length)).toEqual(length(theReason));
-  });
-
-  test('`toMaybe` method', () => {
-    const theErr = Result.err('so sad');
-    expect(theErr.toMaybe()).toEqual(nothing());
   });
 
   test('`toString` method', () => {

--- a/test/toolbelt.test.ts
+++ b/test/toolbelt.test.ts
@@ -8,6 +8,7 @@ import {
   toOkOrErr,
   fromResult,
   fromMaybe,
+  toMaybe,
 } from 'true-myth/toolbelt';
 
 describe('transposeResult', () => {
@@ -31,6 +32,15 @@ describe('transposeResult', () => {
     expect(transposed).toStrictEqual(Maybe.just(Result.err('hello')));
     expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
   });
+});
+
+test('`toMaybe`', () => {
+  const theValue = 'huzzah';
+  const anOk = Result.ok(theValue);
+  expect(toMaybe(anOk)).toEqual(Maybe.just(theValue));
+
+  const anErr = Result.err('uh uh');
+  expect(toMaybe(anErr)).toEqual(Maybe.nothing());
 });
 
 test('fromMaybe', () => {


### PR DESCRIPTION
This breaking change enables better tree-shaking by fully decoupling the `true-myth/maybe` and `true-myth/result` modules from each other, pushing the interop between the two types into the `true-myth/toolbelt` module. Apps and libraries which use only one of the modules and do *not* use the toolbelt module will be able to trivially tree-shake out the other module.