### PR TITLE
Fix regression of `Result.ok()`

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -74,12 +74,14 @@ class ResultImpl<T, E> {
 
     @throws If you pass `null`.
    */
-  static ok<T, E>(value?: T | null): Result<T, E> {
-    if (isVoid(value)) {
-      throw new Error('Tried to construct `Ok` with `null`. Maybe you want `Maybe.Nothing`?');
-    }
-
-    return new ResultImpl<T, E>(['Ok', value]) as Result<T, E>;
+  static ok<T, E>(): Result<Unit, E>;
+  static ok<T, E>(value: null): Result<Unit, E>;
+  static ok<T, E>(value: undefined): Result<Unit, E>;
+  static ok<T, E>(value: T): Result<T, E>;
+  static ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
+    return isVoid(value)
+      ? (new ResultImpl<Unit, E>(['Ok', Unit]) as Result<Unit, E>)
+      : (new ResultImpl<T, E>(['Ok', value]) as Result<T, E>);
   }
 
   /**
@@ -105,14 +107,14 @@ class ResultImpl<T, E> {
 
     @throws If you pass `null` or `undefined`.
    */
-  static err<T, E>(error: E | null): Result<T, E> {
-    if (isVoid(error)) {
-      throw new Error(
-        'Tried to construct `Err` with `null` or `undefined`. Maybe you want `Maybe.Nothing`?'
-      );
-    }
-
-    return new ResultImpl<T, E>(['Err', error]) as Result<T, E>;
+  static err<T, E>(): Result<T, Unit>;
+  static err<T, E>(error: null): Result<T, Unit>;
+  static err<T, E>(error: undefined): Result<T, Unit>;
+  static err<T, E>(error: E): Result<T, E>;
+  static err<T, E>(error?: E): Result<T, Unit> | Result<T, E> {
+    return isVoid(error)
+      ? (new ResultImpl<T, Unit>(['Err', Unit]) as Result<T, Unit>)
+      : (new ResultImpl<T, E>(['Err', error]) as Result<T, E>);
   }
 
   /** Distinguish between the {@linkcode Variant.Ok} and {@linkcode Variant.Err} {@linkcode Variant variants}. */
@@ -368,11 +370,7 @@ export function tryOr<T, E>(
   @typeparam T The type of the item contained in the `Result`.
   @param value The value to wrap in a `Result.Ok`.
  */
-export function ok<T, E>(): Result<Unit, E>;
-export function ok<T, E>(value: T): Result<T, E>;
-export function ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
-  return value === undefined ? Result.ok(Unit) : Result.ok(value);
-}
+export const ok = ResultImpl.ok;
 
 /**
   Create an instance of {@linkcode Err}.
@@ -420,11 +418,7 @@ export function ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
   @typeparam T The type of the item contained in the `Result`.
   @param E The error value to wrap in a `Result.Err`.
  */
-export function err<T, E>(): Result<T, Unit>;
-export function err<T, E>(error: E): Result<T, E>;
-export function err<T, E>(error?: E): Result<T, Unit> | Result<T, E> {
-  return isVoid(error) ? Result.err(Unit) : Result.err(error);
-}
+export const err = ResultImpl.err;
 
 /**
   Execute the provided callback, wrapping the return value in {@linkcode Ok}.

--- a/src/toolbelt.ts
+++ b/src/toolbelt.ts
@@ -72,6 +72,14 @@ export function fromMaybe<T, E>(
   @param maybe a `Maybe<Result<T, E>>` to transform to a `Result<Maybe<T>, E>>`.
  */
 export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T>, E> {
+  // SAFETY: TS is unable to unify this expression throughout without explicitly
+  // casting at the end: it thinks that the `T` and `E` values here may be
+  // nullable and so may end up with `Unit` instead of one or the other. Alas,
+  // there is no way around this: `extends NonNullable<_>` doesn't actually do
+  // anything here. However, we can see that this will actually always hold,
+  // because it's impossible to get here without having *already* filled in the
+  // fully-resolved type for `T` or `E`: if it's `Unit`, it is `Unit` by the
+  // time this function is called.
   return maybe.match({
     Just: (result) =>
       result.match({
@@ -79,7 +87,7 @@ export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T
         Err: (e) => Result.err(e),
       }),
     Nothing: () => Result.ok(Maybe.nothing()),
-  });
+  }) as Result<Maybe<T>, E>;
 }
 
 /**

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -25,6 +25,10 @@ describe('`Result` pure functions', () => {
     const withUnit = ResultNS.ok();
     expectTypeOf(withUnit).toEqualTypeOf<Result<Unit, unknown>>();
     expect(withUnit).toEqual(ResultNS.ok(Unit));
+
+    const withUnitFromImport = Result.ok();
+    expectTypeOf(withUnit).toEqualTypeOf<Result<Unit, unknown>>();
+    expect(withUnitFromImport).toEqual(Result.ok(Unit));
   });
 
   test('`err`', () => {
@@ -451,8 +455,8 @@ describe('`Ok` instance', () => {
     const unqualifiedOk = Result.ok('string');
     expectTypeOf(unqualifiedOk).toMatchTypeOf<Result<string, unknown>>();
 
-    expect(() => Result.ok(null)).toThrow();
-    expect(() => Result.ok(undefined)).toThrow();
+    expect(() => Result.ok(null)).not.toThrow();
+    expect(() => Result.ok(undefined)).not.toThrow();
   });
 
   test('`value` property', () => {
@@ -624,8 +628,8 @@ describe('`ResultNS.Err` class', () => {
     const unqualifiedErr = Result.err('string');
     expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<unknown, string>>();
 
-    expect(() => Result.err(null)).toThrow();
-    expect(() => Result.err(undefined)).toThrow();
+    expect(() => Result.err(null)).not.toThrow();
+    expect(() => Result.err(undefined)).not.toThrow();
   });
 
   test('`error` property', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^27.2.5", "@jest/types@^27.4.2":
+"@jest/types@^27.4.2":
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
   integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
@@ -1540,7 +1540,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^27.0.6, diff-sequences@^27.4.0:
+diff-sequences@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
   integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
@@ -2522,7 +2522,7 @@ jest-environment-node@^27.4.4:
     jest-mock "^27.4.2"
     jest-util "^27.4.2"
 
-jest-get-type@^27.3.1, jest-get-type@^27.4.0:
+jest-get-type@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
   integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
@@ -3723,7 +3723,7 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
-pretty-format@^27.0.0, pretty-format@^27.3.1, pretty-format@^27.4.2:
+pretty-format@^27.0.0, pretty-format@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.2.tgz#e4ce92ad66c3888423d332b40477c87d1dac1fb8"
   integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==


### PR DESCRIPTION
In the work done to collapse the separate classes together for 5.0, I accidentally kept the *wrong* side of an inconsistency from all versions prior to v5. Historically we had a bit of a weird misalignment around the constructors: you could call `Result.ok()`, which was actually a sneakily-exported standalone function which constructed an `Ok` class instance, or you could call `new Ok()`. If you called `Result.ok()`, you got back `Result<Unit, unknown>`. If you called `new Ok()`, you got the error you hit here. When I folded the `Ok` and `Err` classes into a single `Result` class, I accidentally brought along the error instead of the convenience function behavior!

While making the fix here, introduce additional explicitness so that the runtime behavior and the type behavior match: calling the `ok` or `err` static constructors with `null` or `undefined` produces a `Result` with a `Unit` value in that position instead of ending up with `Result<null, E>`. (This requires a single unsafe cast, in the case of the `toolbelt` function `transposeMaybe`.)

Resolves #261