### PR TITLE
Fix v5 regression of checks on `.value`

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -112,7 +112,7 @@ class MaybeImpl<T> {
       throw new Error(`attempted to call "just" with ${value}`);
     }
 
-    return new Maybe<T>(value);
+    return new MaybeImpl<T>(value) as Maybe<T>;
   }
 
   /**
@@ -129,8 +129,8 @@ class MaybeImpl<T> {
     @typeparam T The type of the item contained in the `Maybe`.
     @returns     An instance of `Maybe.Nothing<T>`.
    */
-  static nothing<T>(_?: null): Maybe<T> {
-    return new MaybeImpl() as Maybe<T>;
+  static nothing<T>(_?: null): Nothing<T> {
+    return new MaybeImpl() as Nothing<T>;
   }
 
   /** Distinguish between the `Just` and `Nothing` {@link Variant variants}. */
@@ -143,7 +143,7 @@ class MaybeImpl<T> {
 
     @warning throws if you access this from a {@linkcode Just}
    */
-  get value(): T | never {
+  get value(): T {
     if (this.repr[0] === Variant.Nothing) {
       throw new Error('Cannot get the value of `Nothing`');
     }
@@ -328,11 +328,10 @@ export interface Just<T> extends MaybeImpl<T> {
   @typeparam T The type which would be wrapped in a {@linkcode Just} variant of
     the {@linkcode Maybe}.
  */
-export interface Nothing<T> extends MaybeImpl<T> {
+export interface Nothing<T> extends Pick<MaybeImpl<T>, Exclude<keyof MaybeImpl<T>, 'value'>> {
   /** `Nothing` is always {@linkcode Variant.Nothing}. */
   readonly variant: 'Nothing';
-  /** @internal */
-  value: never;
+
   isJust: false;
   isNothing: true;
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -69,8 +69,6 @@ class ResultImpl<T, E> {
     @param value The value to wrap in an `Ok`.
    */
   static ok<T, E>(): Result<Unit, E>;
-  static ok<T, E>(value: null): Result<Unit, E>;
-  static ok<T, E>(value: undefined): Result<Unit, E>;
   static ok<T, E>(value: T): Result<T, E>;
   static ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
     return isVoid(value)
@@ -96,8 +94,6 @@ class ResultImpl<T, E> {
     @param error The value to wrap in an `Err`.
    */
   static err<T, E>(): Result<T, Unit>;
-  static err<T, E>(error: null): Result<T, Unit>;
-  static err<T, E>(error: undefined): Result<T, Unit>;
   static err<T, E>(error: E): Result<T, E>;
   static err<T, E>(error?: E): Result<T, Unit> | Result<T, E> {
     return isVoid(error)

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -17,7 +17,7 @@ describe('`Maybe` pure functions', () => {
         expect(theJust.value).toBe('string');
         break;
       case MaybeNS.Variant.Nothing:
-        expect(false).toBe(true); // because this should never happen
+        expect(true).toBe(false); // Not possible
         break;
       default:
         expect(false).toBe(true); // because those are the only cases
@@ -31,6 +31,8 @@ describe('`Maybe` pure functions', () => {
     const theNothing = MaybeNS.nothing();
     expect(theNothing).toBeInstanceOf(Maybe);
     switch (theNothing.variant) {
+      // @ts-expect-error -- this cannot happen! Should fail to type-check if it
+      // *does* happen.
       case MaybeNS.Variant.Just:
         expect(true).toBe(false); // because this should never happen
         break;
@@ -42,7 +44,7 @@ describe('`Maybe` pure functions', () => {
     }
 
     const nothingOnType = MaybeNS.nothing<string>();
-    expectTypeOf(nothingOnType).toEqualTypeOf<Maybe<string>>();
+    expectTypeOf(nothingOnType).toMatchTypeOf<Maybe<string>>();
   });
 
   describe('`of`', () => {
@@ -51,6 +53,7 @@ describe('`Maybe` pure functions', () => {
       expectTypeOf(nothingFromNull).toEqualTypeOf<Maybe<string>>();
       expect(nothingFromNull.isJust).toBe(false);
       expect(nothingFromNull.isNothing).toBe(true);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => nothingFromNull.value).toThrow();
     });
 
@@ -59,6 +62,7 @@ describe('`Maybe` pure functions', () => {
       expectTypeOf(nothingFromUndefined).toEqualTypeOf<Maybe<number>>();
       expect(nothingFromUndefined.isJust).toBe(false);
       expect(nothingFromUndefined.isNothing).toBe(true);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => nothingFromUndefined.value).toThrow();
     });
 
@@ -84,7 +88,7 @@ describe('`Maybe` pure functions', () => {
 
     const none = MaybeNS.nothing<string>();
     const noLength = MaybeNS.map(length, none);
-    expectTypeOf(none).toEqualTypeOf<Maybe<string>>();
+    expectTypeOf(none).toMatchTypeOf<Maybe<string>>();
     expect(noLength).toEqual(MaybeNS.nothing());
   });
 
@@ -199,6 +203,7 @@ describe('`Maybe` pure functions', () => {
 
   test('`unwrap`', () => {
     expect((MaybeNS.of('42') as Just<string>).value).toBe('42');
+    // @ts-expect-error -- `value` isn't accessible without narrowing
     expect(() => MaybeNS.nothing().value).toThrow();
   });
 
@@ -541,7 +546,9 @@ describe('`Maybe` class', () => {
     expectTypeOf(maybe).toHaveProperty('isJust');
     expectTypeOf(maybe).toHaveProperty('isJust');
     expectTypeOf(maybe).toHaveProperty('isNothing');
-    expectTypeOf(maybe).toHaveProperty('value');
+    if (maybe.isJust) {
+      expectTypeOf(maybe).toHaveProperty('value');
+    }
     expectTypeOf(Maybe).constructorParameters.toEqualTypeOf<[value?: unknown] | []>();
   });
 
@@ -549,13 +556,13 @@ describe('`Maybe` class', () => {
     test('constructor', () => {
       const theJust = new Maybe('cool');
       expect(theJust.variant).toEqual(Variant.Just);
-      expect(theJust.value).toEqual('cool');
+      expect((theJust as Just<string>).value).toEqual('cool');
     });
 
     test('static constructor', () => {
       const theJust = Maybe.just(123);
       expect(theJust.variant).toEqual(Variant.Just);
-      expect(theJust.value).toEqual(123);
+      expect((theJust as Just<number>).value).toEqual(123);
 
       expect(() => Maybe.just(null)).toThrow();
       expect(() => Maybe.just(undefined)).toThrow();
@@ -769,14 +776,17 @@ describe('`Maybe` class', () => {
     test('static constructor', () => {
       const theNothing = Maybe.nothing();
       expect(theNothing.variant).toEqual(Variant.Nothing);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => theNothing.value).toThrow();
 
       const fromNull = Maybe.nothing(null);
       expect(fromNull.variant).toEqual(Variant.Nothing);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => fromNull.value).toThrow();
 
       const nothingFromUndefined = Maybe.nothing(undefined);
       expect(nothingFromUndefined.variant).toEqual(Variant.Nothing);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => nothingFromUndefined.value).toThrow();
     });
 
@@ -787,6 +797,7 @@ describe('`Maybe` class', () => {
 
     test('`value` property', () => {
       const theNothing = new Maybe();
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => theNothing.value).toThrow();
     });
 
@@ -860,8 +871,9 @@ describe('`Maybe` class', () => {
       expect(theNothing.andThen(getDefaultValue)).toEqual(theNothing);
     });
 
-    test('`unsafelyUnwrap` method', () => {
+    test('`value` access', () => {
       const noStuffAtAll = new Maybe();
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => noStuffAtAll.value).toThrow();
     });
 


### PR DESCRIPTION
Note: I'm not *positive* this won't accidentally cause red squiggles for folks who’ve upgraded to v5 already, because I had to loosen a couple of the type checks here. However, I take those to be in the "bug fix" bucket: they *should* have been causing red squiggles in the first place!

- Fixes #271.
- Requires #273 (because otherwise the inference gets confused).