### PR TITLE
Revert handling of explicit `null` and `undefined`

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -69,8 +69,6 @@ class ResultImpl<T, E> {
     @param value The value to wrap in an `Ok`.
    */
   static ok<T, E>(): Result<Unit, E>;
-  static ok<T, E>(value: null): Result<Unit, E>;
-  static ok<T, E>(value: undefined): Result<Unit, E>;
   static ok<T, E>(value: T): Result<T, E>;
   static ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
     return isVoid(value)
@@ -96,8 +94,6 @@ class ResultImpl<T, E> {
     @param error The value to wrap in an `Err`.
    */
   static err<T, E>(): Result<T, Unit>;
-  static err<T, E>(error: null): Result<T, Unit>;
-  static err<T, E>(error: undefined): Result<T, Unit>;
   static err<T, E>(error: E): Result<T, E>;
   static err<T, E>(error?: E): Result<T, Unit> | Result<T, E> {
     return isVoid(error)


### PR DESCRIPTION
While the new behavior is preferable, because it means you never end up with `Result<null, E>` or `Result<undefined, E>` etc., it does not actually work correctly with inference: the type parameter resolution consistently ends up bailing and ending up as `Maybe<unknown>` when it should be resolving to `Maybe<T>` within a `Result<Maybe<_>, E>` (or vice versa in the `Err` case).

While it is probably worth thinking about how to tackle this again in v6, it may just be a persistent limitation of the overload-based type resolution that this requires.

Fixes #26