### PR TITLE
One fewer assignment in Nothing construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     ],
     "moduleNameMapper": {
       "^true-myth/(.*)$": "<rootDir>/src/$1",
+      "^true-myth$": "<rootDir>/src/index.ts",
       "^(\\.{1,2}/.*)\\.js$": "$1"
     },
     "moduleDirectories": [

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -88,7 +88,7 @@ class MaybeImpl<T> {
                 the value passed.
   */
   static of<T>(value: T | null | undefined): Maybe<T> {
-    return new MaybeImpl(value) as Maybe<T>;
+    return new Maybe(value);
   }
 
   /**
@@ -108,7 +108,7 @@ class MaybeImpl<T> {
       throw new Error(`attempted to call "just" with ${value}`);
     }
 
-    return new Maybe<T>(value);
+    return new Maybe(value);
   }
 
   /**
@@ -125,8 +125,8 @@ class MaybeImpl<T> {
     @typeparam T The type of the item contained in the `Maybe`.
     @returns     An instance of `Maybe.Nothing<T>`.
    */
-  static nothing<T>(_?: null): Maybe<T> {
-    return new MaybeImpl() as Maybe<T>;
+  static nothing<T>(_?: null): Nothing<T> {
+    return new MaybeImpl() as Nothing<T>;
   }
 
   /** Distinguish between the `Just` and `Nothing` {@link Variant variants}. */
@@ -139,7 +139,7 @@ class MaybeImpl<T> {
 
     @warning throws if you access this from a {@linkcode Just}
    */
-  get value(): T | never {
+  get value(): T {
     if (this.repr[0] === Variant.Nothing) {
       throw new Error('Cannot get the value of `Nothing`');
     }
@@ -227,7 +227,10 @@ class MaybeImpl<T> {
 
   /** Method variant for {@linkcode equals} */
   equals(comparison: Maybe<T>): boolean {
-    return this.repr[0] === comparison.repr[0] && this.repr[1] === comparison.repr[1];
+    return (
+      this.repr[0] === (comparison as MaybeImpl<T>).repr[0] &&
+      this.repr[1] === (comparison as MaybeImpl<T>).repr[1]
+    );
   }
 
   /** Method variant for {@linkcode ap} */
@@ -304,11 +307,10 @@ export interface Just<T> extends MaybeImpl<T> {
   @typeparam T The type which would be wrapped in a {@linkcode Just} variant of
     the {@linkcode Maybe}.
  */
-export interface Nothing<T> extends MaybeImpl<T> {
+export interface Nothing<T> extends Pick<MaybeImpl<T>, Exclude<keyof MaybeImpl<T>, 'value'>> {
   /** `Nothing` is always {@linkcode Variant.Nothing}. */
   readonly variant: 'Nothing';
-  /** @internal */
-  value: never;
+
   isJust: false;
   isNothing: true;
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -47,19 +47,22 @@ let NOTHING: Nothing<any>;
 
 // Defines the *implementation*, but not the *types*. See the exports below.
 class MaybeImpl<T> {
-  private repr: Repr<T>;
+  // SAFETY: this is definitely assigned in the constructor for every *actual*
+  // instance, but TS cannot see that: it is only set for `Nothing` instances
+  // when `NOTHING` does not already exist.
+  private repr!: Repr<T>;
 
   constructor(value?: T | null | undefined) {
     if (isVoid(value)) {
       // SAFETY: there is only a single `Nothing` in the system, because the
       // only difference between `Nothing<string>` and `Nothing<number>` is at
       // the type-checking level.
-      this.repr = [Variant.Nothing];
       if (!NOTHING) {
-        NOTHING = this as Maybe<any> as Nothing<any>;
+        this.repr = [Variant.Nothing];
+        NOTHING = this as Nothing<any>;
       }
 
-      return NOTHING as Maybe<any> as this;
+      return NOTHING as MaybeImpl<T>;
     } else {
       this.repr = [Variant.Just, value];
     }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -208,12 +208,12 @@ class MaybeImpl<T> {
   }
 
   /** Method variant for {@linkcode toString} */
-  toString(this: Maybe<T>): string {
+  toString(): string {
     return this.repr[0] === 'Just' ? `Just(${this.repr[1]})` : 'Nothing';
   }
 
   /** Method variant for {@linkcode toJSON} */
-  toJSON(this: Maybe<T>): MaybeJSON<unknown> {
+  toJSON(): MaybeJSON<unknown> {
     const variant = this.repr[0];
 
     if (variant === 'Just') {

--- a/src/result.ts
+++ b/src/result.ts
@@ -64,8 +64,6 @@ class ResultImpl<T, E> {
     @param value The value to wrap in an `Ok`.
    */
   static ok<T, E>(): Result<Unit, E>;
-  static ok<T, E>(value: null): Result<Unit, E>;
-  static ok<T, E>(value: undefined): Result<Unit, E>;
   static ok<T, E>(value: T): Result<T, E>;
   static ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
     return isVoid(value)
@@ -91,8 +89,6 @@ class ResultImpl<T, E> {
     @param error The value to wrap in an `Err`.
    */
   static err<T, E>(): Result<T, Unit>;
-  static err<T, E>(error: null): Result<T, Unit>;
-  static err<T, E>(error: undefined): Result<T, Unit>;
   static err<T, E>(error: E): Result<T, E>;
   static err<T, E>(error?: E): Result<T, Unit> | Result<T, E> {
     return isVoid(error)

--- a/test/interop.test.ts
+++ b/test/interop.test.ts
@@ -1,0 +1,10 @@
+import { Maybe, Result } from 'true-myth';
+
+describe('nested Result and Maybe', () => {
+  test('Result of Maybe', () => {
+    function inferenceFun(): Result<Maybe<string>, number> {
+      return Result.ok(Maybe.nothing());
+    }
+    expect(inferenceFun()).toBeInstanceOf(Result);
+  });
+});

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -16,7 +16,7 @@ describe('`Maybe` pure functions', () => {
         expect(theJust.value).toBe('string');
         break;
       case MaybeNS.Variant.Nothing:
-        expect(false).toBe(true); // because this should never happen
+        expect(true).toBe(false); // Not possible
         break;
       default:
         expect(false).toBe(true); // because those are the only cases
@@ -30,6 +30,8 @@ describe('`Maybe` pure functions', () => {
     const theNothing = MaybeNS.nothing();
     expect(theNothing).toBeInstanceOf(Maybe);
     switch (theNothing.variant) {
+      // @ts-expect-error -- this cannot happen! Should fail to type-check if it
+      // *does* happen.
       case MaybeNS.Variant.Just:
         expect(true).toBe(false); // because this should never happen
         break;
@@ -41,7 +43,7 @@ describe('`Maybe` pure functions', () => {
     }
 
     const nothingOnType = MaybeNS.nothing<string>();
-    expectTypeOf(nothingOnType).toEqualTypeOf<Maybe<string>>();
+    expectTypeOf(nothingOnType).toMatchTypeOf<Maybe<string>>();
   });
 
   describe('`of`', () => {
@@ -50,6 +52,7 @@ describe('`Maybe` pure functions', () => {
       expectTypeOf(nothingFromNull).toEqualTypeOf<Maybe<string>>();
       expect(nothingFromNull.isJust).toBe(false);
       expect(nothingFromNull.isNothing).toBe(true);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => nothingFromNull.value).toThrow();
     });
 
@@ -58,6 +61,7 @@ describe('`Maybe` pure functions', () => {
       expectTypeOf(nothingFromUndefined).toEqualTypeOf<Maybe<number>>();
       expect(nothingFromUndefined.isJust).toBe(false);
       expect(nothingFromUndefined.isNothing).toBe(true);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => nothingFromUndefined.value).toThrow();
     });
 
@@ -83,7 +87,7 @@ describe('`Maybe` pure functions', () => {
 
     const none = MaybeNS.nothing<string>();
     const noLength = MaybeNS.map(length, none);
-    expectTypeOf(none).toEqualTypeOf<Maybe<string>>();
+    expectTypeOf(none).toMatchTypeOf<Maybe<string>>();
     expect(noLength).toEqual(MaybeNS.nothing());
   });
 
@@ -198,6 +202,7 @@ describe('`Maybe` pure functions', () => {
 
   test('`unwrap`', () => {
     expect((MaybeNS.of('42') as Just<string>).value).toBe('42');
+    // @ts-expect-error -- `value` isn't accessible without narrowing
     expect(() => MaybeNS.nothing().value).toThrow();
   });
 
@@ -484,7 +489,9 @@ describe('`Maybe` class', () => {
     expectTypeOf(maybe).toHaveProperty('isJust');
     expectTypeOf(maybe).toHaveProperty('isJust');
     expectTypeOf(maybe).toHaveProperty('isNothing');
-    expectTypeOf(maybe).toHaveProperty('value');
+    if (maybe.isJust) {
+      expectTypeOf(maybe).toHaveProperty('value');
+    }
     expectTypeOf(Maybe).constructorParameters.toEqualTypeOf<[value?: unknown] | []>();
   });
 
@@ -492,13 +499,13 @@ describe('`Maybe` class', () => {
     test('constructor', () => {
       const theJust = new Maybe('cool');
       expect(theJust.variant).toEqual(Variant.Just);
-      expect(theJust.value).toEqual('cool');
+      expect((theJust as Just<string>).value).toEqual('cool');
     });
 
     test('static constructor', () => {
       const theJust = Maybe.just(123);
       expect(theJust.variant).toEqual(Variant.Just);
-      expect(theJust.value).toEqual(123);
+      expect((theJust as Just<number>).value).toEqual(123);
 
       expect(() => Maybe.just(null)).toThrow();
       expect(() => Maybe.just(undefined)).toThrow();
@@ -696,14 +703,17 @@ describe('`Maybe` class', () => {
     test('static constructor', () => {
       const theNothing = Maybe.nothing();
       expect(theNothing.variant).toEqual(Variant.Nothing);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => theNothing.value).toThrow();
 
       const fromNull = Maybe.nothing(null);
       expect(fromNull.variant).toEqual(Variant.Nothing);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => fromNull.value).toThrow();
 
       const nothingFromUndefined = Maybe.nothing(undefined);
       expect(nothingFromUndefined.variant).toEqual(Variant.Nothing);
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => nothingFromUndefined.value).toThrow();
     });
 
@@ -714,6 +724,7 @@ describe('`Maybe` class', () => {
 
     test('`value` property', () => {
       const theNothing = new Maybe();
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => theNothing.value).toThrow();
     });
 
@@ -787,8 +798,9 @@ describe('`Maybe` class', () => {
       expect(theNothing.andThen(getDefaultValue)).toEqual(theNothing);
     });
 
-    test('`unsafelyUnwrap` method', () => {
+    test('`value` access', () => {
       const noStuffAtAll = new Maybe();
+      // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => noStuffAtAll.value).toThrow();
     });
 


### PR DESCRIPTION
A very minor performance enhancement: introduce a use of the definite assignment operator (and corresponding `// SAFETY: ...` comment) to allow us to skip initializing `repr` for a class we are going to stop constructing immediately in the case of a `NOTHING` construction.

Builds on #274.