### PR TITLE
Finish forward-porting null/undefined reversion

### DIFF
--- a/src/toolbelt.ts
+++ b/src/toolbelt.ts
@@ -87,7 +87,7 @@ export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T
         Err: (e) => Result.err(e),
       }),
     Nothing: () => Result.ok(Maybe.nothing()),
-  }) as Result<Maybe<T>, E>;
+  });
 }
 
 /**


### PR DESCRIPTION
This was supposed to be included a749c58, but was missed on accident.