### PR TITLE
feat(maybe/find): type narrowing via predicates

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1111,6 +1111,12 @@ export function isInstance<T>(item: unknown): item is Maybe<T> {
 
 export type Predicate<T> = (element: T, index: number, array: T[]) => boolean;
 
+export type NarrowingPredicate<T, S extends T> = (
+  element: T,
+  index: number,
+  array: T[]
+) => element is S;
+
 // NOTE: documentation is lightly adapted from the MDN and TypeScript docs for
 // `Array.prototype.find`.
 /**
@@ -1167,10 +1173,12 @@ export type Predicate<T> = (element: T, index: number, array: T[]) => boolean;
                     returns `Nothing`.
  * @param array     The array to search using the predicate.
  */
+export function find<T, S extends T>(predicate: NarrowingPredicate<T, S>, array: T[]): Maybe<S>;
+export function find<T, S extends T>(predicate: NarrowingPredicate<T, S>): (array: T[]) => Maybe<S>;
 export function find<T>(predicate: Predicate<T>, array: T[]): Maybe<T>;
 export function find<T>(predicate: Predicate<T>): (array: T[]) => Maybe<T>;
-export function find<T>(
-  predicate: Predicate<T>,
+export function find<T, S extends T>(
+  predicate: NarrowingPredicate<T, S> | Predicate<T>,
   array?: T[]
 ): Maybe<T> | ((array: T[]) => Maybe<T>) {
   const op = (a: T[]) => Maybe.of(a.find(predicate));

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1111,11 +1111,11 @@ export function isInstance<T>(item: unknown): item is Maybe<T> {
 
 export type Predicate<T> = (element: T, index: number, array: T[]) => boolean;
 
-export type NarrowingPredicate<T, S extends T> = (
+export type NarrowingPredicate<T, U extends T> = (
   element: T,
   index: number,
   array: T[]
-) => element is S;
+) => element is U;
 
 // NOTE: documentation is lightly adapted from the MDN and TypeScript docs for
 // `Array.prototype.find`.
@@ -1173,12 +1173,12 @@ export type NarrowingPredicate<T, S extends T> = (
                     returns `Nothing`.
  * @param array     The array to search using the predicate.
  */
-export function find<T, S extends T>(predicate: NarrowingPredicate<T, S>, array: T[]): Maybe<S>;
-export function find<T, S extends T>(predicate: NarrowingPredicate<T, S>): (array: T[]) => Maybe<S>;
+export function find<T, U extends T>(predicate: NarrowingPredicate<T, U>, array: T[]): Maybe<U>;
+export function find<T, U extends T>(predicate: NarrowingPredicate<T, U>): (array: T[]) => Maybe<U>;
 export function find<T>(predicate: Predicate<T>, array: T[]): Maybe<T>;
 export function find<T>(predicate: Predicate<T>): (array: T[]) => Maybe<T>;
-export function find<T, S extends T>(
-  predicate: NarrowingPredicate<T, S> | Predicate<T>,
+export function find<T, U extends T>(
+  predicate: NarrowingPredicate<T, U> | Predicate<T>,
   array?: T[]
 ): Maybe<T> | ((array: T[]) => Maybe<T>) {
   const op = (a: T[]) => Maybe.of(a.find(predicate));

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -377,6 +377,15 @@ describe('`Maybe` pure functions', () => {
       const found = findAtLeast5(array);
       expect(found.variant).toBe(MaybeNS.Variant.Just);
       expect((found as Just<Item>).value).toEqual(array[1]);
+
+      // Type narrowing via predicates.
+      // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
+      const findByName = <T extends string>(name: T) =>
+        MaybeNS.find((item: Item): item is Item & { name: T } => item.name === name);
+      const waffles = findByName('waffles')(array);
+      expect(waffles.variant).toBe(MaybeNS.Variant.Just);
+      expect((waffles as Just<Item>).value).toEqual(array[1]);
+      expectTypeOf(waffles).toMatchTypeOf<Maybe<{ name: 'waffles' }>>();
     });
 
     test('`head`', () => {


### PR DESCRIPTION
Adds support for type narrowing via [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to [`find`](https://true-myth.js.org/modules/maybe.html#find).

```ts
interface User {
  name: string;
  role: string;
}

interface Admin extends User {
  role: 'admin';
}

const isAdmin = (user: User): user is Admin => user.role === 'admin';

const users = [
  { name: 'Jan',   role: 'contributor' },
  { name: 'Chris', role: 'admin'       },
];

const admin = find(isAdmin, users);
// => Maybe<Admin>

const oldApproach = find(user => user.role === 'admin', users);
// => Maybe<User>
```