### PR TITLE
Fix ember build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 
 
-
+## Unreleased
+* [#312](https://github.com/true-myth/true-myth/pull/312) ember-addon keyword in package.json break ember builds ([@ombr])
 
 ## 5.1.2 (2021-12-27)
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "types": "index.d.ts",
   "keywords": [
-    "ember-addon",
     "typescript",
     "functional programming",
     "maybe",


### PR DESCRIPTION
With a brand new install, I am getting the following error:

```
ember_1              | yarn run v1.22.15
ember_1              | $ ember serve
ember_1              | Must use import to load ES Module: /app/node_modules/true-myth/dist/index.js
ember_1              | require() of ES modules is not supported.
ember_1              | require() of /app/node_modules/true-myth/dist/index.js from /app/node_modules/ember-cli/lib/models/package-info-cache/package-info.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
ember_1              | Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /app/node_modules/true-myth/package.json.
ember_1              | 
ember_1              | 
ember_1              | 
ember_1              | Stack Trace and Error Report: /tmp/error.dump.260e28d5f9d7bdee673f9a8fbcb392d8.log
ember_1              | error Command failed with exit code 1.
ember_1              | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
scpix_ember_1 exited with code 1
```

Removing the ember-addon keyword fixed it.