### PR TITLE
Export pure isJust() function

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -351,6 +351,17 @@ export interface Nothing<T> extends Pick<MaybeImpl<T>, Exclude<keyof MaybeImpl<T
 export const just = MaybeImpl.just;
 
 /**
+  Is the {@linkcode Maybe} a {@linkcode Just}?
+ 
+  @typeparam T The type of the item contained in the `Maybe`.
+  @param maybe The `Maybe` to check.
+  @returns A type guarded `Just`.
+ */
+export function isJust<T>(maybe: Maybe<T>): maybe is Just<T> {
+  return maybe.isJust;
+}
+
+/**
   Create a {@linkcode Maybe} instance which is a {@linkcode Nothing}.
 
   If you want to create an instance with a specific type, e.g. for use in a

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -516,6 +516,22 @@ describe('`Maybe` pure functions', () => {
     const querySelector = MaybeNS.wrapReturn(returnsNullable);
     expectTypeOf(querySelector).toEqualTypeOf<() => Maybe<string>>();
   });
+
+  test('`isJust` with a Just', () => {
+    const testJust: Maybe<string> = MaybeNS.just('test');
+
+    if (MaybeNS.isJust(testJust)) {
+      expect(testJust.value).toEqual('test');
+    } else {
+      fail('Expected a Just');
+    }
+  });
+
+  test('`isJust` with a Nothing', () => {
+    const testNothing: Maybe<string> = MaybeNS.nothing();
+
+    expect(MaybeNS.isJust(testNothing)).toEqual(false);
+  });
 });
 
 // We aren't even really concerned with the "runtime" behavior here, which we


### PR DESCRIPTION
```ts
import { isJust, just, Maybe } from 'true-myth/maybe';

const myJust: Maybe<string> = just('test');

if (isJust(myJust)) {
  console.log(myJust.value);
}
```

This will also "fix" https://github.com/true-myth/true-myth/issues/305#issuecomment-1078781731 somehow. `isJust` will then show up in https://true-myth.js.org/modules/maybe.html