### PR TITLE
Export pure isNothing() function

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -362,6 +362,17 @@ export function isJust<T>(maybe: Maybe<T>): maybe is Just<T> {
 }
 
 /**
+  Is the {@linkcode Maybe} a {@linkcode Nothing}?
+  
+  @typeparam T The type of the item contained in the `Maybe`.
+  @param maybe The `Maybe` to check.
+  @returns A type guarded `Nothing`.
+*/
+export function isNothing<T>(maybe: Maybe<T>): maybe is Nothing<T> {
+  return maybe.isNothing;
+}
+
+/**
   Create a {@linkcode Maybe} instance which is a {@linkcode Nothing}.
 
   If you want to create an instance with a specific type, e.g. for use in a

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -532,6 +532,18 @@ describe('`Maybe` pure functions', () => {
 
     expect(MaybeNS.isJust(testNothing)).toEqual(false);
   });
+
+  test('`isNothing` with a Just', () => {
+    const testJust: Maybe<string> = MaybeNS.just('test');
+
+    expect(MaybeNS.isNothing(testJust)).toEqual(false);
+  });
+
+  test('`isNothing` with a Nothing', () => {
+    const testNothing: Maybe<string> = MaybeNS.nothing();
+
+    expect(MaybeNS.isNothing(testNothing)).toEqual(true);
+  });
 });
 
 // We aren't even really concerned with the "runtime" behavior here, which we


### PR DESCRIPTION
```ts
import { isNothing, nothing, Maybe } from 'true-myth/maybe';

const myJust: Maybe<string> = nothing();

if (isNothing(myJust)) {
  console.log('No myJust.value available');
}
```

This will also "fix" https://github.com/true-myth/true-myth/issues/305#issuecomment-1078781731 somehow. `isNothing` will then show up in https://true-myth.js.org/modules/maybe.html