### PR TITLE
Export pure isErr() function

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -368,6 +368,17 @@ export function isOk<T, E>(result: Result<T, E>): result is Ok<T, E> {
 }
 
 /**
+  Is the {@linkcode Result} an {@linkcode Err}?
+  
+  @typeparam T The type of the item contained in the `Result`.
+  @param result The `Result` to check.
+  @returns A type guarded `Err`.
+*/
+export function isErr<T, E>(result: Result<T, E>): result is Err<T, E> {
+  return result.isErr;
+}
+
+/**
   Create an instance of {@linkcode Err}.
 
   If you need to create an instance with a specific type (as you do whenever you

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -435,6 +435,18 @@ describe('`Result` pure functions', () => {
 
     expect(ResultNS.isOk(testErr)).toEqual(false);
   });
+
+  test('`isErr` with an Ok', () => {
+    const testOk: Result<number, string> = ResultNS.ok(42);
+
+    expect(ResultNS.isErr(testOk)).toEqual(false);
+  });
+
+  test('`isErr` with an Err', () => {
+    const testErr: Result<number, string> = ResultNS.err('');
+
+    expect(ResultNS.isErr(testErr)).toEqual(true);
+  });
 });
 
 // We aren't even really concerned with the "runtime" behavior here, which we


### PR DESCRIPTION
```ts
import { isErr, err Result } from 'true-myth/result';

const myResult: Result<number, string> = err('Something failed');

if (isErr(myResult)) {
  console.log('myResult is an Err');
}
```

Fixes https://github.com/true-myth/true-myth/issues/305