### PR TITLE
Add missing readonly variants modifiers

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -313,7 +313,7 @@ class MaybeImpl<T> {
  */
 export interface Just<T> extends MaybeImpl<T> {
   /** `Just` is always {@linkcode Variant.Just}. */
-  variant: 'Just';
+  readonly variant: 'Just';
   /** The wrapped value. */
   value: T;
   isJust: true;

--- a/src/result.ts
+++ b/src/result.ts
@@ -242,7 +242,7 @@ class ResultImpl<T, E> {
  */
 export interface Ok<T, E> extends ResultImpl<T, E> {
   /** `Ok` is always [`Variant.Ok`](../enums/_result_.variant#ok). */
-  variant: 'Ok';
+  readonly variant: 'Ok';
   isOk: true;
   isErr: false;
   /** The wrapped value */


### PR DESCRIPTION
`Nothing` and `Err` also defined their `variant` as `readonly`.