### PR TITLE
Add support for TypeScript 4.7

### DIFF
--- a/src/-private/utils.ts
+++ b/src/-private/utils.ts
@@ -16,3 +16,20 @@ export const isVoid = (value: unknown): value is undefined | null =>
 export function curry1<T, U>(op: (t: T) => U, item?: T) {
   return item !== undefined ? op(item) : op;
 }
+
+/**
+ * Check whether a given key is in an object
+ * @internal
+ */
+function has<T, K extends PropertyKey>(value: T, key: K): value is T & { [Key in K]: unknown } {
+  return typeof value === 'object' && value !== null && key in value;
+}
+
+export function safeToString(value: unknown): string {
+  if (has(value, 'toString') && typeof value['toString'] === 'function') {
+    const fnResult = value.toString();
+    return typeof fnResult === 'string' ? fnResult : JSON.stringify(value);
+  } else {
+    return JSON.stringify(value);
+  }
+}

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -5,7 +5,7 @@
  */
 
 import Result from './result.js';
-import { curry1, isVoid } from './-private/utils.js';
+import { curry1, isVoid, safeToString } from './-private/utils.js';
 
 // Import for backwards-compatibility re-export
 import * as Toolbelt from './toolbelt.js';
@@ -846,8 +846,8 @@ export function fromResult<T>(result: Result<T, unknown>): Maybe<T> {
   @param maybe The value to convert to a string.
   @returns     The string representation of the `Maybe`.
  */
-export function toString<T extends { toString(): string }>(maybe: Maybe<T>): string {
-  const body = maybe.isJust ? `(${maybe.value.toString()})` : '';
+export function toString<T>(maybe: Maybe<T>): string {
+  const body = maybe.map((value) => `(${safeToString(value)})`).unwrapOr('');
   return `${maybe.variant}${body}`;
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -7,7 +7,7 @@
 import type Maybe from './maybe.js';
 
 import Unit from './unit.js';
-import { curry1, isVoid } from './-private/utils.js';
+import { curry1, isVoid, safeToString } from './-private/utils.js';
 
 // Import for backwards-compatibility re-export
 import * as Toolbelt from './toolbelt.js';
@@ -988,15 +988,13 @@ export function fromMaybe<T, E>(
   `toString(err([1, 2, 3]))`        | `Err(1,2,3)`
   `toString(err({ an: 'object' }))` | `Err([object Object])`
 
-  @typeparam T The type of the wrapped value; its own `.toString` will be used
-               to print the interior contents of the `Just` variant.
-  @param maybe The value to convert to a string.
-  @returns     The string representation of the `Maybe`.
+  @typeparam T  The type of the wrapped value; its own `.toString` will be used
+                to print the interior contents of the `Just` variant.
+  @param result The value to convert to a string.
+  @returns      The string representation of the `Maybe`.
  */
-export const toString = <T extends { toString(): string }, E extends { toString(): string }>(
-  result: Result<T, E>
-): string => {
-  const body = (result.isOk ? result.value : result.error).toString();
+export const toString = <T, E>(result: Result<T, E>): string => {
+  const body = result.match({ Ok: safeToString, Err: safeToString });
   return `${result.variant.toString()}(${body})`;
 };
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -282,9 +282,33 @@ describe('`Maybe` pure functions', () => {
     expect(MaybeNS.fromResult(anErr)).toEqual(MaybeNS.nothing());
   });
 
-  test('`toString`', () => {
-    expect(MaybeNS.toString(MaybeNS.of(42))).toEqual('Just(42)');
-    expect(MaybeNS.toString(MaybeNS.nothing<string>())).toEqual('Nothing');
+  describe('`toString`', () => {
+    test('normal cases', () => {
+      expect(MaybeNS.toString(MaybeNS.of(42))).toEqual('Just(42)');
+      expect(MaybeNS.toString(MaybeNS.nothing<string>())).toEqual('Nothing');
+    });
+
+    test('custom `toString`s', () => {
+      const withNotAFunction = {
+        whyThough: 'because JS bro',
+        toString: '🤨',
+      };
+
+      expect(MaybeNS.toString(Maybe.of(withNotAFunction))).toEqual(
+        `Just(${JSON.stringify(withNotAFunction)})`
+      );
+
+      const withBadFunction = {
+        cueSobbing: true,
+        toString() {
+          return { lol: 123 };
+        },
+      };
+
+      expect(MaybeNS.toString(Maybe.of(withBadFunction))).toEqual(
+        `Just(${JSON.stringify(withBadFunction)})`
+      );
+    });
   });
 
   test('`toJSON`', () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -318,15 +318,39 @@ describe('`Result` pure functions', () => {
     expect(ResultNS.fromMaybe(errValue, aNothing)).toEqual(anErr);
   });
 
-  test('toString', () => {
-    const theValue = { thisIsReally: 'something' };
-    const errValue = ['oh', 'no'];
+  describe('toString', () => {
+    test('normal cases', () => {
+      const theValue = { thisIsReally: 'something' };
+      const errValue = ['oh', 'no'];
 
-    const anOk = ResultNS.ok<typeof theValue, typeof errValue>(theValue);
-    expect(ResultNS.toString(anOk)).toEqual(`Ok(${theValue.toString()})`);
+      const anOk = ResultNS.ok<typeof theValue, typeof errValue>(theValue);
+      expect(ResultNS.toString(anOk)).toEqual(`Ok(${theValue.toString()})`);
 
-    const anErr = ResultNS.err<typeof theValue, typeof errValue>(errValue);
-    expect(ResultNS.toString(anErr)).toEqual(`Err(${errValue.toString()})`);
+      const anErr = ResultNS.err<typeof theValue, typeof errValue>(errValue);
+      expect(ResultNS.toString(anErr)).toEqual(`Err(${errValue.toString()})`);
+    });
+
+    test('custom `toString`s', () => {
+      const withNotAFunction = {
+        whyThough: 'because JS bro',
+        toString: '🤨',
+      };
+
+      expect(ResultNS.toString(Result.ok(withNotAFunction))).toEqual(
+        `Ok(${JSON.stringify(withNotAFunction)})`
+      );
+
+      const withBadFunction = {
+        cueSobbing: true,
+        toString() {
+          return { lol: 123 };
+        },
+      };
+
+      expect(ResultNS.toString(Result.err(withBadFunction))).toEqual(
+        `Err(${JSON.stringify(withBadFunction)})`
+      );
+    });
   });
 
   test('`toJSON`', () => {
@@ -825,6 +849,6 @@ describe('`ResultNS.Err` class', () => {
 
     const result = fn.ap(val);
 
-    expect(result.toString()).toEqual(`Err(ERR_ALLURBASE)`);
+    expect(result.toString()).toEqual(`Err("ERR_ALLURBASE")`);
   });
 });


### PR DESCRIPTION
TS 4.7 catches a class of error which 4.6 and earlier did not, courtesy of microsoft/TypeScript#43183: if the type passed does not implement `toString()`, it notices, because it no longer defaults to falling back to `{}`.

To resolve this, *loosen* the constraints on what is acceptable as input to `toString`, by making the implementation itself more robust. Doing so also fixes a bug with the output for `toString` when working with strings: previously if you had `Maybe("a string")`, the `toString` output would be `'Maybe(a string)'`; it is now `'Maybe("a string")'`.

Fixes #330