### PR TITLE
Update minimum Node to v14, add v18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12', '14', '16']
+        node-version: ['14', '16', '18']
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": "12.* || >= 14.*"
+    "node": "14.* || 16.* || >= 18.*"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",
@@ -136,7 +136,7 @@
     }
   },
   "volta": {
-    "node": "12.22.7",
+    "node": "14.19.1",
     "yarn": "1.22.17",
     "npm": "7.1.2"
   }


### PR DESCRIPTION
Node 12 LTS will be end-of-life at the end of the month!