### PR TITLE
Decrease Unit implementation runtime size

### DIFF
--- a/src/public/unit.ts
+++ b/src/public/unit.ts
@@ -5,30 +5,27 @@
   @module
  */
 
-const TagSymbol = Symbol('BrandTag');
+declare const Tag: unique symbol;
 
 /**
  * Create a unique, nominalish type.
  * @internal
  */
-class Brand<Tag extends string> {
-  protected readonly [TagSymbol]: Tag;
-
-  constructor(tag: Tag) {
-    this[TagSymbol] = tag;
-  }
+declare class _Unit {
+  private readonly [Tag]: '()';
 }
 
 /**
   The `Unit` type exists for the cases where you want a type-safe equivalent of
   `undefined` or `null`. It's a concrete instance, which won't blow up on you,
-  and you can safely use it with e.g. {@linkcode result.Result Result} without
-  being concerned that you'll accidentally introduce `null` or `undefined` back
-  into your application.
+  and you can safely use it with e.g. `Result` without being concerned that
+  you'll accidentally introduce `null` or `undefined` back into your
+  application.
 
   Equivalent to `()` or "unit" in many functional or functional-influenced
   languages.
  */
-export const Unit = new Brand('unit');
-export type Unit = typeof Unit;
+export const Unit = Object.create(null) as Unit;
+export interface Unit extends _Unit {}
+
 export default Unit;

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -4,9 +4,9 @@ import { Unit as RexportedUnit } from 'true-myth';
 
 test('the unit type', () => {
   expectTypeOf<Unit>().toEqualTypeOf<{}>();
-  expectTypeOf({}).not.toMatchTypeOf(Unit);
+  expectTypeOf({}).toEqualTypeOf(Unit);
   expectTypeOf<Unit>().toEqualTypeOf<RexportedUnit>();
 
-  expect(Unit).not.toEqual({});
-  expect(RexportedUnit).not.toEqual({});
+  expect(Unit).toEqual({});
+  expect(RexportedUnit).toEqual({});
 });


### PR DESCRIPTION
Make it a prototype-less object which is *cast* as `Unit`. This means that it has an even smaller overhead at runtime than it did before, and it basically acts like an empty object in the type system... but one with a useful name, and a guarantee that there is only ever one of it.

All the type test changes here indicate that this is a *wider* type, usable in more places than previously. Since it was impossible to perform an actual brand check before in a way that surfaced in the type system, this is safe. (From a runtime POV, users could have been distinguishing it by using `Object.getOwnPropertySymbols()` but 🤷🏼‍♂️)