### PR TITLE
v5.x: Add Node 18 and TS 4.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12', '14', '16']
+        node-version: ['12', '14', '16', '18']
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        ts-version: ['~4.2', '~4.3', '~4.4', '~4.5', '4.6', 'next']
+        ts-version: ['~4.2', '~4.3', '~4.4', '~4.5', '4.6', '4.7', 'next']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
     <img src='https://img.shields.io/npm/v/true-myth.svg' alt='npm'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L25'>
-    <img src='https://img.shields.io/badge/Node-12%20LTS%20%7C%2014%20LTS%20%7C%2016%20LTS-darkgreen' alt='supported Node versions'>
+    <img src='https://img.shields.io/badge/Node-12%20LTS%20%7C%2014%20LTS%20%7C%2016%20LTS%20%7C%2018-darkgreen' alt='supported Node versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L59'>
-    <img src='https://img.shields.io/badge/TypeScript-4.2%20%7C%204.3%20%7C%204.4%20%7C%204.5%20%7C%204.6%20%7C%20next-3178c6' alt='supported TypeScript versions'>
+    <img src='https://img.shields.io/badge/TypeScript-4.2%20%7C%204.3%20%7C%204.4%20%7C%204.5%20%7C%204.6%20%7C%204.7%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/true-myth/true-myth/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": "12.* || >= 14.*"
+    "node": "12.* || 14.* || 16.* || >= 18.*"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",


### PR DESCRIPTION
This will be incorporated into v5.4, the final release on the 5.x branch. Users on Node 12 or TS <4.7 can update to v5.4, *then* upgrade to Node 14 and/or TS 4.7, *then* upgrade to True Myth 6.0. (This will all be in the release notes.)