### PR TITLE
Incorporate TS 4.7 *and* next in support matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        ts-version: ['next']
+        ts-version: ['4.7', 'next']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     <img src='https://img.shields.io/badge/Node-12%20LTS%20%7C%2014%20LTS%20%7C%2016%20LTS-darkgreen' alt='supported Node versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L59'>
-    <img src='https://img.shields.io/badge/TypeScript-next-3178c6' alt='supported TypeScript versions'>
+    <img src='https://img.shields.io/badge/TypeScript-4.7%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/true-myth/true-myth/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "shelljs": "^0.8.2",
     "ts-jest": "^27.0.7",
     "typedoc": "^0.22.10",
-    "typescript": "^4.7.0-dev.20220504"
+    "typescript": "^4.7.2"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4992,7 +4992,7 @@ typedoc@^0.22.10:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@^4.7.0-dev.20220504:
+typescript@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
   integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==


### PR DESCRIPTION
This has been targeting TS 4.7 dev builds since adding in use of `exports` in #357. Now that it [has been released](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/), update CI config and docs to show we are testing both 4.7 and nightly.