### PR TITLE
Simplify `exports` definitions for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,9 @@
   "main": "dist/public/index.js",
   "module": "dist/public/index.js",
   "exports": {
-    ".": {
-      "import": "./dist/public/index.js",
-      "types": "./dist/public/index.d.ts"
-    },
-    "./*": {
-      "types": "./dist/public/*.d.ts",
-      "import": "./dist/public/*.js"
-    },
-    "./package.json": "./package.json"
+    ".": "./dist/public/index.js",
+    "./package.json": "./package.json",
+    "./*": "./dist/public/*.js"
   },
   "types": "dist/public/index.d.ts",
   "keywords": [


### PR DESCRIPTION
TypeScript's types lookup will automatically check "next to" the JS files in `exports`, with the `types` field being necessary *only* when defining types as exported at a *different* location than immediately adjacent to the compiled JS they correspond to.