### PR TITLE
v5.x: Drop `preversion` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lint": "yarn eslint src/*.ts test/*.ts",
     "prepublishOnly": "yarn test && yarn build",
     "postpublish": "yarn clean",
-    "preversion": "./scripts/build-docs && git add docs",
     "test": "jest",
     "tdd": "jest --watch"
   },


### PR DESCRIPTION
This is no longer necessary since it's handled via GH Pages as of #358.