### PR TITLE
Drop `preversion` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lint": "yarn eslint src/*.ts test/*.ts",
     "prepublishOnly": "yarn test && yarn build",
     "postpublish": "yarn clean",
-    "preversion": "./scripts/build-docs && git add docs",
     "test": "jest",
     "tdd": "jest --watch"
   },


### PR DESCRIPTION
This is no longer necessary since it's handled via GH Pages as of https://github.com/true-myth/true-myth/pull/358.

(Ported forward to v6 from #385)