### PR TITLE
chore: remove defunct parts of package

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -1,4 +1,0 @@
-{
-  "blueprint": "libkit",
-  "testPort": "0"
-}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "build": "yarn clean && yarn tsc --project ts/publish.tsconfig.json",
     "clean": "rimraf ./dist",
     "doc": "./scripts/build-docs",
-    "lint": "yarn eslint src/*.ts test/*.ts",
     "prepublishOnly": "yarn test && yarn build",
     "postpublish": "yarn clean",
     "test": "jest",


### PR DESCRIPTION
- We removed ESLint a while back but it was in package `scripts`.
- We removed Ember CLI even longer ago, but still had config.