### PR TITLE
Upgrade to latest TypeDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "release-it": "^16.0.0",
     "rimraf": "^5.0.1",
     "shelljs": "^0.8.5",
-    "typedoc": "^0.24.4",
+    "typedoc": "^0.24.8",
     "typescript": "~5.1",
     "vitest": "^0.33.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ devDependencies:
     specifier: ^0.8.5
     version: 0.8.5
   typedoc:
-    specifier: ^0.24.4
-    version: 0.24.4(typescript@5.1.3)
+    specifier: ^0.24.8
+    version: 0.24.8(typescript@5.1.3)
   typescript:
     specifier: ~5.1
     version: 5.1.3
@@ -4168,12 +4168,12 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typedoc@0.24.4(typescript@5.1.3):
-    resolution: {integrity: sha512-vQuliyGhJEGeKzzCFHbkS3m0gHoIL6cfr0fHf6eX658iGELtq2J9mWe0b+X5McEYgFoMuHFt5Py3Zug6Sxjn/Q==}
+  /typedoc@0.24.8(typescript@5.1.3):
+    resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
     engines: {node: '>= 14.14'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -9,7 +9,7 @@ import { curry1, isVoid, safeToString } from './-private/utils.js';
 /**
   Discriminant for the {@linkcode Just} and {@linkcode Nothing} type instances.
 
-  You can use the discriminant via the `variant` property of {@linkcode Maybe}¿
+  You can use the discriminant via the `variant` property of {@linkcode Maybe}
   instances if you need to match explicitly on it.
  */
 export const Variant = {


### PR DESCRIPTION
This gets to a current version *and* makes it actually publish in a more correct way again, by dint of having restructured the exports locations.