### PR TITLE
Fix CJS import location in package `exports` map

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       },
       "require": {
         "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs/index.cjs"
       }
     },
     "./package.json": "./package.json",


### PR DESCRIPTION
Just what it says on the tin. Whoops. Guess we need a 7.0.1. (Imagine if this whole thing stunk less!)