### PR TITLE
Handle `undefined` correctly with `Result.ok`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postpublish": "pnpm clean",
     "test": "vitest run --coverage",
     "tdd": "vitest",
-    "type-check": "tsc --noEmit --skipLibCheck"
+    "type-check": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/src/result.ts
+++ b/src/result.ts
@@ -63,12 +63,17 @@ class ResultImpl<T, E> {
 
     @param value The value to wrap in an `Ok`.
    */
-  static ok<T, E>(): Result<Unit, E>;
+  static ok<T extends {}, E>(): Result<Unit, E>;
   static ok<T, E>(value: T): Result<T, E>;
   static ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
-    return isVoid(value)
+    // We produce `Unit` *only* in the case where no arguments are passed, so
+    // that we can allow `undefined` in the cases where someone explicitly opts
+    // into something like `Result<undefined, Blah>`.
+    return arguments.length === 0
       ? (new ResultImpl<Unit, E>(['Ok', Unit]) as Result<Unit, E>)
-      : (new ResultImpl<T, E>(['Ok', value]) as Result<T, E>);
+      : // SAFETY: TS does not understand that the arity check above accounts for
+        // the case where the value is not passed.
+        (new ResultImpl<T, E>(['Ok', value as T]) as Result<T, E>);
   }
 
   /**

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -26,8 +26,12 @@ describe('`Result` pure functions', () => {
     expect(withUnit).toEqual(ResultNS.ok(Unit));
 
     const withUnitFromImport = Result.ok();
-    expectTypeOf(withUnit).toEqualTypeOf<Result<Unit, unknown>>();
+    expectTypeOf(withUnitFromImport).toEqualTypeOf<Result<Unit, unknown>>();
     expect(withUnitFromImport).toEqual(Result.ok(Unit));
+
+    const withUndefined = Result.ok(undefined);
+    expectTypeOf(withUndefined).toEqualTypeOf<Result<undefined, unknown>>();
+    expect((withUndefined as Ok<undefined, unknown>).value).toBeUndefined();
   });
 
   test('`err`', () => {

--- a/ts/base.tsconfig.json
+++ b/ts/base.tsconfig.json
@@ -12,7 +12,12 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
 
-    "moduleResolution": "Node16"
+    "moduleResolution": "Node16",
+
+    // Normally, this is a *very* bad idea. However, here the library *itself*
+    // has no dependencies, and so type checking should always be completely
+    // localized.
+    "skipLibCheck": true
   },
   // as a base, don't include anything: specify that in the other files
   "include": []


### PR DESCRIPTION
Previously, we treated the arity-0 and the arity-1 with a first argument of `undefined` versions of `Result.ok` identically. This can directly result in a type error at runtime by setting the actual value to `Unit` while “successfully” producing a type of `Result<undefined, SomeError>`, since there was a mismatch between the implementation and the produced type (i.e. a case where the overload logic and the implementation logic diverged):

```ts
function foo(): Result<undefined, string> {
    return Result.ok(undefined);
}
```

Since the implementation here simply checks whether the argument `isVoid`, it will use `Unit` under the hood; but the type checking correctly sees that we are passing a `T` which is `undefined` and thus produces the correct type. The result is that the `.value` is `Unit` when it *should* be `undefined`, which is the inverse of the case we had previously taken great care to handle.

This solves the problem by changing the behavior so the public contract and the implementation actually match, by doing an arity check instead of an `isVoid` check on the first argument. As a result:

- `Result.ok()` → `Result<Unit, E>`
- `Result.ok(undefined)` → `Result<undefined, E>`

Fixes #607