### PR TITLE
Simplify CI test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,27 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16', '18', '20']
+        node-version: ['18']
 
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: pnpm install
-      - run: pnpm test
-
-  tests_other:
-    name: 'Tests: ${{ matrix.os }}'
-    runs-on: '${{ matrix.os }}-latest'
-
-    strategy:
-      matrix:
-        os: [macOS, windows]
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: volta-cli/action@v4
       - run: pnpm install
       - run: pnpm test
 


### PR DESCRIPTION
We historically tested against macOS, Windows, and multiple Node versions, because when I originally set up this repo, we were using Ember CLI to generate the build artifacts, and wanted to guarantee the behavior of the build integration across all targets. We have not used Ember CLI here for many years, though, and True Myth makes *zero* use of Node APIs. Accordingly, we can simply test using the current Node LTS (for convenience, really!) and make sure we have full type-checking coverage for our supported set of TS versions.