### PR TITLE
Allow readonly Arrays in find()

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -492,8 +492,8 @@ export function mapOr<T, U>(
   return mapFn === undefined
     ? partialOp
     : maybe === undefined
-    ? partialOp(mapFn)
-    : partialOp(mapFn, maybe);
+      ? partialOp(mapFn)
+      : partialOp(mapFn, maybe);
 }
 
 /**
@@ -1083,12 +1083,12 @@ export function isInstance<T>(item: unknown): item is Maybe<T> {
   return item instanceof Maybe;
 }
 
-export type Predicate<T> = (element: T, index: number, array: T[]) => boolean;
+export type Predicate<T> = (element: T, index: number, array: T[] | readonly T[]) => boolean;
 
 export type NarrowingPredicate<T, U extends T> = (
   element: T,
   index: number,
-  array: T[]
+  array: T[] | readonly T[]
 ) => element is U;
 
 // NOTE: documentation is lightly adapted from the MDN and TypeScript docs for
@@ -1147,15 +1147,20 @@ export type NarrowingPredicate<T, U extends T> = (
                     returns `Nothing`.
  * @param array     The array to search using the predicate.
  */
-export function find<T, U extends T>(predicate: NarrowingPredicate<T, U>, array: T[]): Maybe<U>;
-export function find<T, U extends T>(predicate: NarrowingPredicate<T, U>): (array: T[]) => Maybe<U>;
-export function find<T>(predicate: Predicate<T>, array: T[]): Maybe<T>;
-export function find<T>(predicate: Predicate<T>): (array: T[]) => Maybe<T>;
+export function find<T, U extends T>(
+  predicate: NarrowingPredicate<T, U>,
+  array: T[] | readonly T[]
+): Maybe<U>;
+export function find<T, U extends T>(
+  predicate: NarrowingPredicate<T, U>
+): (array: T[] | readonly T[]) => Maybe<U>;
+export function find<T>(predicate: Predicate<T>, array: T[] | readonly T[]): Maybe<T>;
+export function find<T>(predicate: Predicate<T>): (array: T[] | readonly T[]) => Maybe<T>;
 export function find<T, U extends T>(
   predicate: NarrowingPredicate<T, U> | Predicate<T>,
-  array?: T[]
-): Maybe<T> | ((array: T[]) => Maybe<T>) {
-  const op = (a: T[]) => Maybe.of(a.find(predicate));
+  array?: T[] | readonly T[]
+): Maybe<T> | ((array: T[] | readonly T[]) => Maybe<T>) {
+  const op = (a: T[] | readonly T[]) => Maybe.of(a.find(predicate));
   return curry1(op, array);
 }
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -392,6 +392,10 @@ describe('`Maybe` pure functions', () => {
       expect(waffles.variant).toBe(MaybeNS.Variant.Just);
       expect((waffles as Just<Item>).value).toEqual(array[1]);
       expectTypeOf(waffles).toMatchTypeOf<Maybe<{ name: 'waffles' }>>();
+
+      const readonlyEmpty: readonly number[] = [];
+      const foundReadonly = MaybeNS.find(pred, readonlyEmpty);
+      expectTypeOf(foundReadonly).toMatchTypeOf<Maybe<number>>();
     });
 
     test('`first`', () => {


### PR DESCRIPTION
At the moment it is only possible to put mutable Arrays into `find()`.