### PR TITLE
Correctly handle `null` and `undefined` in function return types

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -492,8 +492,8 @@ export function mapOr<T, U>(
   return mapFn === undefined
     ? partialOp
     : maybe === undefined
-      ? partialOp(mapFn)
-      : partialOp(mapFn, maybe);
+    ? partialOp(mapFn)
+    : partialOp(mapFn, maybe);
 }
 
 /**
@@ -1487,7 +1487,7 @@ export function get<T, K extends keyof T>(
 export function wrapReturn<
   F extends AnyFunction,
   P extends Parameters<F>,
-  R extends NonNullable<ReturnType<F>>,
+  R extends NonNullable<ReturnType<F>>
 >(fn: F): (...args: P) => Maybe<R> {
   return (...args) => Maybe.of(fn(...args)) as Maybe<R>;
 }

--- a/src/toolbelt.ts
+++ b/src/toolbelt.ts
@@ -32,7 +32,7 @@ export function transposeResult<T, E>(result: Result<Maybe<T>, E>): Maybe<Result
   return result.match({
     Ok: (maybe) =>
       maybe.match({
-        Just: (v) => Maybe.just(Result.ok(v)),
+        Just: (v) => Maybe.just(Result.ok<T, E>(v)),
         Nothing: () => Maybe.nothing(),
       }),
     Err: (e) => Maybe.just(Result.err<T, E>(e)),

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -24,6 +24,13 @@ describe('`Maybe` pure functions', () => {
 
     expect(() => MaybeNS.just(null)).toThrow();
     expect(() => MaybeNS.just(undefined)).toThrow();
+
+    expectTypeOf(Maybe.just(() => null)).toBeNever();
+    expectTypeOf(Maybe.just(() => undefined)).toBeNever();
+
+    let example = (): string | undefined => undefined;
+    expectTypeOf(Maybe.just(example)).toBeNever();
+    expectTypeOf(Maybe.just(() => 'hello')).toEqualTypeOf<Maybe<() => string>>();
   });
 
   test('`nothing`', () => {
@@ -47,6 +54,13 @@ describe('`Maybe` pure functions', () => {
   });
 
   describe('`of`', () => {
+    expectTypeOf(Maybe.of(() => null)).toBeNever();
+    expectTypeOf(Maybe.of(() => undefined)).toBeNever();
+
+    let example = (): string | undefined => undefined;
+    expectTypeOf(Maybe.of(example)).toBeNever();
+    expectTypeOf(Maybe.of(() => 'hello')).toEqualTypeOf<Maybe<() => string>>();
+
     test('with `null', () => {
       const nothingFromNull = MaybeNS.of<string>(null);
       expectTypeOf(nothingFromNull).toEqualTypeOf<Maybe<string>>();
@@ -89,6 +103,14 @@ describe('`Maybe` pure functions', () => {
     const noLength = MaybeNS.map(length, none);
     expectTypeOf(none).toMatchTypeOf<Maybe<string>>();
     expect(noLength).toEqual(MaybeNS.nothing());
+
+    expect(() => {
+      MaybeNS.map(
+        // @ts-expect-error
+        (_val) => null,
+        Maybe.of('Hello')
+      );
+    }).toThrow();
   });
 
   test('`mapOr`', () => {
@@ -615,6 +637,14 @@ describe('`Maybe` class', () => {
       const theResult = new Maybe(plus2(theValue));
 
       expect(theJust.map(plus2)).toEqual(theResult);
+
+      // Forbid returning `null` at the type level, but not at the runtime level.
+      expect(() => {
+        theJust.map(
+          // @ts-expect-error
+          (_val) => null
+        );
+      }).toThrow();
     });
 
     test('`mapOr` method', () => {
@@ -733,7 +763,7 @@ describe('`Maybe` class', () => {
 
     test('`ap` method', () => {
       const toString = (a: number) => a.toString();
-      const fn: Maybe<typeof toString> = new Maybe(toString);
+      const fn = new Maybe(toString);
       const val = new Maybe(3);
 
       const result = fn.ap(val);
@@ -804,6 +834,11 @@ describe('`Maybe` class', () => {
     test('`map` method', () => {
       const theNothing = new Maybe<string>();
       expect(theNothing.map(length)).toEqual(theNothing);
+
+      theNothing.map(
+        // @ts-expect-error
+        (_val) => null
+      );
     });
 
     test('`mapOr` method', () => {


### PR DESCRIPTION
Forbid returning `null` or `undefined` from the callback passed to `Maybe.map` (method or standalone functions), and also forbid constructing a `Maybe` of a function type which returns `null | undefined`.

Before, you could write these, and they would type check but produce a nonsensical type of `Maybe<null>` and throw an error at runtime:

```ts
let example1 = Maybe.of("Hello").map((_s) => null);
let example2 = Maybe.of((_: number) => null).ap(Maybe.just(123));
```

To prevent the first, we simply constrain the type parameter `U` for `map` to be non-nullable. The second is subtler, because we cannot actually prevent the user from constructing this directly; if we attempted to, it would fall into the `T | null | undefined` fallback. Instead, produce `never` in any case where a function passed to `Maybe.of` or `Maybe.just` includes `null` or `undefined` in its return type.