### PR TITLE
Forbid `null` and `undefined` as arguments to `Maybe.just`

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -106,10 +106,6 @@ class MaybeImpl<T> {
   /**
     Create an instance of `Maybe.Just`.
 
-    `null` and `undefined` are allowed by the type signature so that the
-    function may `throw` on those rather than constructing a type like
-    `Maybe<undefined>`.
-
     @typeparam T The type of the item contained in the `Maybe`.
     @param value The value to wrap in a `Maybe.Just`.
     @returns     An instance of `Maybe.Just<T>`.
@@ -120,10 +116,12 @@ class MaybeImpl<T> {
   static just<F extends (...args: any) => {}>(value: F): Maybe<F>;
   static just<T extends {}, F extends (...args: any) => T | null | undefined>(value: F): never;
   static just<F extends (...args: any) => null | undefined>(value: F): never;
-  // Otherwise, `just` handles `null` and `undefined` values by throwing, per
-  // the docstring.
-  static just<T>(value?: T | null): Maybe<T>;
-  static just<T>(value?: T | null): Maybe<T> {
+  // The public signature otherwise only allows non-null values.
+  static just<T extends {}>(value: T): Maybe<T>;
+  // The runtime signature *does* allow null and undefined values so that the
+  // body can correctly throw at runtime in the case where a caller passes data
+  // whose type lies about the contained value.
+  static just<T>(value: T | null | undefined): Maybe<T> {
     if (isVoid(value)) {
       throw new Error(`attempted to call "just" with ${value}`);
     }

--- a/src/toolbelt.ts
+++ b/src/toolbelt.ts
@@ -49,7 +49,7 @@ export function transposeResult<T, E>(result: Result<Maybe<T>, E>): Maybe<Result
   @param result The `Result` to convert to a `Maybe`
   @returns      `Just` the value in `result` if it is `Ok`; otherwise `Nothing`
  */
-export function toMaybe<T>(result: Result<T, unknown>): Maybe<T> {
+export function toMaybe<T extends {}>(result: Result<T, unknown>): Maybe<T> {
   return result.isOk ? Maybe.just(result.value) : Maybe.nothing();
 }
 
@@ -85,7 +85,7 @@ export function fromMaybe<T, E>(
 
   @param maybe a `Maybe<Result<T, E>>` to transform to a `Result<Maybe<T>, E>>`.
  */
-export function transposeMaybe<T, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T>, E> {
+export function transposeMaybe<T extends {}, E>(maybe: Maybe<Result<T, E>>): Result<Maybe<T>, E> {
   return maybe.match({
     Just: (result) =>
       result.match({
@@ -151,6 +151,6 @@ export function toOkOrElseErr<T, E>(
   @param result The `Result` to construct a `Maybe` from.
   @returns      `Just` if `result` was `Ok` or `Nothing` if it was `Err`.
  */
-export function fromResult<T>(result: Result<T, unknown>): Maybe<T> {
+export function fromResult<T extends {}>(result: Result<T, unknown>): Maybe<T> {
   return result.isOk ? Maybe.just(result.value) : Maybe.nothing<T>();
 }

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -22,8 +22,18 @@ describe('`Maybe` pure functions', () => {
         expect(false).toBe(true); // because those are the only cases
     }
 
-    expect(() => MaybeNS.just(null)).toThrow();
-    expect(() => MaybeNS.just(undefined)).toThrow();
+    expect(() =>
+      MaybeNS.just(
+        // @ts-expect-error: null is forbidden here
+        null
+      )
+    ).toThrow();
+    expect(() =>
+      MaybeNS.just(
+        // @ts-expect-error: undefined is forbidden here
+        undefined
+      )
+    ).toThrow();
 
     expectTypeOf(Maybe.just(() => null)).toBeNever();
     expectTypeOf(Maybe.just(() => undefined)).toBeNever();
@@ -462,7 +472,7 @@ describe('`Maybe` pure functions', () => {
   test('`property`', () => {
     type Person = { name?: string };
     let chris: Person = { name: 'chris' };
-    expect(MaybeNS.property('name', chris)).toEqual(MaybeNS.just(chris.name));
+    expect(MaybeNS.property('name', chris)).toEqual(MaybeNS.just('chris'));
 
     let nobody: Person = {};
     expect(MaybeNS.property('name', nobody)).toEqual(MaybeNS.nothing());
@@ -477,7 +487,7 @@ describe('`Maybe` pure functions', () => {
     type Person = { name?: string };
     let chris: Person = { name: 'chris' };
     let justChris: Maybe<Person> = MaybeNS.just(chris);
-    expect(MaybeNS.get('name', justChris)).toEqual(MaybeNS.just(chris.name));
+    expect(MaybeNS.get('name', justChris)).toEqual(MaybeNS.just('chris'));
 
     let nobody: Maybe<Person> = MaybeNS.nothing();
     expect(MaybeNS.get('name', nobody)).toEqual(MaybeNS.nothing());
@@ -597,8 +607,36 @@ describe('`Maybe` class', () => {
       expect(theJust.variant).toEqual(Variant.Just);
       expect((theJust as Just<number>).value).toEqual(123);
 
-      expect(() => Maybe.just(null)).toThrow();
-      expect(() => Maybe.just(undefined)).toThrow();
+      expect(() =>
+        Maybe.just(
+          // @ts-expect-error
+          null
+        )
+      ).toThrow();
+
+      expect(() =>
+        Maybe.just(
+          // @ts-expect-error
+          undefined
+        )
+      ).toThrow();
+
+      // By definition cannot throw on this since it actually does exist and the
+      // semantics we are checking are type-only at this point.
+      expect(() =>
+        Maybe.just(
+          // @ts-expect-error
+          'Hello' as string | null | undefined
+        )
+      ).not.toThrow();
+
+      // Whereas here it should fail both type-checking *and* at runtime.
+      expect(() =>
+        Maybe.just(
+          // @ts-expect-error
+          null as string | null | undefined
+        )
+      ).toThrow();
     });
 
     test('`value` property', () => {

--- a/test/toolbelt.test.ts
+++ b/test/toolbelt.test.ts
@@ -39,7 +39,7 @@ test('`toMaybe`', () => {
   const anOk = Result.ok(theValue);
   expect(toMaybe(anOk)).toEqual(Maybe.just(theValue));
 
-  const anErr = Result.err('uh uh');
+  const anErr = Result.err<number, string>('uh uh');
   expect(toMaybe(anErr)).toEqual(Maybe.nothing());
 });
 
@@ -111,6 +111,6 @@ test('`fromResult`', () => {
   expect(fromResult(anOk)).toEqual(Maybe.just(value));
 
   const reason = 'oh teh noes';
-  const anErr = Result.err(reason);
+  const anErr = Result.err<number, string>(reason);
   expect(fromResult(anErr)).toEqual(Maybe.nothing());
 });


### PR DESCRIPTION
While working on #753, I noticed that a similar issue applies to the `Maybe.just` constructor as to `Maybe.of`: it historically would allow functions which produce `null` or `undefined`. I included the fix for that specific issue in #755. However, as I did so, I realized that the types for `Maybe.just` have been looser than they need to be for quite a while now: when we wrote the library, we could not properly forbid `null` or `undefined` at construction time, because we had no good way to name the constraint that any argument passed to `just` be non-null. That changed several years ago, so we can now require only types which are `{}`, i.e. not `null` or `undefined`, on the type side while also continuing to throw if someone passes incorrectly typed data which is actually `null` or `undefined`.

This is not a breaking change, but a *feature*: it is what we always wanted, and aligns the types with the runtime behavior. However, it may in some cases require additional type annotations when working directly with a `Result` and using toolbelt functions. Specifically, there were some cases where the old implementation unsafely allowed `unknown`, which necessarily includes `null | undefined`, and could therefore end up with a `Maybe<unknown>`, and indeed via the unconstrained generic could move from `Result<null, string>` to `Maybe<null>` using e.g. the `transposeResult` method. This is no longer possible! 🎉