### PR TITLE
fix: set error type in `Result.ok` and ok type in `Result.err` to `never` by default

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -60,7 +60,7 @@ class ResultImpl<T, E> {
     system won't allow you to construct it that way). Instead, for convenience,
     you can simply call {@linkcode ok}, which will construct the type correctly.
    */
-  static ok<T extends {}, E>(): Result<Unit, E>;
+  static ok<T extends {}, E = never>(): Result<Unit, E>;
   /**
     Create an instance of {@linkcode Ok}.
 
@@ -84,8 +84,8 @@ class ResultImpl<T, E> {
 
     @param value The value to wrap in an `Ok`.
    */
-  static ok<T, E>(value: T): Result<T, E>;
-  static ok<T, E>(value?: T): Result<Unit, E> | Result<T, E> {
+  static ok<T, E = never>(value: T): Result<T, E>;
+  static ok<T, E = never>(value?: T): Result<Unit, E> | Result<T, E> {
     // We produce `Unit` *only* in the case where no arguments are passed, so
     // that we can allow `undefined` in the cases where someone explicitly opts
     // into something like `Result<undefined, Blah>`.
@@ -111,7 +111,7 @@ class ResultImpl<T, E> {
     const anErr = Result.err('alas, failure');
     ```
    */
-  static err<T, E>(): Result<T, Unit>;
+  static err<T = never, E = never>(): Result<T, Unit>;
   /**
     Create an instance of {@linkcode Err}.
 
@@ -129,8 +129,8 @@ class ResultImpl<T, E> {
 
     @param error The value to wrap in an `Err`.
    */
-  static err<T, E>(error: E): Result<T, E>;
-  static err<T, E>(error?: E): Result<T, Unit> | Result<T, E> {
+  static err<T = never, E = never>(error: E): Result<T, E>;
+  static err<T = never, E = never>(error?: E): Result<T, Unit> | Result<T, E> {
     return isVoid(error)
       ? (new ResultImpl<T, Unit>(['Err', Unit]) as Result<T, Unit>)
       : (new ResultImpl<T, E>(['Err', error]) as Result<T, E>);

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -22,15 +22,15 @@ describe('`Result` pure functions', () => {
     }
 
     const withUnit = ResultNS.ok();
-    expectTypeOf(withUnit).toEqualTypeOf<Result<Unit, unknown>>();
+    expectTypeOf(withUnit).toEqualTypeOf<Result<Unit, never>>();
     expect(withUnit).toEqual(ResultNS.ok(Unit));
 
     const withUnitFromImport = Result.ok();
-    expectTypeOf(withUnitFromImport).toEqualTypeOf<Result<Unit, unknown>>();
+    expectTypeOf(withUnitFromImport).toEqualTypeOf<Result<Unit, never>>();
     expect(withUnitFromImport).toEqual(Result.ok(Unit));
 
     const withUndefined = Result.ok(undefined);
-    expectTypeOf(withUndefined).toEqualTypeOf<Result<undefined, unknown>>();
+    expectTypeOf(withUndefined).toEqualTypeOf<Result<undefined, never>>();
     expect((withUndefined as Ok<undefined, unknown>).value).toBeUndefined();
   });
 
@@ -50,7 +50,7 @@ describe('`Result` pure functions', () => {
     }
 
     const withUnit = ResultNS.err();
-    expectTypeOf(withUnit).toEqualTypeOf<Result<unknown, Unit>>();
+    expectTypeOf(withUnit).toEqualTypeOf<Result<never, Unit>>();
     expect(withUnit).toEqual(ResultNS.err(Unit));
   });
 
@@ -277,15 +277,14 @@ describe('`Result` pure functions', () => {
     const anErr = ResultNS.err('pumpkins are not');
     expect(ResultNS.unwrapOr(defaultValue, anErr)).toBe(defaultValue);
     // make sure you can unwrap to a different type, like undefined
-    expectTypeOf(anOk).toEqualTypeOf<Result<string, unknown>>();
+    expectTypeOf(anOk).toEqualTypeOf<Result<string, never>>();
     const anOkOrUndefined = ResultNS.unwrapOr(undefined, anOk);
     expectTypeOf(anOkOrUndefined).toEqualTypeOf<string | undefined>();
     expect(anOkOrUndefined).toEqual(theValue);
-    // test the err variant too, though in this case it's not actually a
-    // different type because unknown ≡ unknown | undefined
-    expectTypeOf(anErr).toEqualTypeOf<Result<unknown, string>>();
+
+    expectTypeOf(anErr).toEqualTypeOf<Result<never, string>>();
     const anErrOrUndefined = ResultNS.unwrapOr(undefined, anErr);
-    expectTypeOf(anErrOrUndefined).toEqualTypeOf<unknown>(); // unknown ≡ unknown | undefined
+    expectTypeOf(anErrOrUndefined).toEqualTypeOf<undefined>(); // undefined ≡ never | undefined
     expect(anErrOrUndefined).toEqual(undefined);
   });
 
@@ -452,25 +451,25 @@ describe('`Result` pure functions', () => {
 test('narrowing', () => {
   const oneOk = ResultNS.ok();
   if (oneOk.isOk) {
-    expectTypeOf(oneOk).toEqualTypeOf<Ok<Unit, unknown>>();
+    expectTypeOf(oneOk).toEqualTypeOf<Ok<Unit, never>>();
     expect(oneOk.value).toBeDefined();
   }
 
   const anotherOk = ResultNS.ok();
   if (anotherOk.variant === Variant.Ok) {
-    expectTypeOf(anotherOk).toEqualTypeOf<Ok<Unit, unknown>>();
+    expectTypeOf(anotherOk).toEqualTypeOf<Ok<Unit, never>>();
     expect(anotherOk.value).toBeDefined();
   }
 
   const oneErr = ResultNS.err();
   if (oneErr.isErr) {
-    expectTypeOf(oneErr).toEqualTypeOf<Err<unknown, Unit>>();
+    expectTypeOf(oneErr).toEqualTypeOf<Err<never, Unit>>();
     expect(oneErr.error).toBeDefined();
   }
 
   const anotherErr = ResultNS.err();
   if (anotherErr.variant === Variant.Err) {
-    expectTypeOf(anotherErr).toEqualTypeOf<Err<unknown, Unit>>();
+    expectTypeOf(anotherErr).toEqualTypeOf<Err<never, Unit>>();
     expect(anotherErr.error).toBeDefined();
   }
 
@@ -504,7 +503,7 @@ describe('`Ok` instance', () => {
     let result = Result.ok('yeat');
 
     if (result.isErr) {
-      expectTypeOf<(typeof result)['error']>().toBeUnknown();
+      expectTypeOf<(typeof result)['error']>().toBeNever();
     }
     if (result.isOk) {
       // @ts-expect-error
@@ -565,7 +564,7 @@ describe('`Ok` instance', () => {
   });
 
   test('`and` method', () => {
-    const theOk = Result.ok(100);
+    const theOk = Result.ok<number, string[]>(100);
 
     const anotherOk = Result.ok({ not: 'a number' });
     expect(theOk.and(anotherOk)).toBe(anotherOk);
@@ -576,7 +575,7 @@ describe('`Ok` instance', () => {
 
   test('`andThen` method', () => {
     const theValue = 'anything will do';
-    const theOk = Result.ok(theValue);
+    const theOk = Result.ok<string, number>(theValue);
     const lengthResult = (s: string) => Result.ok(s.length);
     expect(theOk.andThen(lengthResult)).toEqual(lengthResult(theValue));
 
@@ -708,6 +707,7 @@ describe('`ResultNS.Err` class', () => {
 
     const unqualifiedErr = Result.err('string');
     expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<unknown, string>>();
+    expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<never, string>>();
 
     expect(() => Result.err(null)).not.toThrow();
     expect(() => Result.err(undefined)).not.toThrow();
@@ -870,7 +870,7 @@ describe('`ResultNS.Err` class', () => {
     const b = Result.ok<string, string>('a');
     const c = Result.err<string, string>('err');
     const d = Result.err<string, string>('err');
-    expect(a.equals(b)).toBe(true);
+    expect(b.equals(a)).toBe(true);
     expect(b.equals(c)).toBe(false);
     expect(c.equals(d)).toBe(true);
   });


### PR DESCRIPTION
Fixes #788