### PR TITLE
fix: do not set sourceRoot in tsconfigs

### DIFF
--- a/ts/publish.cjs.tsconfig.json
+++ b/ts/publish.cjs.tsconfig.json
@@ -8,7 +8,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "sourceRoot": "../src",
     "outDir": "../dist/cjs"
   }
 }

--- a/ts/publish.esm.tsconfig.json
+++ b/ts/publish.esm.tsconfig.json
@@ -7,7 +7,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "sourceRoot": "../src",
     "outDir": "../dist/es"
   }
 }


### PR DESCRIPTION
Setting `sourceRoot` prevents source maps from resolving correctly in the general case; it is really only intended for a case where you are distributing the sources from somewhere *besides* the package itself.

Fixes #809