### PR TITLE
Fix vitest config for coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,10 +10,13 @@ export default defineConfig({
     coverage: {
       reporter: ['text'],
       include: ['src/**/*.ts'],
-      branches: 100,
-      functions: 100,
-      statements: 100,
-      lines: 100,
+      exclude: ['src/index.ts'],
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        statements: 100,
+        lines: 100,
+      },
     },
   },
 });


### PR DESCRIPTION
I think this was a funky case where the vitest upgrade made a breaking change to this config such that it started silently allowing lower coverage; or else we accidentally misconfigured it from the start. Either way, this fixes it.