### PR TITLE
infra: improve name of CI job for tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   tests_linux:
-    name: 'Tests: ubuntu (node@${{ matrix.node-version }})'
+    name: 'Tests: Node ${{ matrix.node-version }}'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The old naming scheme dates to when we tested on multiple operating systems, but we have not done that for years.