### PR TITLE
feature: add `unwrap` and `unwrapErr` test helpers

### DIFF
--- a/src/test-support.ts
+++ b/src/test-support.ts
@@ -1,0 +1,25 @@
+/**
+  Helpers to make it easier to test `Maybe` and `Result`.
+
+  @module
+ */
+
+import Maybe, { type Just, isInstance as isMaybe } from './maybe.js';
+import Result, { type Err, type Ok } from './result.js';
+
+/** Unwrap the contained `Just` value. Throws if `maybe` is `Nothing`. */
+export function unwrap<T>(maybe: Maybe<T>): T;
+/** Unwrap the contained `Ok` value. Throws if `result` is `Err`. */
+export function unwrap<T, E>(result: Result<T, E>): T;
+export function unwrap<T>(wrapped: Maybe<T> | Result<T, unknown>): T {
+  if (isMaybe(wrapped)) {
+    return (wrapped as Just<T>).value;
+  } else {
+    return (wrapped as Ok<T, unknown>).value;
+  }
+}
+
+/** Unwrap the contained `Err` error. Throws if `result` is `Ok`. */
+export function unwrapErr<E>(result: Result<unknown, E>): E {
+  return (result as Err<unknown, E>).error;
+}

--- a/test/test-support.test.ts
+++ b/test/test-support.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+
+import { Result, Maybe } from 'true-myth';
+import { unwrap, unwrapErr } from 'true-myth/test-support';
+
+describe('`unwrap`', () => {
+  test('works on a `Just`', () => {
+    let it = Maybe.of('hello');
+    let unwrapped = unwrap(it);
+    expect(unwrapped).toBe('hello');
+    expectTypeOf(unwrapped).toBeString();
+  });
+
+  test('throws on a `Nothing`', () => {
+    let it = Maybe.nothing<string>();
+    expect(() => unwrap(it)).toThrow();
+  });
+
+  test('works on an `Ok`', () => {
+    let it = Result.ok('hello');
+    let unwrapped = unwrap(it);
+    expect(unwrapped).toBe('hello');
+    expectTypeOf(unwrapped).toBeString();
+  });
+});
+
+describe('`unwrapErr`', () => {
+  test('throws on an `Ok`', () => {
+    let it = Result.ok('hello');
+    expect(() => unwrapErr(it)).toThrow();
+  });
+
+  test('unwrap throws on a Nothing', () => {
+    let it = Result.err('oh no');
+    let unwrapped = unwrapErr(it);
+    expect(unwrapped).toBe('oh no');
+    expectTypeOf(unwrapped).toBeString();
+  });
+});


### PR DESCRIPTION
Long ago, we had methods which did this:

- `Maybe.prototype.unsafelyUnwrap`
- `Result.prototype.unsafelyUnwrap`
- `Result.prototype.unsafelyUnwrapErr`

We removed these when we made it possible to directly access `.value` and (for `Result`) `.error` after narrowing, because that is always safe to do and guides users toward a happy path. However, it can be rather annoying for tests, not least for tests where “does this return the correct variant” is the thing under test!

Because we want to continue to encourage the safe path as the happy path and to avoid adding any bloat to the payload for users who do *not* use these, add `unwrap` and `unwrapErr` functions to a new `test-support` module. The `unwrap` function is polymorphic; it works correctly with both `Maybe` and `Result`. For obvious reasons, `unwrapErr` only applies to a `Result`.

Fixes #817