### PR TITLE
feature: implement a new `Task` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 
 
+
+## 8.2.0-beta.1 (2024-12-31)
+
+Beta release with `Task`, so folks can easily test it out!
+
+#### :bug: Bug Fix
+* [#887](https://github.com/true-myth/true-myth/pull/887) Result: correct the implementation of `static err` constructor ([@chriskrycho](https://github.com/chriskrycho))
+
+#### :memo: Documentation
+* [#886](https://github.com/true-myth/true-myth/pull/886) docs/internals: `Task`-inspired improvements ([@chriskrycho](https://github.com/chriskrycho))
+* [#881](https://github.com/true-myth/true-myth/pull/881) docs: remove long-defunct reference to `new` from `Result.(ok|err)` ([@chriskrycho](https://github.com/chriskrycho))
+
+#### :house: Internal
+* [#886](https://github.com/true-myth/true-myth/pull/886) docs/internals: `Task`-inspired improvements ([@chriskrycho](https://github.com/chriskrycho))
+
+#### Committers: 1
+- Chris Krycho ([@chriskrycho](https://github.com/chriskrycho))
+
 ## 8.1.0 (2024-12-04)
 
 The big feature: a new module just for test support, with two functions in it: `unwrap` and `unwrapErr`. You can now write this:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/true-myth/true-myth/issues"
   },
-  "version": "8.1.0",
+  "version": "8.2.0-beta.1",
   "type": "module",
   "main": "dist/es/index.js",
   "module": "dist/es/index.js",

--- a/src/doc/task.md
+++ b/src/doc/task.md
@@ -1,0 +1,143 @@
+# Task
+
+A `Task<T, E>` is a type representing the state of an asynchronous computation which may fail, with a successful value of type `T` or an error of type `E`. It has three states:
+
+- `Pending`
+- `Resolved`, with a value of type `T`
+- `Rejected`, with a reason of type `E`
+
+In general, however, because of the asynchronous nature of a `Task`, you will interact with it via its methods, rather than matching on its state, since you generally want to perform an operation once it has resolved.
+
+You can think of a `Task<T, E>` as being basically a `Promise<Result<T, E>>`, because it *is* a `Promise<Result<T, E>>` under the hood, but with two main differences:
+
+1. A `Task` cannot *reject*. All rejections must be handled. This means that, like a `Result`, it will *never* throw an error if used in strict TypeScript.
+
+2. Unlike `Promise`, `Task` robustly distinguishes between `map` and `andThen` operations.
+
+`Task` also implements JavaScript’s `PromiseLike` interface, so you can`await` it; when a `Task<T, E>` is awaited, it produces a `Result<T, E>`.
+
+## Creating a `Task`
+
+The simplest way to create a `Task` is to call `Task.try(somePromise)`. Because any promise may reject/throw an error, this simplest form catches all rejections and maps them into the `Rejected` variant. Given a `Promise<T>`, the resulting `Task` thus has the type `Task<T, unknown>`. For example:
+
+```ts
+let { promise, reject } = Promise.withResolvers<number>();
+
+// `theTask` has the type `Task<number, unknown>`
+let theTask = Task.try(promise);
+
+// The rejection will always produce
+reject("Tasks always safely handle errors!");
+await theTask;
+console.log(theTask.state); // State.Rejected
+
+// The `reason` here is of type `unknown`. Attempting to access it on a pending
+// or resolved `Task` (rather than a rejected `Task`) will throw an error.
+console.log(theTask.reason); // "Tasks always safely handle errors!"
+```
+
+You can also provide a fallback value for the error using `tryOr`:
+
+```ts
+let { promise, reject } = Promise.withResolvers<number>();
+
+// `theTask` has the type `Task<number, string>`
+let theTask = Task.tryOr(promise, "a fallback error");
+
+reject({ thisStructuredObject: "will be ignored!" });
+await theTask;
+
+console.log(theTask.reason); // "a fallback error"
+```
+
+You can use `Task.tryOrElse` to produce a known rejection reason from the `unknown` rejection reason of a `Promise`:
+
+```ts
+let { promise, reject } = Promise.withResolvers<number>();
+
+// `theTask` has the type `Task<number, Error>`
+let theTask = Task.tryOrElse(
+  promise,
+  (reason) => new Error("Promise was rejected", { cause: reason })
+);
+```
+
+`Task` also has `resolved` and `rejected` static helpers:
+
+```ts
+// `resolved` has the type `Task<number, never>`
+let resolved = Task.resolved(123);
+
+// `rejected` has the type `Task<never, string>`
+let rejected = Task.rejected("something went wrong");
+```
+
+
+## Working with a `Task`
+
+There are many helpers (“combinators”) for working with a `Task`. The most common are `map`, `mapRejected`, `andThen`, and `orElse`.
+
+- `map` transforms a value “within” a `Task` context:
+
+    ```ts
+    let theTask = Task.resolved(123);
+    let doubled = theTask.map((n) => n * 2);
+    let theResult = await doubled;
+    console.log(theResult); // Ok(456)
+    ```
+
+- `mapRejected` does the same, but for a rejection:
+
+    ```ts
+    let theTask = Task.rejected(new Error("ugh"));
+    let wrapped = theTask.mapRejected(
+      (err) => new Error(`sigh (caused by: ${err.message})`)
+    );
+    let theResult = await wrapped;
+    console.log(theResult); // Err("Error: sigh (caused by: ugh)")
+    ```
+
+- `andThen` uses the value produced by one resolved `Task` to create another `Task`, but without nesting them. `orElse` is like `andThen`, but for the `Rejection`. You can often combine them to good effect. For example, a safe `fetch` usage might look like this:
+
+    ```ts
+    const USERS = "..."; // some endpoint
+    let fetchUsersTask = Task.try(fetch(USERS))
+      .orElse(handleError('http'))
+      .andThen((res) => Task.try(res.json().orElse(handleError('parse')))
+      .match({
+        Resolved: (users) => {
+          for (let user of users) {
+            console.log(user);
+          }
+        },
+        Rejected: (error) => {
+          let currentError = error;
+          console.error(currentError.message)
+          while (currentError = currentError.cause) {
+            console.error(currentError.message);
+          }
+        },
+      });
+      
+    let usersResult = await fetchUsersTask;
+    usersResult.match({
+      Ok: (users) => 
+    });
+    for (let user of users) {
+      // ...
+    }
+    
+    function handleError(name: string): (error: unknown) => Error {
+      return new Error(`my-lib.${name}`, { cause: error });
+    }
+    ```
+
+- 
+
+There are many others; see the API docs!
+
+## Timing
+
+Because `Task` wraps `Promise`, it (currently) always requires *at least* two ticks of the microtask queue before it will produce its final state. In practical terms, you must *always* `await` a `Task` before its `state` will be `Resolved` or `Rejected`, even with `Task.resolved` and `Task.rejected`. If the (Stage 1) [Faster Promise Adoption][fpa] TC39 proposal is adopted, this *may* change/improve.
+
+[fpa]: https://github.com/tc39/proposal-faster-promise-adoption

--- a/src/doc/task.md
+++ b/src/doc/task.md
@@ -100,8 +100,7 @@ There are many helpers (“combinators”) for working with a `Task`. The most c
 - `andThen` uses the value produced by one resolved `Task` to create another `Task`, but without nesting them. `orElse` is like `andThen`, but for the `Rejection`. You can often combine them to good effect. For example, a safe `fetch` usage might look like this:
 
     ```ts
-    const USERS = "..."; // some endpoint
-    let fetchUsersTask = Task.try(fetch(USERS))
+    let fetchUsersTask = Task.try(fetch(/* some endpoint */))
       .orElse(handleError('http'))
       .andThen((res) => Task.try(res.json().orElse(handleError('parse')))
       .match({
@@ -118,21 +117,27 @@ There are many helpers (“combinators”) for working with a `Task`. The most c
           }
         },
       });
-      
+
     let usersResult = await fetchUsersTask;
     usersResult.match({
-      Ok: (users) => 
+      Ok: (users) => {
+        for (let user of users) {
+          console.log(user);
+        }
+      },
+      Err: (error) => {
+        let currentError = error;
+        console.error(currentError.message)
+        while (currentError = currentError.cause) {
+          console.error(currentError.message);
+        }
+      }
     });
-    for (let user of users) {
-      // ...
-    }
-    
+
     function handleError(name: string): (error: unknown) => Error {
       return new Error(`my-lib.${name}`, { cause: error });
     }
     ```
-
-- 
 
 There are many others; see the API docs!
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,6 @@ export * as ResultNS from './result.js';
 
 export { default as Unit } from './unit.js';
 
+export { default as Task } from './task.js';
+
 export * as Toolbelt from './toolbelt.js';

--- a/src/task.ts
+++ b/src/task.ts
@@ -863,6 +863,10 @@ type TaskConstructor = Omit<typeof TaskImpl, 'constructor'> & {
   ): Task<T, E>;
 };
 
+// Duplicate documentation because it will show up more nicely when rendered in
+// TypeDoc than if it applies to only one or the other; using `@inheritdoc` will
+// also work but works less well in terms of how editors render it (they do not
+// process that “directive” in general).
 /**
   A `Task` is a type safe asynchronous computation.
 
@@ -880,9 +884,30 @@ type TaskConstructor = Omit<typeof TaskImpl, 'constructor'> & {
   `Task` also implements JavaScript’s `PromiseLike` interface, so you can
   `await` it; when a `Task<T, E>` is awaited, it produces a {@linkcode result
   Result<T, E>}.
+
+  @group Task
  */
 export const Task = TaskImpl as TaskConstructor;
 
-/** @inheritdoc Task */
+/**
+  A `Task` is a type safe asynchronous computation.
+
+  You can think of a `Task<T, E>` as being basically a `Promise<Result<T, E>>`,
+  because it *is* a `Promise<Result<T, E>>` under the hood, but with two main
+  differences from a “normal” `Promise`:
+
+  1. A `Task` *cannot* “reject”. All errors must be handled. This means that,
+     like a {@linkcode Result}, it will *never* throw an error if used in
+     strict TypeScript.
+
+  2. Unlike `Promise`, `Task` robustly distinguishes between `map` and `andThen`
+     operations.
+
+  `Task` also implements JavaScript’s `PromiseLike` interface, so you can
+  `await` it; when a `Task<T, E>` is awaited, it produces a {@linkcode result
+  Result<T, E>}.
+
+  @group Task
+ */
 export type Task<T, E> = Pending<T, E> | Resolved<T, E> | Rejected<T, E>;
 export default Task;

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,0 +1,851 @@
+/**
+  {@include doc/task.md}
+
+  @module
+ */
+
+import { safeToString } from './-private/utils.js';
+import Result, { map as mapResult, mapErr, match as matchResult } from './result.js';
+import Unit from './unit.js';
+
+/**
+  A `Task` is a type safe asynchronous computation.
+
+  You can think of a `Task<T, E>` as being basically a `Promise<Result<T, E>>`,
+  because it *is* a `Promise<Result<T, E>>` under the hood, but with two main
+  differences from a “normal” `Promise`:
+
+  1. A `Task` *cannot* “reject”. All errors must be handled. This means that,
+     like a {@linkcode Result}, it will *never* throw an error if used in
+     strict TypeScript.
+
+  2. Unlike `Promise`, `Task` robustly distinguishes between `map` and `andThen`
+     operations.
+
+  `Task` also implements JavaScript’s `PromiseLike` interface, so you can
+  `await` it; when a `Task<T, E>` is awaited, it produces a {@linkcode result
+  Result<T, E>}.
+ */
+export class Task<T, E> implements PromiseLike<Result<T, E>> {
+  readonly #promise: Promise<Result<T, E>>;
+  #state: Repr<T, E> = [State.Pending];
+
+  // TODO: handle a case where the executor *throws an error itself*. That is
+  // not trivial to see what should happen: in the case of `Promise`, it gets
+  // folded into the resulting rejection, but it also does not have to try to
+  // account for the type of the rejection!
+  /**
+    Construct a new `Task`, using callbacks to wrap APIs which do not natively
+    provide a `Promise`.
+
+    This is identical to the [Promise][promise] constructor, with one very
+    important difference: rather than producing a value upon resolution and
+    throwing an exception when a rejection occurs like `Promise`, a `Task`
+    always “succeeds” in producing a usable value, just like {@linkcode Result}
+    for synchronous code.
+
+    [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise
+
+    For constructing a `Task` from an existing `Promise`, see:
+
+    - {@linkcode Task.try}
+    - {@linkcode Task.tryOr}
+    - {@linkcode Task.tryOrElse}
+
+    For constructing a `Task` immediately resolved or rejected with given
+    values, see {@linkcode Task.resolved} and {@linkcode Task.rejected}
+    respectively.
+
+    @param executor A function which the constructor will execute to manage
+      the lifecycle of the `Task`. The executor in turn has two functions as
+      parameters: one to call on resolution, the other on rejection.
+   */
+  constructor(executor: (resolve: (value: T) => void, reject: (reason: E) => void) => void) {
+    this.#promise = new Promise<Result<T, E>>((resolve) =>
+      executor(
+        (value) => {
+          this.#state = [State.Resolved, value];
+          resolve(Result.ok(value));
+        },
+        (reason) => {
+          this.#state = [State.Rejected, reason];
+          resolve(Result.err(reason));
+        }
+      )
+    );
+  }
+
+  // Implement `PromiseLike`; this allows `await someTask` to “just work” and to
+  // produce the resulting `Result<A, B>`. It also powers the mechanics of things
+  // like `andThen` below, since it makes it possible to use JS’ implicit
+  // unwrapping of “thenables” to produce new `Task`s even when there is an
+  // intermediate `Promise`.
+  then<A, B>(
+    onSuccess?: (result: Result<T, E>) => A | PromiseLike<A>,
+    onRejected?: (reason: unknown) => B | PromiseLike<B>
+  ): PromiseLike<A | B> {
+    return this.#promise.then(onSuccess, onRejected);
+  }
+
+  toString() {
+    switch (this.#state[0]) {
+      case State.Pending:
+        return 'Task.Pending';
+
+      case State.Resolved:
+        return `Task.Resolved(${safeToString(this.#state[1])})`;
+
+      case State.Rejected:
+        return `Task.Rejected(${safeToString(this.#state[1])})`;
+
+      /* v8 ignore next 2 */
+      default:
+        unreachable(this.#state);
+    }
+  }
+
+  /**
+    Produce a `Task<T, E>` from a promise of a {@linkcode Result Result<T, E>}.
+
+    > [!WARNING]
+    > This constructor assumes you have already correctly handled the promise
+    > rejection state, presumably by mapping it into the wrapped `Result`. It is
+    > *unsafe* for this promise ever to reject! You should only ever use this
+    > with `Promise<Result<T, E>>` you have created yourself (including via a
+    > `Task`, of course).
+    >
+    > For any other `Promise<Result<T, E>>`, you should first attach a `catch`
+    > handler which will also produce a `Result<T, E>`.
+    >
+    > If you call this with an unmanaged `Promise<Result<T, E>>`, that is, one
+    > that has *not* correctly set up a `catch` handler, the rejection will
+    > throw an {@linkcode UnsafePromise} error that will ***not*** be catchable
+    > by awaiting the `Task` or its original `Promise`. This can cause test
+    > instability and unpredictable behavior in your application.
+
+    @param promise The promise from which to create the `Task`.
+
+    @group Constructors
+   */
+  static unsafeTrusted<T, E>(promise: Promise<Result<T, E>>): Task<T, E> {
+    return new Task((resolve, reject) => {
+      promise.then(
+        matchResult({
+          Ok: resolve,
+          Err: reject,
+        }),
+        (rejectionReason: unknown) => {
+          throw new UnsafePromise(rejectionReason);
+        }
+      );
+    });
+  }
+
+  /**
+    Produce a `Task<T, unknown>` from a promise.
+
+    To handle the error case and produce a concrete `Task<T, E>` instead, use
+    the overload which accepts an `onRejection` handler instead.
+
+    @param promise The promise from which to create the `Task`.
+
+    @group Constructors
+   */
+  static try<T>(promise: Promise<T>): Task<T, unknown> {
+    return new Task((resolve, reject) => {
+      promise.then(resolve, reject);
+    });
+  }
+
+  /**
+    Produce a `Task<T, E>` from a `Promise<T>` and use a fallback value if the
+    task rejects, ignoring the rejection reason.
+
+    Notes:
+
+    - To leave any error as `unknown`, use the overload which accepts only the
+      promise.
+    - To handle the rejection reason rather than ignoring it, use the overload
+      which accepts a function.
+
+    @param promise The promise from which to create the `Task`.
+    @param onRejection A function to transform an unknown rejection reason into
+      a known `E`.
+
+    @group Constructors
+   */
+  static tryOr<T, E>(promise: Promise<T>, rejectionValue: E): Task<T, E> {
+    return new Task((resolve, reject) => {
+      promise.then(resolve, (_reason) => reject(rejectionValue));
+    });
+  }
+
+  /**
+    Produce a `Task<T, E>` from a `Promise<T>` and a function to transform an
+    unknown error to `E`.
+
+    To leave any error as `unknown`, use the overload which accepts only the
+    promise.
+
+    @param promise The promise from which to create the `Task`.
+    @param onRejection A function to transform an unknown rejection reason into
+      a known `E`.
+
+    @group Constructors
+   */
+  static tryOrElse<T, E>(promise: Promise<T>, onRejection: (reason: unknown) => E): Task<T, E> {
+    return new Task((resolve, reject) => {
+      promise.then(resolve, (reason) => reject(onRejection(reason)));
+    });
+  }
+
+  /**
+    Construct a `Task` which is already resolved. Useful when you have a value
+    already, but need it to be available in an API which expects a `Task`.
+
+    @group Constructors
+   */
+  static resolved<T extends Unit, E = never>(): Task<Unit, E>;
+  /**
+    Construct a `Task` which is already resolved. Useful when you have a value
+    already, but need it to be available in an API which expects a `Task`.
+
+    @group Constructors
+   */
+  static resolved<T, E = never>(value: T): Task<T, E>;
+  // The implementation is intentionally vague about the types: we do not know
+  // and do not care what the actual types in play are at runtime; we just need
+  // to uphold the contract. Because the overload matches the types above, the
+  // *call site* will guarantee the safety of the resulting types.
+  static resolved(value?: {}): Task<unknown, unknown> {
+    // We produce `Unit` *only* in the case where no arguments are passed, so
+    // that we can allow `undefined` in the cases where someone explicitly opts
+    // into something like `Result<undefined, Blah>`.
+    let result = arguments.length === 0 ? Unit : value;
+    return new Task((resolve) => resolve(result));
+  }
+
+  /**
+    Construct a `Task` which is already rejected. Useful when you have an error
+    already, but need it to be available in an API which expects a `Task`.
+
+    @group Constructors
+   */
+  static rejected<T = never, E extends {} = {}>(): Task<T, Unit>;
+  /**
+    Construct a `Task` which is already rejected. Useful when you have an error
+    already, but need it to be available in an API which expects a `Task`.
+
+    @group Constructors
+   */
+  static rejected<T = never, E = unknown>(reason: E): Task<T, E>;
+  // The implementation is intentionally vague about the types: we do not know
+  // and do not care what the actual types in play are at runtime; we just need
+  // to uphold the contract. Because the overload matches the types above, the
+  // *call site* will guarantee the safety of the resulting types.
+  static rejected(reason?: {}): Task<unknown, unknown> {
+    // We produce `Unit` *only* in the case where no arguments are passed, so
+    // that we can allow `undefined` in the cases where someone explicitly opts
+    // into something like `Result<Blah, undefined>`.
+    let result = arguments.length === 0 ? Unit : reason;
+    return new Task((_, reject) => reject(result));
+  }
+
+  static fromResult<T, E>(result: Result<T, E>): Task<T, E> {
+    return new Task((resolve, reject) =>
+      result.match({
+        Ok: resolve,
+        Err: reject,
+      })
+    );
+  }
+
+  /**
+    Create a pending `Task` and supply `resolveWith` and `rejectWith` helpers,
+    similar to the [`Promise.withResolvers`][pwr] static method, but producing a
+    `Task` with the usual safety guarantees.
+
+    [pwr]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
+
+    ## Examples
+
+    ### Resolution
+
+    ```ts
+    let { task, resolveWith, rejectWith } = Task.withResolvers<string, Error>();
+    resolveWith("Hello!");
+
+    let result = await task.map((s) => s.length);
+    let length = result.unwrapOr(0);
+    console.log(length); // 5
+    ```
+
+    ### Rejection
+
+    ```ts
+    let { task, resolveWith, rejectWith } = Task.withResolvers<string, Error>();
+    rejectWith(new Error("oh teh noes!"));
+
+    let result = await task.mapRejection((s) => s.length);
+    let errLength = result.isErr ? result.error : 0;
+    console.log(errLength); // 5
+    ```
+
+    @group Constructors
+   */
+  static withResolvers<T, E>(): WithResolvers<T, E> {
+    let resolveWith!: WithResolvers<T, E>['resolveWith'];
+    let rejectWith!: WithResolvers<T, E>['rejectWith'];
+    let task = new Task<T, E>((resolve, reject) => {
+      resolveWith = resolve;
+      rejectWith = reject;
+    });
+    return { task, resolveWith, rejectWith };
+  }
+
+  get state(): State {
+    return this.#state[0];
+  }
+
+  isPending(): this is Pending<T, E> {
+    return this.#state[0] === State.Pending;
+  }
+
+  isResolved(): this is Resolved<T, E> {
+    return this.#state[0] === State.Resolved;
+  }
+
+  isRejected(): this is Rejected<T, E> {
+    return this.#state[0] === State.Rejected;
+  }
+
+  /**
+    The value of a resolved `Task`.
+
+    > [!WARNING]
+    > It is an error to access this property on a `Task` which is `Pending` or
+    > `Rejected`.
+   */
+  get value(): T {
+    if (this.#state[0] === State.Resolved) {
+      return this.#state[1];
+    }
+
+    throw new InvalidAccess('value', this.#state[0]);
+  }
+
+  /**
+    The cause of a rejection.
+
+    > [!WARNING]
+    > It is an error to access this property on a `Task` which is `Pending` or
+    > `Resolved`.
+   */
+  get reason(): E {
+    if (this.#state[0] === State.Rejected) {
+      return this.#state[1];
+    }
+
+    throw new InvalidAccess('reason', this.#state[0]);
+  }
+
+  /**
+    Map over a {@linkcode Task} instance: apply the function to the resolved
+    value if the task completes successfully, producing a new `Task` with the
+    value returned from the function. If the task failed, return the rejection
+    as {@linkcode Rejected} without modification.
+
+    `map` works a lot like [`Array.prototype.map`][array-map], but with one
+    important difference. Both `Task` and `Array` are kind of like a “container”
+    for other kinds of items, but where `Array.prototype.map` has 0 to _n_
+    items, a `Task` represents the possibility of an item being available at
+    some point in the future, and when it is present, it is *either* a success
+    or an error.
+
+    [array-map]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
+
+    Where `Array.prototype.map` will apply the mapping function to every item in
+    the array (if there are any), `Task.map` will only apply the mapping
+    function to the resolved element if it is `Resolved`.
+
+    If you have no items in an array of numbers named `foo` and call `foo.map(x
+    => x + 1)`, you'll still some have an array with nothing in it. But if you
+    have any items in the array (`[2, 3]`), and you call `foo.map(x => x + 1)`
+    on it, you'll get a new array with each of those items inside the array
+    "container" transformed (`[3, 4]`).
+
+    With this `map`, the `Rejected` variant is treated *by the `map` function*
+    kind of the same way as the empty array case: it's just ignored, and you get
+    back a new `Task` that is still just the same `Rejected` instance. But if
+    you have an `Resolved` variant, the map function is applied to it, and you
+    get back a new `Task` with the value transformed, and still `Resolved`.
+
+    ## Examples
+
+    ```ts
+    import Task from 'true-myth/task';
+    const double = n => n * 2;
+
+    const aResolvedTask = Task.resolved(12);
+    const mappedResolved = aResolvedTask.map(double);
+    let resolvedResult = await aResolvedTask;
+    console.log(resolvedResult.toString()); // Ok(24)
+
+    const aRejectedTask = Task.rejected("nothing here!");
+    const mappedRejected = map(double, aRejectedTask);
+    let rejectedResult = await aRejectedTask;
+    console.log(rejectedResult.toString()); // Err("nothing here!")
+    ```
+
+    @template T The type of the resolved value.
+    @template U The type of the resolved value of the returned `Task`.
+    @param mapFn The function to apply the value to when the `Task` finishes if
+      it is `Resolved`.
+   */
+  map<U>(mapFn: (t: T) => U): Task<U, E> {
+    return Task.unsafeTrusted(this.#promise.then(mapResult(mapFn)));
+  }
+
+  /**
+    Map over a {@linkcode Task}, exactly as in {@linkcode map}, but operating on
+    the rejection reason if the `Task` rejects, producing a new `Task`, still
+    rejected, with the value returned from the function. If the task completed
+    successfully, return it as `Resolved` without modification. This is handy
+    for when you need to line up a bunch of different types of errors, or if you
+    need an error of one shape to be in a different shape to use somewhere else
+    in your codebase.
+
+    ## Examples
+
+    ```ts
+    import Task from 'true-myth/task';
+
+    const extractReason = (err: { code: number, reason: string }) => err.reason;
+
+    const aResolvedTask = Task.resolved(12);
+    const mappedResolved = aResolvedTask.mapErr(extractReason);
+    console.log(mappedOk));  // Ok(12)
+
+    const aRejectedTask = Task.rejected({ code: 101, reason: 'bad file' });
+    const mappedRejection = await aRejectedTask.map(extractReason);
+    console.log(toString(mappedRejection));  // Err("bad file")
+    ```
+
+    @template T The type of the value produced if the `Task` resolves.
+    @template E The type of the rejection reason if the `Task` rejects.
+    @template F The type of the rejection for the new `Task`, returned by the
+      `mapFn`.
+    @param mapFn The function to apply to the rejection reason if the `Task` is
+      rejected.
+    @param result   The `Result` instance to map over an error case for.
+   */
+  mapRejected<F>(mapFn: (e: E) => F): Task<T, F> {
+    return Task.unsafeTrusted(this.#promise.then(mapErr(mapFn)));
+  }
+
+  /**
+    You can think of this like a short-circuiting logical "and" operation on a
+    {@linkcode Task}. If this `task` resolves, then the output is the task
+    passed to the method. If this `task` rejects, the result is its rejection
+    reason.
+
+    This is useful when you have another `Task` value you want to provide if and
+    *only if* the first task resolves successfully – that is, when you need to
+    make sure that if you reject, whatever else you're handing a `Task` to
+    *also* gets that {@linkcode Rejection}.
+
+    Notice that, unlike in {@linkcode Task.map}, the original `task`
+    resolution value is not involved in constructing the new `Task`.
+
+    ## Examples
+
+    ```ts
+    let resolvedA = Task.resolved<string, string>('A');
+    let resolvedB = Task.resolved<string, string>('B');
+    let rejectedA = Task.rejected<string, string>('bad');
+    let rejectedB = Task.rejected<string, string>('lame');
+
+    let aAndB = resolvedA.and(resolvedB);
+    await aAndB;
+
+    let aAndRA = resolvedA.and(rejectedA);
+    await aAndRA;
+
+    let raAndA = rejectedA.and(resolvedA);
+    await raAndA;
+
+    let raAndRb = rejectedA.and(rejectedB);
+    await raAndRb;
+
+    expect(aAndB.toString()).toEqual('Task.Resolved("B")');
+    expect(aAndRA.toString()).toEqual('Task.Rejected("bad")');
+    expect(raAndA.toString()).toEqual('Task.Rejected("bad")');
+    expect(raAndRb.toString()).toEqual('Task.Rejected("bad")');
+    ```
+
+    @template U The type of the value for a resolved version of the `other`
+      `Task`, i.e., the success type of the final `Task` present if the first
+      `Task` is `Ok`.
+
+    @param other The `Result` instance to return if `result` is `Err`.
+   */
+  and<U>(other: Task<U, E>): Task<U, E> {
+    return new Task((resolve, reject) => {
+      this.#promise.then(
+        matchResult({
+          Ok: (_) => {
+            other.#promise.then(
+              matchResult({
+                Ok: resolve,
+                Err: reject,
+              })
+            );
+          },
+          Err: reject,
+        })
+      );
+    });
+  }
+
+  /**
+    Apply a function to the resulting value if a {@linkcode Task} is {@linkcode
+    Resolved}, producing a new `Task`; or if it is {@linkcode Rejected} return
+    the rejection reason unmodified.
+
+    This differs from `map` in that `thenFn` returns another `Task`. You can use
+    `andThen` to combine two functions which *both* create a `Task` from an
+    unwrapped type.
+
+    The [`Promise.prototype.then`][then] method a helpful comparison: if you
+    have a `Promise`, you can pass its `then` method a callback which returns
+    another `Promise`, and the result will not be a *nested* promise, but a
+    single `Promise`. The difference is that `Promise.prototype.then` unwraps
+    *all* layers to only ever return a single `Promise` value, whereas this
+    method will not unwrap nested `Task`s.
+
+    `Promise.prototype.then` also acts the same way {@linkcode Task.map map}
+    does, while `Task` distinguishes `map` from `andThen`.
+
+    > [!NOTE] `andThen` is sometimes also known as `bind`, but *not* aliased as
+    > such because [`bind` already means something in JavaScript][bind].
+
+    [then]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+    [bind]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+
+    ## Examples
+
+    ```ts
+    import Task from 'true-myth/task';
+
+    const toLengthAsResult = (s: string) => ok(s.length);
+
+    const aResolvedTask = Task.resolved('just a string');
+    const lengthAsResult = await aResolvedTask.andThen(toLengthAsResult);
+    console.log(lengthAsResult.toString());  // Ok(13)
+
+    const aRejectedTask = Task.rejected(['srsly', 'whatever']);
+    const notLengthAsResult = await aRejectedTask.andThen(toLengthAsResult);
+    console.log(notLengthAsResult.toString());  // Err(srsly,whatever)
+    ```
+
+    @template T The type of the value produced if the `Task` resolves.
+    @template U The type of the value produced by the new `Task` of the `Result`
+      returned by the `thenFn`.
+    @template E  The type of the value wrapped in the `Err` of the `Result`.
+    @param thenFn  The function to apply to the wrapped `T` if `maybe` is `Just`.
+    @param result  The `Maybe` to evaluate and possibly apply a function to.
+   */
+  andThen<U>(thenFn: (t: T) => Task<U, E>): Task<U, E> {
+    return new Task((resolve, reject) => {
+      this.#promise.then(
+        matchResult({
+          Ok: (value) =>
+            // This is a little annoying: there is no direct way to return the
+            // resulting `Task` value here because of the intermediate `Promise`
+            // and the resulting asynchrony. This is a direct consequences of
+            // the fact that what `Task` is, `Promise` really should be in the
+            // first place! We have to basically “unwrap” the inner `Result`,
+            // but to do that, we have to wait for the intermediate `Promise` to
+            // resolve so that the inner `Result` is available so it can in turn
+            // be used with the top-most `Task`’s resolution/rejection helpers!
+            thenFn(value).#promise.then(
+              matchResult({
+                Ok: resolve,
+                Err: reject,
+              })
+            ),
+          Err: reject,
+        })
+      );
+    });
+  }
+
+  /**
+    Provide a fallback for a given {@linkcode Task}. Behaves like a logical
+    `or`: if the `task` value is {@linkcode Resolved}, returns that `task`
+    unchanged, otherwise, returns the `other` `Task`.
+
+    This is useful when you want to make sure that something which takes a
+    `Result` always ends up getting an `Ok` variant, by supplying a default value
+    for the case that you currently have an {@linkcode Err}.
+
+    ```ts
+    import { ok, err, Result, or } from 'true-utils/result';
+
+    const okA = ok<string, string>('a');
+    const okB = ok<string, string>('b');
+    const anErr = err<string, string>(':wat:');
+    const anotherErr = err<string, string>(':headdesk:');
+
+    console.log(or(okB, okA).toString());  // Ok(A)
+    console.log(or(anErr, okA).toString());  // Ok(A)
+    console.log(or(okB, anErr).toString());  // Ok(B)
+    console.log(or(anotherErr, anErr).toString());  // Err(:headdesk:)
+    ```
+
+    @template T          The type wrapped in the `Ok` case of `result`.
+    @template E          The type wrapped in the `Err` case of `result`.
+    @template F          The type wrapped in the `Err` case of `defaultResult`.
+    @param defaultResult  The `Result` to use if `result` is an `Err`.
+    @param result         The `Result` instance to check.
+    @returns              `result` if it is an `Ok`, otherwise `defaultResult`.
+   */
+  or<F>(other: Task<T, F>): Task<T, F> {
+    return new Task((resolve, reject) => {
+      this.#promise.then(
+        matchResult({
+          Ok: resolve,
+          Err: (_) => {
+            other.#promise.then(
+              matchResult({
+                Ok: resolve,
+                Err: reject,
+              })
+            );
+          },
+        })
+      );
+    });
+  }
+
+  /**
+    Like {@linkcode or}, but using a function to construct the alternative
+    {@linkcode Task}.
+
+    Sometimes you need to perform an operation using the rejection reason (and
+    possibly also other data in the environment) to construct a new `Task`,
+    which may itself resolve or reject. In these situations, you can pass a
+    function (which may be a closure) as the `elseFn` to generate the fallback
+    `Result<T>`. It can then transform the data in the `Err` to something usable
+    as an {@linkcode Ok}, or generate a new {@linkcode Err} instance as
+    appropriate.
+
+    Useful for transforming failures to usable data, for trigger retries, etc.
+
+    @param elseFn The function to apply to the `Rejection` reason if the `Task`
+      rejects, to create a new `Task`.
+   */
+  orElse<F>(elseFn: (reason: E) => Task<T, F>): Task<T, F> {
+    return new Task((resolve, reject) => {
+      this.#promise.then(
+        matchResult({
+          Ok: resolve,
+          Err: (reason) => {
+            // See the discussion in `andThen` above; this is exactly the same
+            // issue, and with inverted implementation logic.
+            elseFn(reason).#promise.then(
+              matchResult({
+                Ok: resolve,
+                Err: reject,
+              })
+            );
+          },
+        })
+      );
+    });
+  }
+
+  /**
+    Allows you to produce a new value by providing functions to operate against
+    both the {@linkcode Resolved} and {@linkcode Rejected} states once the
+    {@linkcode Task} resolves.
+
+    (This is a workaround for JavaScript’s lack of native pattern-matching.)
+
+    ## Example
+
+    ```ts
+    import Task from 'true-myth/task';
+
+    let theTask = new Task<number, Error>((resolve, reject) => {
+      let value = Math.random();
+      if (value > 0.5) {
+        resolve(value);
+      } else {
+        reject(new Error(`too low: ${value}`));
+      }
+    });
+
+    // Note that we are here awaiting the `Promise` returned from the `Task`,
+    // not the `Task` itself.
+    await theTask.match({
+      Resolved: (num) => {
+        console.log(num);
+      },
+      Rejected: (err) => {
+        console.error(err);
+      },
+    });
+    ```
+
+    This can both be used to produce side effects (as here) and to produce a
+    value regardless of the resolution/rejection of the task, and is often
+    clearer than trying to use other methods. Thus, this is especially
+    convenient for times when there is a complex task output.
+
+    > [!NOTE]
+    > You could also write the above example like this, taking advantage of how
+    > awaiting a `Task` produces its inner `Result`:
+    >
+    > ```ts
+    > import Task from 'true-myth/task';
+    >
+    > let theTask = new Task<number, Error>((resolve, reject) => {
+    >   let value = Math.random();
+    >   if (value > 0.5) {
+    >     resolve(value);
+    >   } else {
+    >     reject(new Error(`too low: ${value}`));
+    >   }
+    > });
+    >
+    > let theResult = await theTask;
+    > theResult.match({
+    >   Ok: (num) => {
+    >     console.log(num);
+    >   },
+    >   Err: (err) => {
+    >     console.error(err);
+    >   },
+    > });
+    > ```
+    >
+    > Which of these you choose is a matter of taste!
+
+    @param matcher A lightweight object defining what to do in the case of each
+                   variant.
+    @param result  The `result` instance to check.
+   */
+  match<A>(matcher: Matcher<T, E, A>): Promise<A> {
+    return this.#promise.then(
+      matchResult({
+        Ok: matcher.Resolved,
+        Err: matcher.Rejected,
+      })
+    );
+  }
+
+  /**
+    Get the underlying `Promise`. Useful when you need to work with an
+    API which *requires* a `Promise`, rather than a `PromiseLike`.
+
+    Note that this maintains the invariants for a `Task` *up till the point you
+    call this function*. That is, because the resulting promise was managed by a
+    `Task`, it always resolves successfully to a `Result`. However, calling then
+    `then` or `catch` methods on that `Promise` will produce a *new* `Promise`
+    for which those guarantees do not hold.
+
+    > [!IMPORTANT]
+    > If the resulting `Promise` ever rejects, that is a ***BUG***, and you
+    > should [open an issue](https://github.com/true-myth/true-myth/issues) so
+    > we can fix it!
+   */
+  toPromise(): Promise<Result<T, E>> {
+    return this.#promise;
+  }
+}
+
+/** @group Task Variants */
+export interface Pending<T, E> extends Omit<Task<T, E>, 'value' | 'reason'> {
+  get state(): typeof State.Pending;
+}
+
+/** @group Task Variants */
+export interface Resolved<T, E> extends Omit<Task<T, E>, 'value' | 'reason'> {
+  get state(): typeof State.Resolved;
+  get value(): T;
+}
+
+/** @group Task Variants */
+export interface Rejected<T, E> extends Omit<Task<T, E>, 'value' | 'reason'> {
+  get state(): typeof State.Rejected;
+  get reason(): E;
+}
+
+export const State = {
+  Pending: 'Pending',
+  Resolved: 'Resolved',
+  Rejected: 'Rejected',
+} as const;
+
+type State = (typeof State)[keyof typeof State];
+
+type Repr<T, E> =
+  | [tag: typeof State.Pending]
+  | [tag: typeof State.Resolved, value: T]
+  | [tag: typeof State.Rejected, reason: E];
+
+type WithResolvers<T, E> = {
+  task: Task<T, E>;
+  resolveWith: (value: T) => void;
+  rejectWith: (reason: E) => void;
+};
+
+/**
+  A lightweight object defining how to handle each outcome state of a
+  {@linkcode Task}.
+ */
+export type Matcher<T, E, A> = {
+  Resolved: (value: T) => A;
+  Rejected: (reason: E) => A;
+};
+
+/**
+  An error thrown when the `Promise` passed to {@linkcode Task.unsafeTrusted}
+  rejects.
+ */
+export class UnsafePromise extends Error {
+  readonly name = 'TrueMyth.Task.UnsafePromise';
+
+  constructor(unhandledError: unknown) {
+    let explanation =
+      'If you see this message, it means someone constructed a True Myth `Task` with a `Promise<Result<T, E>` but where the `Promise` could still reject. To fix it, make sure all calls to `Task.unsafeTrusted` have a `catch` handler. Never use `Task.unsafeTrusted` with a `Promise` on which you cannot verify by inspection that it was created with a catch handler.';
+
+    super(
+      `Called 'Task.unsafeTrusted' with an unsafe promise.\n${explanation}`,
+      // TODO (v9.0): remove this.
+      // @ts-ignore -- the types for `cause` required `Error | undefined` for a
+      // while before being loosened to allow `unknown`.
+      { cause: unhandledError }
+    );
+  }
+}
+
+export class InvalidAccess extends Error {
+  readonly name = 'TrueMyth.Task.InvalidAccess';
+  constructor(field: 'value' | 'reason', state: State) {
+    super(`Tried to access 'Task.${field}' when its state was '${state}'`);
+  }
+}
+
+/** @inheritdoc Task.tryOr */
+export const tryOr = Task.tryOr;
+
+export const tryOrElse = Task.tryOrElse;
+
+/* v8 ignore next 3 */
+function unreachable(value: never): never {
+  throw new Error(`Unexpected value: ${value}`);
+}
+
+export default Task;

--- a/src/task.ts
+++ b/src/task.ts
@@ -296,13 +296,14 @@ export class Task<T, E> implements PromiseLike<Result<T, E>> {
     @group Constructors
    */
   static withResolvers<T, E>(): WithResolvers<T, E> {
-    let resolveWith!: WithResolvers<T, E>['resolveWith'];
-    let rejectWith!: WithResolvers<T, E>['rejectWith'];
-    let task = new Task<T, E>((resolve, reject) => {
-      resolveWith = resolve;
-      rejectWith = reject;
+    // SAFETY: immediately initialized via the `Task` constructor’s executor.
+    let resolve!: WithResolvers<T, E>['resolve'];
+    let reject!: WithResolvers<T, E>['reject'];
+    let task = new Task<T, E>((resolveTask, rejectTask) => {
+      resolve = resolveTask;
+      reject = rejectTask;
     });
-    return { task, resolveWith, rejectWith };
+    return { task, resolve, reject };
   }
 
   get state(): State {
@@ -799,8 +800,8 @@ type Repr<T, E> =
 
 type WithResolvers<T, E> = {
   task: Task<T, E>;
-  resolveWith: (value: T) => void;
-  rejectWith: (reason: E) => void;
+  resolve: (value: T) => void;
+  reject: (reason: E) => void;
 };
 
 /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -88,7 +88,7 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
 
     @group Constructors
    */
-  static unsafeTrusted<T, E>(promise: Promise<Result<T, E>>): Task<T, E> {
+  static fromUnsafePromise<T, E>(promise: Promise<Result<T, E>>): Task<T, E> {
     return new Task((resolve, reject) => {
       promise.then(
         matchResult({
@@ -365,7 +365,7 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
       it is `Resolved`.
    */
   map<U>(mapFn: (t: T) => U): Task<U, E> {
-    return Task.unsafeTrusted(this.#promise.then(mapResult(mapFn)));
+    return Task.fromUnsafePromise(this.#promise.then(mapResult(mapFn)));
   }
 
   /**
@@ -401,7 +401,7 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
       rejected.
    */
   mapRejected<F>(mapFn: (e: E) => F): Task<T, F> {
-    return TaskImpl.unsafeTrusted(this.#promise.then(mapErr(mapFn)));
+    return TaskImpl.fromUnsafePromise(this.#promise.then(mapErr(mapFn)));
   }
 
   /**
@@ -794,7 +794,7 @@ export class TaskExecutorException extends Error {
 }
 
 /**
-  An error thrown when the `Promise` passed to {@linkcode Task.unsafeTrusted}
+  An error thrown when the `Promise` passed to {@linkcode Task.fromUnsafePromise}
   rejects.
  */
 export class UnsafePromise extends Error {
@@ -802,10 +802,10 @@ export class UnsafePromise extends Error {
 
   constructor(unhandledError: unknown) {
     let explanation =
-      'If you see this message, it means someone constructed a True Myth `Task` with a `Promise<Result<T, E>` but where the `Promise` could still reject. To fix it, make sure all calls to `Task.unsafeTrusted` have a `catch` handler. Never use `Task.unsafeTrusted` with a `Promise` on which you cannot verify by inspection that it was created with a catch handler.';
+      'If you see this message, it means someone constructed a True Myth `Task` with a `Promise<Result<T, E>` but where the `Promise` could still reject. To fix it, make sure all calls to `Task.fromUnsafePromise` have a `catch` handler. Never use `Task.fromUnsafePromise` with a `Promise` on which you cannot verify by inspection that it was created with a catch handler.';
 
     super(
-      `Called 'Task.unsafeTrusted' with an unsafe promise.\n${explanation}`,
+      `Called 'Task.fromUnsafePromise' with an unsafe promise.\n${explanation}`,
       // TODO (v9.0): remove this.
       // @ts-ignore -- the types for `cause` required `Error | undefined` for a
       // while before being loosened to allow `unknown`.

--- a/src/task.ts
+++ b/src/task.ts
@@ -207,19 +207,19 @@ export class Task<T, E> implements PromiseLike<Result<T, E>> {
 
     @group Constructors
    */
-  static resolved<T extends Unit, E = never>(): Task<Unit, E>;
+  static resolve<T extends Unit, E = never>(): Task<Unit, E>;
   /**
     Construct a `Task` which is already resolved. Useful when you have a value
     already, but need it to be available in an API which expects a `Task`.
 
     @group Constructors
    */
-  static resolved<T, E = never>(value: T): Task<T, E>;
+  static resolve<T, E = never>(value: T): Task<T, E>;
   // The implementation is intentionally vague about the types: we do not know
   // and do not care what the actual types in play are at runtime; we just need
   // to uphold the contract. Because the overload matches the types above, the
   // *call site* will guarantee the safety of the resulting types.
-  static resolved(value?: {}): Task<unknown, unknown> {
+  static resolve(value?: {}): Task<unknown, unknown> {
     // We produce `Unit` *only* in the case where no arguments are passed, so
     // that we can allow `undefined` in the cases where someone explicitly opts
     // into something like `Result<undefined, Blah>`.
@@ -233,19 +233,19 @@ export class Task<T, E> implements PromiseLike<Result<T, E>> {
 
     @group Constructors
    */
-  static rejected<T = never, E extends {} = {}>(): Task<T, Unit>;
+  static reject<T = never, E extends {} = {}>(): Task<T, Unit>;
   /**
     Construct a `Task` which is already rejected. Useful when you have an error
     already, but need it to be available in an API which expects a `Task`.
 
     @group Constructors
    */
-  static rejected<T = never, E = unknown>(reason: E): Task<T, E>;
+  static reject<T = never, E = unknown>(reason: E): Task<T, E>;
   // The implementation is intentionally vague about the types: we do not know
   // and do not care what the actual types in play are at runtime; we just need
   // to uphold the contract. Because the overload matches the types above, the
   // *call site* will guarantee the safety of the resulting types.
-  static rejected(reason?: {}): Task<unknown, unknown> {
+  static reject(reason?: {}): Task<unknown, unknown> {
     // We produce `Unit` *only* in the case where no arguments are passed, so
     // that we can allow `undefined` in the cases where someone explicitly opts
     // into something like `Result<Blah, undefined>`.

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1,0 +1,862 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+
+import Task, { InvalidAccess, State, UnsafePromise } from 'true-myth/task';
+import Result from 'true-myth/result';
+import Unit from 'true-myth/unit';
+import { unwrap, unwrapErr } from 'true-myth/test-support';
+
+describe('`Task`', () => {
+  describe('constructor', () => {
+    test('resolve', async () => {
+      let theValue = 123;
+      let theTask = new Task<number, string>((resolve) => resolve(theValue));
+      let result = await theTask;
+      expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+      expect(result.isOk).toBe(true);
+      expect(unwrap(result)).toEqual(theValue);
+    });
+
+    test('reject', async () => {
+      let theReason = 'oh teh noes';
+      let theTask = new Task<number, string>((_, reject) => reject(theReason));
+      let result = await theTask;
+      expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+      expect(result.isErr).toBe(true);
+      expect(unwrapErr(result)).toEqual(theReason);
+    });
+  });
+
+  test('implements the `PromiseLike` API', async () => {
+    let result = await Task.try(Promise.resolve('hello'));
+    expectTypeOf(result).toEqualTypeOf<Result<string, unknown>>();
+    expect(unwrap(result)).toBe('hello');
+  });
+
+  describe('static constructors', () => {
+    describe('`try`', () => {
+      test('when the promise resolves', async () => {
+        let { promise, resolveWith } = deferred<number, never>();
+        let theTask = Task.try(promise);
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
+
+        resolveWith(123);
+        let theResult = await theTask;
+        expectTypeOf(theResult).toEqualTypeOf<Result<number, unknown>>();
+        expect(unwrap(theResult)).toBe(123);
+      });
+
+      test('when the promise rejects', async () => {
+        let { promise, rejectWith } = deferred<never, string>();
+        let theTask = Task.try(promise);
+        expectTypeOf(theTask).toEqualTypeOf<Task<never, unknown>>();
+
+        let theError = 'la';
+        rejectWith(theError);
+        let theResult = await theTask;
+        expectTypeOf(theResult).toEqualTypeOf<Result<never, unknown>>();
+        expect(unwrapErr(theResult)).toEqual(theError);
+      });
+    });
+
+    describe('`unsafeTrusted`', () => {
+      test('when the task resolves', async () => {
+        let { promise, resolveWith } = deferred<Result<number, string>, never>();
+        let theTask = Task.unsafeTrusted(promise);
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        let theInputResult = Result.ok<number, string>(123);
+        resolveWith(theInputResult);
+        let theResultingResult = await theTask;
+        expect(theResultingResult).toEqual(Result.ok(123));
+        expectTypeOf(theResultingResult).toEqualTypeOf(theInputResult);
+      });
+
+      // This jumps through some hoops to test the underlying behavior here: the
+      // way this works under the hood is that the `Task` attaches resolution
+      // and rejection callbacks to the passed promise, and in the case of the
+      // passed promise *rejecting*, it throws a specific kind of error, but it
+      // does so in a promise which is nowhere else exposed, so it is actually
+      // *impossible to catch* other than with this kind of top-level unhandled
+      // error catching mechanism.
+      test('when the task rejects', async () => {
+        // Wire up a promise to wait on this so we can make the test wait till
+        // this is done before exiting. Otherwise, the promise may leak across
+        // tests.
+        let processPromise = new Promise((resolve) => {
+          process.on('unhandledRejection', (error) => {
+            resolve(error);
+          });
+        });
+
+        let { promise, rejectWith } = deferred<Result<number, string>, unknown>();
+        let theTask = Task.unsafeTrusted(promise);
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        let theReason = 'not good';
+        try {
+          // Yes, we must explicitly await both the task and the original
+          // promise, or else the error will not show up deterministically.
+          rejectWith(theReason);
+          await promise;
+          await theTask;
+        } catch (e) {
+          expect(e).toEqual(theReason);
+        }
+
+        let output = await processPromise;
+        expect(output).toBeInstanceOf(UnsafePromise);
+        expect.assertions(2);
+      });
+    });
+
+    describe('`tryOr`', () => {
+      test('when the task resolves', async () => {
+        let { promise, resolveWith } = deferred<number, string>();
+        let theTask = Task.tryOr(promise, 'lolnope');
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        resolveWith(123);
+        let result = await theTask;
+        expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+        expect(unwrap(result)).toBe(123);
+      });
+
+      test('when the task rejects', async () => {
+        let { promise, rejectWith } = deferred<number, string>();
+        let theTask = Task.tryOr(promise, 'lolnope');
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        rejectWith('<this value does not matter>');
+        let result = await theTask;
+        expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+        expect(unwrapErr(result)).toBe('lolnope');
+      });
+    });
+
+    describe('`tryOrElse', () => {
+      test('when the task resolves', async () => {
+        let { promise, resolveWith } = deferred<number, never>();
+        let theTask = Task.tryOrElse(promise, stringify);
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        resolveWith(123);
+        let result = await theTask;
+        expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+        expect(unwrap(result)).toBe(123);
+      });
+
+      test('when the task rejects', async () => {
+        let { promise, rejectWith } = deferred<number, string>();
+        let theTask = Task.tryOrElse(promise, stringify);
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        let theError = 'oh teh noes';
+        rejectWith(theError);
+        let result = await theTask;
+        expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+        expect(unwrapErr(result)).toBe(stringify(theError));
+      });
+    });
+  });
+
+  describe('static `resolved` constructor', () => {
+    test('produces `Task<Unit, never>` when passed no arguments', () => {
+      let theTask = Task.resolved();
+      expectTypeOf(theTask).toEqualTypeOf<Task<Unit, never>>();
+    });
+
+    test('produces `Task<T, never>` when passed a basic argument', () => {
+      let theValue = 'hello';
+      let theTask = Task.resolved(theValue);
+      expectTypeOf(theTask).toEqualTypeOf<Task<typeof theValue, never>>();
+    });
+
+    test('allows explicitly setting a type for `E`', () => {
+      let rejectedWithUnit = Task.resolved<Unit, string>();
+      expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<Unit, string>>();
+
+      let rejectedWithValue = Task.resolved<string, number>('hello');
+      expectTypeOf(rejectedWithValue).toEqualTypeOf<Task<string, number>>();
+    });
+  });
+
+  describe('static `rejected` constructor', () => {
+    test('produces `Task<never, Unit>` when passed no arguments', () => {
+      let theTask = Task.rejected();
+      expectTypeOf(theTask).toEqualTypeOf<Task<never, Unit>>();
+    });
+
+    test('produces `Task<never, E>` when passed an argument', () => {
+      let theReason = 'uh oh';
+      let theTask = Task.rejected(theReason);
+      expectTypeOf(theTask).toEqualTypeOf<Task<never, typeof theReason>>();
+    });
+
+    test('allows explicitly setting a type for `T`', () => {
+      let rejectedWithUnit = Task.rejected<string>();
+      expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<string, Unit>>();
+
+      let rejectedWithValue = Task.rejected<string, number>(123);
+      expectTypeOf(rejectedWithValue).toEqualTypeOf<Task<string, number>>();
+    });
+  });
+
+  // Note to future maintainers: there can be (at present) no path where a known
+  // `Ok` or `Err` immediately produces a `Resolved` or `Rejected` respectively,
+  // because the `Task` *must* be awaited (i.e. there is a required microtask
+  // queue tick because of the underlying promise) before the .
+  //
+  // We *might* be able to “fast path” that by way of a private constructor, but
+  // doing so would make it easy to accidentally touch that internal state
+  // without going through the `#promise`, which would be unsafe.
+  test('static `fromResult` constructor', async () => {
+    let theResult = Result.ok<number, string>(123);
+    let theTask = Task.fromResult(theResult);
+    expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+    let result = await theTask;
+    expect(result.isOk).toBe(true);
+    expect(theTask.state).toEqual(State.Resolved);
+  });
+
+  describe('state', () => {
+    test('is initially Pending', async () => {
+      let { promise, resolveWith } = deferred<number, string>();
+      let theTask = Task.try(promise);
+      expect(theTask.state).toBe(State.Pending);
+      // don't leak it!
+      resolveWith(123);
+      await promise;
+    });
+
+    test('is Resolved once the promise resolves', async () => {
+      let { promise, resolveWith } = deferred<number, string>();
+      let successfulTask = Task.try(promise);
+      resolveWith(123);
+      let result = await successfulTask;
+      expect(successfulTask.state).toBe(State.Resolved);
+      expect(unwrap(result)).toBe(123);
+    });
+
+    test('is Rejected if the promise rejects', async () => {
+      let { promise, rejectWith } = deferred<number, string>();
+
+      let theTask = Task.try(promise);
+      let anError = 'oh teh noes';
+      rejectWith(anError);
+
+      let result = await theTask;
+      expect(theTask.state).toBe(State.Rejected);
+      expect(unwrapErr(result)).toEqual(anError);
+    });
+  });
+
+  describe('static `from` method', () => {
+    test('with a pending promise', async () => {
+      let { promise, resolveWith } = deferred<number, never>();
+      let theTask = Task.tryOrElse(promise, stringify);
+      expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+      expect(theTask.state).toBe(State.Pending);
+
+      resolveWith(123);
+      await promise;
+    });
+
+    test('with a resolved promise', async () => {
+      let thePromise = Promise.resolve(123);
+      let theTask = Task.tryOrElse(thePromise, stringify);
+      await theTask;
+      expect(theTask.state).toBe(State.Resolved);
+    });
+
+    test('with a rejected promise', async () => {
+      let theError = 'oh teh noes';
+      let thePromise = Promise.reject(theError);
+      let theTask = Task.tryOrElse(thePromise, stringify);
+      let theResult = await theTask;
+      expectTypeOf(theResult).toEqualTypeOf<Result<never, string>>();
+      expect(unwrapErr(theResult)).toEqual(stringify(theError));
+    });
+
+    test('with a `Promise<Result<T, E>>`', async () => {
+      let { promise, resolveWith } = deferred<Result<number, string>, never>();
+      let theTask = Task.unsafeTrusted(promise);
+      expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+      resolveWith(Result.ok(123));
+      let result = await theTask;
+      expect(unwrap(result)).toEqual(123);
+    });
+  });
+
+  describe('`map` method', () => {
+    test('for a pending promise', async () => {
+      let { promise, resolveWith } = deferred<number, string>();
+      let theTask = Task.tryOrElse(promise, stringify).map((n) => n % 2 == 0);
+      expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+      resolveWith(123);
+      await theTask;
+    });
+
+    test('when the promise resolves', async () => {
+      let { promise, resolveWith } = deferred<number, string>();
+      let theTask = Task.tryOrElse(promise, stringify).map((n) => n % 2 == 0);
+      expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+      resolveWith(123);
+      let result = await theTask;
+      expect(unwrap(result)).toBe(false);
+    });
+
+    test('when the promise rejects', async () => {
+      let { promise, rejectWith } = deferred<number, string>();
+      let theTask = Task.tryOrElse(promise, stringify).map((n) => n % 2 == 0);
+      expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+      let theReason = 'nope';
+      rejectWith(theReason);
+      let result = await theTask;
+      expect(unwrapErr(result)).toEqual(stringify(theReason));
+    });
+  });
+
+  describe('`mapRejected` method', () => {
+    test('for a pending promise', async () => {
+      let { promise } = deferred<number, string>();
+      let theTask = Task.try(promise).mapRejected(stringify);
+      expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+    });
+
+    test('when the promise resolves', async () => {
+      let { promise, resolveWith } = deferred<number, string>();
+      let theTask = Task.try(promise).mapRejected(stringify);
+      expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+      resolveWith(123);
+      let result = await theTask;
+      expect(unwrap(result)).toBe(123);
+    });
+
+    test('when the promise rejects', async () => {
+      let { promise, rejectWith } = deferred<number, string>();
+      let theTask = Task.try(promise).mapRejected(stringify);
+      expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+      let theReason = 'nope';
+      rejectWith(theReason);
+      let result = await theTask;
+      expect(unwrapErr(result)).toEqual(stringify(theReason));
+    });
+  });
+
+  describe('`and` method', () => {
+    describe('when the first Task resolves', () => {
+      test('when the second Task resolves', async () => {
+        let theValue = 'hello';
+        let theTask = Task.resolved(123).and(Task.resolved(theValue));
+        expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
+        let theResult = await theTask;
+        expect(unwrap(theResult)).toEqual(theValue);
+      });
+
+      test('when the second Task rejects', async () => {
+        let theReason = 'hello';
+        let theTask = Task.resolved<number, string>(123).and(
+          Task.rejected<number, string>(theReason)
+        );
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+        let theResult = await theTask;
+        expect(unwrapErr(theResult)).toEqual(theReason);
+      });
+    });
+
+    describe('when the first Task rejects', () => {
+      test('when the second Task resolves', async () => {
+        let theReason = 123;
+        let theTask = Task.rejected<string, number>(theReason).and(
+          Task.resolved<number, number>(456)
+        );
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
+        let theResult = await theTask;
+        expect(unwrapErr(theResult)).toEqual(theReason);
+      });
+
+      test('when the second Task rejects', async () => {
+        let theReason = 123;
+        let theTask = Task.rejected<string, number>(theReason).and(
+          Task.rejected<string, number>(456)
+        );
+        expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
+        let theResult = await theTask;
+        expect(unwrapErr(theResult)).toEqual(theReason);
+      });
+    });
+
+    // Matches the text in the docs.
+    test('all combinations', async () => {
+      let resolvedA = Task.resolved<string, string>('A');
+      let resolvedB = Task.resolved<string, string>('B');
+      let rejectedA = Task.rejected<string, string>('bad');
+      let rejectedB = Task.rejected<string, string>('lame');
+
+      let aAndB = resolvedA.and(resolvedB);
+      await aAndB;
+
+      let aAndRA = resolvedA.and(rejectedA);
+      await aAndRA;
+
+      let raAndA = rejectedA.and(resolvedA);
+      await raAndA;
+
+      let raAndRb = rejectedA.and(rejectedB);
+      await raAndRb;
+
+      expect(aAndB.toString()).toEqual('Task.Resolved("B")');
+      expect(aAndRA.toString()).toEqual('Task.Rejected("bad")');
+      expect(raAndA.toString()).toEqual('Task.Rejected("bad")');
+      expect(raAndRb.toString()).toEqual('Task.Rejected("bad")');
+    });
+  });
+
+  describe('`andThen` method', () => {
+    test('for a pending promise', async () => {
+      let { promise, resolveWith } = deferred<number, string>();
+      let theTask = Task.tryOrElse(promise, stringify).andThen((n) => Task.resolved(n % 2 == 0));
+      expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+      resolveWith(123);
+      await theTask;
+    });
+
+    describe('when the first `Task` resolves', () => {
+      test('when the second is pending', async () => {
+        let theTask = Task.resolved<number, string>(123).andThen((n) => {
+          return new Task<number, string>((resolve) => {
+            resolve(Math.round(n / 2));
+          });
+        });
+
+        expect(theTask.state).toBe(State.Pending);
+        let theResult = await theTask;
+        expect(theTask.state).toBe(State.Resolved);
+        expect(unwrap(theResult)).toEqual(62);
+      });
+
+      test('when the second `Task` resolves', async () => {
+        let { promise, resolveWith } = deferred<number, string>();
+        let theTask = Task.tryOrElse(promise, stringify).andThen((n) => Task.resolved(n % 2 == 0));
+        expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+        resolveWith(123);
+        let result = await theTask;
+        expect(unwrap(result)).toBe(false);
+      });
+
+      test('when the second `Task` rejects', async () => {
+        let { promise, resolveWith } = deferred<number, string>();
+        let theTask = Task.tryOrElse(promise, stringify).andThen(() => Task.rejected('oh no'));
+        expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
+
+        resolveWith(123);
+        let result = await theTask;
+        expect(unwrapErr(result)).toBe('oh no');
+      });
+    });
+
+    describe('when the first `Task` rejects', () => {
+      test('when the second is pending', async () => {
+        let theReason = 'alas!';
+        let theTask = Task.rejected<number, string>(theReason).andThen((n) => {
+          return new Task<number, string>((resolve) => {
+            resolve(Math.round(n / 2));
+          });
+        });
+
+        expect(theTask.state).toBe(State.Pending);
+        let theResult = await theTask;
+        expect(theTask.state).toBe(State.Rejected);
+        expect(unwrapErr(theResult)).toEqual(theReason);
+      });
+
+      test('when the second `Task` resolves', async () => {
+        let { promise, rejectWith } = deferred<number, string>();
+        let theTask = Task.try(promise).andThen((n) => Task.resolved(n % 2 == 0));
+        expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
+
+        let theReason = 'nope';
+        rejectWith(theReason);
+        let result = await theTask;
+        expect(unwrapErr(result)).toEqual(theReason);
+      });
+
+      test('when the second `Task` rejects', async () => {
+        let theReason = 'nope';
+        let theTask = Task.rejected<number, string>(theReason).andThen((n) =>
+          Task.rejected<number, string>(n % 2 == 0 ? 'yep' : 'nope')
+        );
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+        let result = await theTask;
+        expect(unwrapErr(result)).toEqual(theReason);
+      });
+    });
+
+    describe('`or` method', () => {
+      describe('when the first Task resolves', async () => {
+        test('when the second is pending', async () => {
+          let theFirst = Task.resolved(123);
+          let theSecond = new Task<number, never>(noOp);
+
+          let theChain = theFirst.or(theSecond);
+          expect(theFirst.state).toBe(State.Resolved);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Pending);
+          await theFirst;
+          expect(theFirst.state).toBe(State.Resolved);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Resolved);
+        });
+
+        test('when the second Task resolves', async () => {
+          let theTask = Task.resolved(123).or(Task.resolved(456));
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
+          let theResult = await theTask;
+          expect(unwrap(theResult)).toEqual(123);
+        });
+
+        test('when the second Task rejects', async () => {
+          let theReason = 'hello';
+          let theTask = Task.resolved<number, string>(123).or(
+            Task.rejected<number, string>(theReason)
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+          let theResult = await theTask;
+          expect(unwrap(theResult)).toEqual(123);
+        });
+      });
+
+      describe('when the first Task rejects', () => {
+        test('when the second is pending', async () => {
+          let theFirst = Task.rejected<unknown, string>('blergh');
+          let theSecond = new Task<number, never>(noOp);
+
+          let theChain = theFirst.or(theSecond);
+          expect(theFirst.state).toBe(State.Rejected);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Pending);
+          await theFirst;
+          expect(theFirst.state).toBe(State.Rejected);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Pending);
+        });
+
+        test('when the second Task resolves', async () => {
+          let theTask = Task.rejected<string, number>(123).or(
+            Task.resolved<string, number>('hello')
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
+          let theResult = await theTask;
+          expect(unwrap(theResult)).toBe('hello');
+        });
+
+        test('when the second Task rejects', async () => {
+          let theReason = 123;
+          let theTask = Task.rejected<string, number>(theReason).or(
+            Task.rejected<string, number>(456)
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
+          let theResult = await theTask;
+          expect(unwrapErr(theResult)).toEqual(456);
+        });
+      });
+
+      // Matches the text in the docs.
+      test('all combinations', async () => {
+        let resolvedA = Task.resolved<string, string>('A');
+        let resolvedB = Task.resolved<string, string>('B');
+        let rejectedA = Task.rejected<string, string>('bad');
+        let rejectedB = Task.rejected<string, string>('lame');
+
+        let aOrB = resolvedA.or(resolvedB);
+        await aOrB;
+
+        let aOrRA = resolvedA.or(rejectedA);
+        await aOrRA;
+
+        let raOrA = rejectedA.or(resolvedA);
+        await raOrA;
+
+        let raOrRb = rejectedA.or(rejectedB);
+        await raOrRb;
+
+        expect(aOrB.toString()).toEqual('Task.Resolved("A")');
+        expect(aOrRA.toString()).toEqual('Task.Resolved("A")');
+        expect(raOrA.toString()).toEqual('Task.Resolved("A")');
+        expect(raOrRb.toString()).toEqual('Task.Rejected("lame")');
+      });
+    });
+
+    describe('`orElse` method', () => {
+      test('for a pending promise', async () => {
+        let theTask = new Task<number, string>(noOp).orElse((reason) =>
+          Task.resolved(reason.length)
+        );
+        expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
+
+        expect(theTask.state).toBe(State.Pending);
+      });
+
+      describe('when the first `Task` resolves', () => {
+        test('when the second is pending', async () => {
+          let theFirst = Task.resolved<number, string>(123);
+          let theSecond = new Task<number, boolean>(noOp);
+          let theChain = theFirst.orElse(() => theSecond);
+
+          expect(theFirst.state).toBe(State.Resolved);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Pending);
+          await theFirst;
+          expect(theFirst.state).toBe(State.Resolved);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Resolved);
+        });
+
+        test('when the second `Task` resolves', async () => {
+          let theTask = Task.resolved<number, string>(123).orElse((reason) =>
+            Task.resolved(reason.length)
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
+
+          let result = await theTask;
+          expect(unwrap(result)).toBe(123);
+        });
+
+        test('when the second `Task` rejects', async () => {
+          let theTask = Task.resolved<number, string>(123).orElse((reason) =>
+            Task.rejected(reason.length)
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
+
+          let result = await theTask;
+          expect(unwrap(result)).toBe(123);
+        });
+      });
+
+      describe('when the first `Task` rejects', () => {
+        test('when the second is pending', async () => {
+          let theFirst = Task.rejected<number, string>('teh sads');
+          let theSecond = new Task<number, boolean>(noOp);
+          let theChain = theFirst.orElse(() => theSecond);
+
+          expect(theFirst.state).toBe(State.Rejected);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Pending);
+          await theFirst;
+          expect(theFirst.state).toBe(State.Rejected);
+          expect(theSecond.state).toBe(State.Pending);
+          expect(theChain.state).toBe(State.Pending);
+        });
+
+        test('when the second `Task` resolves', async () => {
+          let theTask = Task.rejected<number, string>('nope').orElse((reason) =>
+            Task.resolved<number, string>(reason.length)
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+
+          let result = await theTask;
+          expect(unwrap(result)).toBe(4);
+        });
+
+        test('when the second `Task` rejects', async () => {
+          let theTask = Task.rejected<number, string>('first error').orElse((reason) =>
+            Task.rejected<number, boolean>(reason.includes("'"))
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, boolean>>();
+
+          let result = await theTask;
+          expect(unwrapErr(result)).toBe(false);
+        });
+      });
+    });
+
+    describe('`match` method', () => {
+      test('with a resolved task', () => {
+        Task.tryOrElse(Promise.resolve(123), stringify).match({
+          Resolved: (value) => expect(value).toBe(123),
+          Rejected: (_reason) => expect.unreachable(),
+        });
+        expect.assertions(1);
+      });
+
+      test('with a rejected task', () => {
+        Task.tryOrElse(Promise.reject(123), stringify).match({
+          Resolved: (_value) => expect.unreachable(),
+          Rejected: (reason) => expect(reason).toEqual(stringify(123)),
+        });
+        expect.assertions(1);
+      });
+
+      test('with a pending task', () => {
+        // Will never resolve, but should be collected at the end of the test.
+        // Note that this test passes when, and only when, no test assertions
+        // run at all.
+        let task = new Task(() => {});
+        task.match({
+          Resolved: () => expect.unreachable(),
+          Rejected: () => expect.unreachable(),
+        });
+        expect.assertions(0);
+      });
+    });
+
+    describe('`value` accessor', () => {
+      test('when the task is pending', () => {
+        let theTask = new Task(noOp);
+        expect(() => theTask.value).toThrowError(InvalidAccess);
+      });
+
+      test('when the task is resolved', () => {
+        let theValue = 123;
+        let theTask = Task.resolved(theValue);
+        expect(theTask.value).toBe(theValue);
+      });
+
+      test('when the task is rejected', () => {
+        let theTask = Task.rejected('oh teh noes');
+        expect(() => theTask.value).toThrowError(InvalidAccess);
+      });
+    });
+
+    describe('`reason` accessor', () => {
+      test('when the task is pending', () => {
+        let theTask = new Task(noOp);
+        expect(() => theTask.reason).toThrowError(InvalidAccess);
+      });
+
+      test('when the task is resolved', () => {
+        let theTask = Task.resolved(123);
+        expect(() => theTask.reason).toThrowError(InvalidAccess);
+      });
+
+      test('when the task is rejected', () => {
+        let theReason = 'oh teh noes';
+        let theTask = Task.rejected(theReason);
+        expect(theTask.reason).toBe(theReason);
+      });
+    });
+  });
+
+  describe('toString', () => {
+    expectTypeOf(Task['toString']).toEqualTypeOf<() => string>();
+
+    test('pending', async () => {
+      let { task, resolveWith } = Task.withResolvers();
+      expect(task.toString()).toEqual('Task.Pending');
+
+      resolveWith('');
+      await task;
+    });
+
+    test('resolved', async () => {
+      let theTask = new Task((resolve) => resolve(123));
+      await theTask;
+      expect(theTask.toString()).toEqual('Task.Resolved(123)');
+    });
+
+    test('rejected', async () => {
+      let theTask = new Task((_, reject) => reject('teh sads'));
+      await theTask;
+      expect(theTask.toString()).toEqual('Task.Rejected("teh sads")');
+    });
+  });
+
+  describe('`toPromise` method', () => {
+    test('with a directly-constructed task', async () => {
+      let { task, resolveWith } = Task.withResolvers();
+      let promise = task.toPromise();
+
+      let theValue = 'hello';
+      resolveWith(theValue);
+      let output = await promise;
+      expect(unwrap(output)).toEqual(theValue);
+    });
+
+    test('with a passed-in-promise', async () => {
+      let { promise: theInputPromise, resolveWith } = deferred();
+      let theTask = Task.try(theInputPromise);
+
+      let theValue = 123;
+      resolveWith(theValue);
+      let theResult = await theTask.toPromise();
+      expect(unwrap(theResult)).toEqual(theValue);
+    });
+  });
+});
+
+describe('narrowing', () => {
+  test('pending', async () => {
+    let { promise, resolveWith } = deferred<number, string>();
+    let theTask = Task.try(promise);
+
+    if (theTask.state === State.Pending) {
+      expect(theTask.isPending()).toBe(true);
+      expect(theTask.isResolved()).toBe(false);
+      expect(theTask.isRejected()).toBe(false);
+    }
+
+    resolveWith(123);
+    await theTask;
+  });
+
+  test('resolved', async () => {
+    let { promise, resolveWith } = deferred<number, string>();
+    let theTask = Task.try(promise);
+
+    resolveWith(123);
+    await theTask;
+
+    if (theTask.state === State.Resolved) {
+      expect(theTask.value).toBe(123);
+      expect(theTask.isPending()).toBe(false);
+      expect(theTask.isResolved()).toBe(true);
+      expect(theTask.isRejected()).toBe(false);
+    }
+  });
+
+  test('rejected', async () => {
+    let { promise, rejectWith } = deferred<number, string>();
+    let theTask = Task.tryOrElse(promise, (e) => `${e}`);
+
+    let theError = 'oh teh noes';
+    rejectWith(theError);
+    await theTask;
+
+    if (theTask.state === State.Rejected) {
+      expect(theTask.reason).toBe(theError);
+      expect(theTask.isPending()).toBe(false);
+      expect(theTask.isResolved()).toBe(false);
+      expect(theTask.isRejected()).toBe(true);
+    }
+  });
+});
+
+function deferred<T, E>(): {
+  promise: Promise<T>;
+  resolveWith: (value: T) => void;
+  rejectWith: (reason: E) => void;
+} {
+  // SAFETY: immediately resolved via promise constructor
+  let resolveWith!: (value: T) => void;
+  let rejectWith!: (reason: unknown) => void;
+  let promise = new Promise<T>((resolve, reject) => {
+    resolveWith = resolve;
+    rejectWith = reject;
+  });
+  return { promise, resolveWith: resolveWith, rejectWith: rejectWith };
+}
+
+function stringify(reason: unknown): string {
+  return JSON.stringify(reason, null, 2);
+}
+
+function noOp() {}

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -24,6 +24,25 @@ describe('`Task`', () => {
       expect(result.isErr).toBe(true);
       expect(unwrapErr(result)).toEqual(theReason);
     });
+
+    test('when an error is thrown', async () => {
+      // Wire up a promise to wait on this so we can make the test wait till
+      // this is done before exiting. Otherwise, the promise may leak across
+      // tests.
+      let processPromise = new Promise((resolve) => {
+        process.on('unhandledRejection', (error) => {
+          resolve(error);
+        });
+      });
+
+      new Task<number, string>((_resolve, _reject) => {
+        throw new Error('oh teh noes');
+      });
+
+      let output = await processPromise;
+      expect(output).toBeInstanceOf(TaskExecutorException);
+      expect.assertions(1);
+    });
   });
 
   test('implements the `PromiseLike` API', async () => {

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -109,7 +109,7 @@ describe('`Task`', () => {
     describe('`unsafeTrusted`', () => {
       test('when the task resolves', async () => {
         let { promise, resolve } = deferred<Result<number, string>, never>();
-        let theTask = Task.unsafeTrusted(promise);
+        let theTask = Task.fromUnsafePromise(promise);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
         let theInputResult = Result.ok<number, string>(123);
@@ -137,7 +137,7 @@ describe('`Task`', () => {
         });
 
         let { promise, reject } = deferred<Result<number, string>, unknown>();
-        let theTask = Task.unsafeTrusted(promise);
+        let theTask = Task.fromUnsafePromise(promise);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
         let theReason = 'not good';
@@ -327,7 +327,7 @@ describe('`Task`', () => {
 
     test('with a `Promise<Result<T, E>>`', async () => {
       let { promise, resolve } = deferred<Result<number, string>, never>();
-      let theTask = Task.unsafeTrusted(promise);
+      let theTask = Task.fromUnsafePromise(promise);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
       resolve(Result.ok(123));

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -180,42 +180,42 @@ describe('`Task`', () => {
 
   describe('static `resolved` constructor', () => {
     test('produces `Task<Unit, never>` when passed no arguments', () => {
-      let theTask = Task.resolved();
+      let theTask = Task.resolve();
       expectTypeOf(theTask).toEqualTypeOf<Task<Unit, never>>();
     });
 
     test('produces `Task<T, never>` when passed a basic argument', () => {
       let theValue = 'hello';
-      let theTask = Task.resolved(theValue);
+      let theTask = Task.resolve(theValue);
       expectTypeOf(theTask).toEqualTypeOf<Task<typeof theValue, never>>();
     });
 
     test('allows explicitly setting a type for `E`', () => {
-      let rejectedWithUnit = Task.resolved<Unit, string>();
+      let rejectedWithUnit = Task.resolve<Unit, string>();
       expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<Unit, string>>();
 
-      let rejectedWithValue = Task.resolved<string, number>('hello');
+      let rejectedWithValue = Task.resolve<string, number>('hello');
       expectTypeOf(rejectedWithValue).toEqualTypeOf<Task<string, number>>();
     });
   });
 
   describe('static `rejected` constructor', () => {
     test('produces `Task<never, Unit>` when passed no arguments', () => {
-      let theTask = Task.rejected();
+      let theTask = Task.reject();
       expectTypeOf(theTask).toEqualTypeOf<Task<never, Unit>>();
     });
 
     test('produces `Task<never, E>` when passed an argument', () => {
       let theReason = 'uh oh';
-      let theTask = Task.rejected(theReason);
+      let theTask = Task.reject(theReason);
       expectTypeOf(theTask).toEqualTypeOf<Task<never, typeof theReason>>();
     });
 
     test('allows explicitly setting a type for `T`', () => {
-      let rejectedWithUnit = Task.rejected<string>();
+      let rejectedWithUnit = Task.reject<string>();
       expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<string, Unit>>();
 
-      let rejectedWithValue = Task.rejected<string, number>(123);
+      let rejectedWithValue = Task.reject<string, number>(123);
       expectTypeOf(rejectedWithValue).toEqualTypeOf<Task<string, number>>();
     });
   });
@@ -372,7 +372,7 @@ describe('`Task`', () => {
     describe('when the first Task resolves', () => {
       test('when the second Task resolves', async () => {
         let theValue = 'hello';
-        let theTask = Task.resolved(123).and(Task.resolved(theValue));
+        let theTask = Task.resolve(123).and(Task.resolve(theValue));
         expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
         let theResult = await theTask;
         expect(unwrap(theResult)).toEqual(theValue);
@@ -380,9 +380,7 @@ describe('`Task`', () => {
 
       test('when the second Task rejects', async () => {
         let theReason = 'hello';
-        let theTask = Task.resolved<number, string>(123).and(
-          Task.rejected<number, string>(theReason)
-        );
+        let theTask = Task.resolve<number, string>(123).and(Task.reject<number, string>(theReason));
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
         expect(unwrapErr(theResult)).toEqual(theReason);
@@ -392,9 +390,7 @@ describe('`Task`', () => {
     describe('when the first Task rejects', () => {
       test('when the second Task resolves', async () => {
         let theReason = 123;
-        let theTask = Task.rejected<string, number>(theReason).and(
-          Task.resolved<number, number>(456)
-        );
+        let theTask = Task.reject<string, number>(theReason).and(Task.resolve<number, number>(456));
         expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
         let theResult = await theTask;
         expect(unwrapErr(theResult)).toEqual(theReason);
@@ -402,9 +398,7 @@ describe('`Task`', () => {
 
       test('when the second Task rejects', async () => {
         let theReason = 123;
-        let theTask = Task.rejected<string, number>(theReason).and(
-          Task.rejected<string, number>(456)
-        );
+        let theTask = Task.reject<string, number>(theReason).and(Task.reject<string, number>(456));
         expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
         let theResult = await theTask;
         expect(unwrapErr(theResult)).toEqual(theReason);
@@ -413,10 +407,10 @@ describe('`Task`', () => {
 
     // Matches the text in the docs.
     test('all combinations', async () => {
-      let resolvedA = Task.resolved<string, string>('A');
-      let resolvedB = Task.resolved<string, string>('B');
-      let rejectedA = Task.rejected<string, string>('bad');
-      let rejectedB = Task.rejected<string, string>('lame');
+      let resolvedA = Task.resolve<string, string>('A');
+      let resolvedB = Task.resolve<string, string>('B');
+      let rejectedA = Task.reject<string, string>('bad');
+      let rejectedB = Task.reject<string, string>('lame');
 
       let aAndB = resolvedA.and(resolvedB);
       await aAndB;
@@ -440,7 +434,7 @@ describe('`Task`', () => {
   describe('`andThen` method', () => {
     test('for a pending promise', async () => {
       let { promise, resolveWith } = deferred<number, string>();
-      let theTask = Task.tryOrElse(promise, stringify).andThen((n) => Task.resolved(n % 2 == 0));
+      let theTask = Task.tryOrElse(promise, stringify).andThen((n) => Task.resolve(n % 2 == 0));
       expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
       resolveWith(123);
@@ -449,7 +443,7 @@ describe('`Task`', () => {
 
     describe('when the first `Task` resolves', () => {
       test('when the second is pending', async () => {
-        let theTask = Task.resolved<number, string>(123).andThen((n) => {
+        let theTask = Task.resolve<number, string>(123).andThen((n) => {
           return new Task<number, string>((resolve) => {
             resolve(Math.round(n / 2));
           });
@@ -463,7 +457,7 @@ describe('`Task`', () => {
 
       test('when the second `Task` resolves', async () => {
         let { promise, resolveWith } = deferred<number, string>();
-        let theTask = Task.tryOrElse(promise, stringify).andThen((n) => Task.resolved(n % 2 == 0));
+        let theTask = Task.tryOrElse(promise, stringify).andThen((n) => Task.resolve(n % 2 == 0));
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
         resolveWith(123);
@@ -473,7 +467,7 @@ describe('`Task`', () => {
 
       test('when the second `Task` rejects', async () => {
         let { promise, resolveWith } = deferred<number, string>();
-        let theTask = Task.tryOrElse(promise, stringify).andThen(() => Task.rejected('oh no'));
+        let theTask = Task.tryOrElse(promise, stringify).andThen(() => Task.reject('oh no'));
         expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
 
         resolveWith(123);
@@ -485,7 +479,7 @@ describe('`Task`', () => {
     describe('when the first `Task` rejects', () => {
       test('when the second is pending', async () => {
         let theReason = 'alas!';
-        let theTask = Task.rejected<number, string>(theReason).andThen((n) => {
+        let theTask = Task.reject<number, string>(theReason).andThen((n) => {
           return new Task<number, string>((resolve) => {
             resolve(Math.round(n / 2));
           });
@@ -499,7 +493,7 @@ describe('`Task`', () => {
 
       test('when the second `Task` resolves', async () => {
         let { promise, rejectWith } = deferred<number, string>();
-        let theTask = Task.try(promise).andThen((n) => Task.resolved(n % 2 == 0));
+        let theTask = Task.try(promise).andThen((n) => Task.resolve(n % 2 == 0));
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
 
         let theReason = 'nope';
@@ -510,8 +504,8 @@ describe('`Task`', () => {
 
       test('when the second `Task` rejects', async () => {
         let theReason = 'nope';
-        let theTask = Task.rejected<number, string>(theReason).andThen((n) =>
-          Task.rejected<number, string>(n % 2 == 0 ? 'yep' : 'nope')
+        let theTask = Task.reject<number, string>(theReason).andThen((n) =>
+          Task.reject<number, string>(n % 2 == 0 ? 'yep' : 'nope')
         );
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
@@ -523,7 +517,7 @@ describe('`Task`', () => {
     describe('`or` method', () => {
       describe('when the first Task resolves', async () => {
         test('when the second is pending', async () => {
-          let theFirst = Task.resolved(123);
+          let theFirst = Task.resolve(123);
           let theSecond = new Task<number, never>(noOp);
 
           let theChain = theFirst.or(theSecond);
@@ -537,7 +531,7 @@ describe('`Task`', () => {
         });
 
         test('when the second Task resolves', async () => {
-          let theTask = Task.resolved(123).or(Task.resolved(456));
+          let theTask = Task.resolve(123).or(Task.resolve(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toEqual(123);
@@ -545,8 +539,8 @@ describe('`Task`', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 'hello';
-          let theTask = Task.resolved<number, string>(123).or(
-            Task.rejected<number, string>(theReason)
+          let theTask = Task.resolve<number, string>(123).or(
+            Task.reject<number, string>(theReason)
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
@@ -556,7 +550,7 @@ describe('`Task`', () => {
 
       describe('when the first Task rejects', () => {
         test('when the second is pending', async () => {
-          let theFirst = Task.rejected<unknown, string>('blergh');
+          let theFirst = Task.reject<unknown, string>('blergh');
           let theSecond = new Task<number, never>(noOp);
 
           let theChain = theFirst.or(theSecond);
@@ -570,9 +564,7 @@ describe('`Task`', () => {
         });
 
         test('when the second Task resolves', async () => {
-          let theTask = Task.rejected<string, number>(123).or(
-            Task.resolved<string, number>('hello')
-          );
+          let theTask = Task.reject<string, number>(123).or(Task.resolve<string, number>('hello'));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toBe('hello');
@@ -580,9 +572,7 @@ describe('`Task`', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 123;
-          let theTask = Task.rejected<string, number>(theReason).or(
-            Task.rejected<string, number>(456)
-          );
+          let theTask = Task.reject<string, number>(theReason).or(Task.reject<string, number>(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(456);
@@ -591,10 +581,10 @@ describe('`Task`', () => {
 
       // Matches the text in the docs.
       test('all combinations', async () => {
-        let resolvedA = Task.resolved<string, string>('A');
-        let resolvedB = Task.resolved<string, string>('B');
-        let rejectedA = Task.rejected<string, string>('bad');
-        let rejectedB = Task.rejected<string, string>('lame');
+        let resolvedA = Task.resolve<string, string>('A');
+        let resolvedB = Task.resolve<string, string>('B');
+        let rejectedA = Task.reject<string, string>('bad');
+        let rejectedB = Task.reject<string, string>('lame');
 
         let aOrB = resolvedA.or(resolvedB);
         await aOrB;
@@ -618,7 +608,7 @@ describe('`Task`', () => {
     describe('`orElse` method', () => {
       test('for a pending promise', async () => {
         let theTask = new Task<number, string>(noOp).orElse((reason) =>
-          Task.resolved(reason.length)
+          Task.resolve(reason.length)
         );
         expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
@@ -627,7 +617,7 @@ describe('`Task`', () => {
 
       describe('when the first `Task` resolves', () => {
         test('when the second is pending', async () => {
-          let theFirst = Task.resolved<number, string>(123);
+          let theFirst = Task.resolve<number, string>(123);
           let theSecond = new Task<number, boolean>(noOp);
           let theChain = theFirst.orElse(() => theSecond);
 
@@ -641,8 +631,8 @@ describe('`Task`', () => {
         });
 
         test('when the second `Task` resolves', async () => {
-          let theTask = Task.resolved<number, string>(123).orElse((reason) =>
-            Task.resolved(reason.length)
+          let theTask = Task.resolve<number, string>(123).orElse((reason) =>
+            Task.resolve(reason.length)
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
@@ -651,8 +641,8 @@ describe('`Task`', () => {
         });
 
         test('when the second `Task` rejects', async () => {
-          let theTask = Task.resolved<number, string>(123).orElse((reason) =>
-            Task.rejected(reason.length)
+          let theTask = Task.resolve<number, string>(123).orElse((reason) =>
+            Task.reject(reason.length)
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
 
@@ -663,7 +653,7 @@ describe('`Task`', () => {
 
       describe('when the first `Task` rejects', () => {
         test('when the second is pending', async () => {
-          let theFirst = Task.rejected<number, string>('teh sads');
+          let theFirst = Task.reject<number, string>('teh sads');
           let theSecond = new Task<number, boolean>(noOp);
           let theChain = theFirst.orElse(() => theSecond);
 
@@ -677,8 +667,8 @@ describe('`Task`', () => {
         });
 
         test('when the second `Task` resolves', async () => {
-          let theTask = Task.rejected<number, string>('nope').orElse((reason) =>
-            Task.resolved<number, string>(reason.length)
+          let theTask = Task.reject<number, string>('nope').orElse((reason) =>
+            Task.resolve<number, string>(reason.length)
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
@@ -687,8 +677,8 @@ describe('`Task`', () => {
         });
 
         test('when the second `Task` rejects', async () => {
-          let theTask = Task.rejected<number, string>('first error').orElse((reason) =>
-            Task.rejected<number, boolean>(reason.includes("'"))
+          let theTask = Task.reject<number, string>('first error').orElse((reason) =>
+            Task.reject<number, boolean>(reason.includes("'"))
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, boolean>>();
 
@@ -736,13 +726,13 @@ describe('`Task`', () => {
 
       test('when the task is resolved', () => {
         let theValue = 123;
-        let theTask = Task.resolved(theValue);
         expect(theTask.value).toBe(theValue);
+        let theTask = Task.resolve(theValue);
       });
 
       test('when the task is rejected', () => {
-        let theTask = Task.rejected('oh teh noes');
         expect(() => theTask.value).toThrowError(InvalidAccess);
+        let theTask = Task.reject('oh teh noes');
       });
     });
 
@@ -753,14 +743,14 @@ describe('`Task`', () => {
       });
 
       test('when the task is resolved', () => {
-        let theTask = Task.resolved(123);
         expect(() => theTask.reason).toThrowError(InvalidAccess);
+        let theTask = Task.resolve(123);
       });
 
       test('when the task is rejected', () => {
         let theReason = 'oh teh noes';
-        let theTask = Task.rejected(theReason);
         expect(theTask.reason).toBe(theReason);
+        let theTask = Task.reject(theReason);
       });
     });
   });

--- a/ts/base.tsconfig.json
+++ b/ts/base.tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2022",
     "module": "Node16",
 
     "strict": true,


### PR DESCRIPTION
## Overview

Finally—*finally!*—True Myth get a `Task` type! A `Task<T, E>` is like a `Promise<Result<T, E>>`. In fact, under the hood, it is *exactly* a `Promise<Result<T, E>>`, but in general you do not need to think about that layering. Instead, you get a nice type-safe API for fallible async operations. (It’s what `Promise` should have been!)

You can try it out the implementation in this PR by installing [v8.2.0-beta.1][beta-release] via the `beta` tag:

[beta-release]: https://github.com/true-myth/true-myth/releases/tag/v8.2.0-beta.1

| Package manager | Command                       |
| --------------- | ----------------------------- |
| npm             | `npm install true-myth@beta`  |
| yarn            | `yarn add true-myth@beta`     |
| pnpm            | `pnpm install true-myth@beta` |

## Highlights

- You can create a `Task` the exact same way you would a `Promise`, but a `Task` created this way will never throw an error. For example, a timeout task mingling `setTimeout` would look like this:

    ```ts
    function timeout(ms: number): Task<void, never> {
      return new Task((resolve) => setTimeout(resolve, ms));
    }
    ```

- You can create a `Task` safely from a `Promise` like this:

    ```ts
    let thePromise = fetch("https://true-myth.js.org");
    let theTask = Task.from(thePromise, (reason) => {
      console.error(JSON.stringify(reason));
    });
    ```

- You can call `map`, `andThen`, `orElse`, `match`, and many other helpers on `Task` just like you have always been able to do on `Result`.

    ```ts
    function mapAndPrint(aTask: Task<string, Error>) {
      aTask.map((s) => s.length).match({
        Resolved: (value) => console.log("Success!", value),
        Rejected: (reason) => console.error("Alas:", reason),
      });
    }
    ```

- You can compose `Task`s together. (Today, you will need to do a fair bit of this manually, but in the future we will probably ship support for doing this out of the box.) For example, you could combine the `Task` instances in the `fetch` and `timeout` examples above like this to ignore any result from the `fetch`:

    ```ts
    function race(
      fetchTask: Task<Response, void>,
      timeout: Task<void, never>
    ): Task<Response, TimeoutError | void> {
      return new Task((resolve, reject) => {
        Promise.race([fetchTask, timeout]).then((result) =>
          result.match({
            Ok: (winner) => {
              if (winner instanceof Response) {
                resolve(winner);
              } else {
                reject(new TimeoutError());
              }
            },
            Err: reject,
          })
        );
      });
    }
    ```
    
    (If you squint a bit, you can probably see a better way to make a `timeout`-based API that just does this under the hood, and which is strictly more general. Yep! We’ll ship something like that eventually!)

- Once you have a `Task`, you can also `await` it to get a `Result<T, E>` (a great idea we got from the excellent [neverthrow][neverthrow] library):

    ```ts
    async function handle(theTask: Task<string, Error>): string {
      let result = await theTask;
      return result.match({
        Ok: (val) => val,
        Err: (err) => err.message,
      });
    }
    ```

There is a bunch more, too, and this is just the first release, with a solid baseline API!

I expect we will add nice utilities (combinators) like `all`, `any`, `first`, etc. over time: having the baseline in place is enough to get us the foundation we need. We can (and, I expect, *will*) add that kind of extended functionality in future point releases!

- Resolves #25
- Resolves #824
- Background discussion: https://github.com/true-myth/true-myth/discussions/208 and the very helpful input from @ceuk’s work on a similar idea after forking True Myth a few years ago.

[neverthrow]: https://github.com/supermacro/neverthrow

## What isn’t here yet?

- There are not yet any of the module-level functions with their support for currying. These will be easy to add incrementally, and you can expect to see a v8.3.0 release in the next few weeks with them, but I wanted to actually ship this!

- I have not implemented `mapOr`, `mapOrElse`, `unwrapOr`, or `unwrapOrElse` helper methods or functions. Any implementation of these would produce a `Promise`, and I think that warrants some further design consideration before we commit to doing that, given the whole point here is to enable people to get *away* from working with `Promise` in general, and given that in the cases where you want to use those you can `(await theTask).unwrapOr(...)` by way of the `PromiseLike<Result<T, E>>` implementation.

- I have also not implemented `Task.prototype.ap`. I am not sure if or how much `Maybe.prototype.ap` and `Result.prototype.ap` get used—I have literally never used them at any point since we added them half a decade ago. I am happy enough to add `Task.prototype.ap` if folks *do* use it, but I want to see if there is demand for it before we add it!

- As mentioned above, there are presently none of the “combinators”/utility functions we know are super helpful with async operations in particular, like `race`, `all`, `some`, `every`, etc.—and here again I expect to implement them somewhat “on demand”. We are not starting by implementing all of the relevant[^relevant] `Promise` API surface, for example, but it seems reasonable that we eventually will!

[^relevant]: “Relevant” is an important word here because of important differences between `Promise` and `Task` at the instance layer. Intuitively, I think all the `Promise` *static* methods probably make sense to implement, but not all of the instance methods do. See the open question about `implements Promise` for more.

## Open questions

A few things I would like some input on before merging this:

- [x] Should we have `Task implements Promise<Result<T, E>>`, not just `Task implements PromiseLike<Result<T, E>>`? See #888 for discussion.

- [x] Should we reproduce the approach we have in `Result` and `Maybe` for exporting the relevant classes in a non-subclass-able way? It makes a hash of our documentation, and it is not clear to me that having the public type be a union is actually “good” for the final developer experience when consumed (so much so that I am considering whether this is something we might want to change in a v9.0.0 when we drop Node.js 18 support in 2025). I am mildly inclined to put a stake in the ground and say `Task` is the class, but to explicitly document that subclassing it is *not* public API.

    The flipside is that the major motivation for doing that is the reality that it lets us expose `value` *only* on `Just` and `Ok`, and `error` *only* on `Err`. Likewise, we could make it here so that `Resolved` has a `value` and `Rejected` a `reason`, using the same type-export techniques.Subclasses could also theoretically do this. However, we have to date avoided exposing subclasses and instead provided completely monomorphic types, which has significant potential benefits in terms of runtime performance. Subclassing would not be *terrible*, but it also would not be *optimal*, and critically would require a very different approach than `Maybe` or `Result` has today, or than the current implementation, which simply allows calling `new Task` just like `new Promise` and getting the appropriate behavior encoded in the type.
    
    In sum, I do not see a “clean win” between the choices here!

### Naming

This is the big one!

- [x] I’m reasonably happy with `Task`, but could probably be persuaded that `Future` is also viable. I do *not* like `ResultAsync` or `AsyncResult` or similar.

- [x] The family of static constructor functions which take a `Promise` and produce a `Task`:
    - `try`
    - `tryOr`
    - `tryOrElse`

    One of my main considerations here is: I actually think `tryOrElse` is the version most people should reach for most of the time! It’s the best way to get a `Task<T, E>` from `Promise<T>` in a way that correctly handles the `unknown` rejection reason. But it is the longest and least convenient name!
    
    Options for improving that include:
    
    - Using overloads with e.g. `Task.from` or `Task.try`, so that all of these are possible:

        ```ts
        let taskUnknown = Task.from(aPromise);
        let taskWithFixedRejection = Task.from(aPromise, "whoops");
        let taskWithHandling = Task.from(aPromise, (reason) => JSON.stringify);
        ```
        
        I actually originally implemented it this way, but stepped away from it for a few reasons:
        
        1. It is not symmetric with `Result`, where we have `tryOr` and `tryOrElse`.[^result-try] Notably, however, there is today no `Result` versions which does *not* take an `Err` of some type, and the `Result` versions of `tryOr` and `tryOrElse` 
        2. It did not address the tendency to just do `Task.from(aPromise)`.
        3. We needed to be able to distinguish between the “base case” represented by `Task.from` and `Task.trusted`. (However, we could still have `Task.from` *and* `Task.trusted` and `Task.fromResult` if we wanted.)

    - Making `Task.from` or `Task.try` take the `(reason: unknown) => E`, and having longer names for the others, so `Task.fromPromiseUnknown` or `Task.fromPromiseWithDefaultRejection` or other such shenanigans.

- [x] The name of the `trusted` static constructor. It accepts a `Promise<Result<T, E>>`, and assumes that you have already gone out of your way to attach a `catch` handler to it (most likely because you used `Task.prototype.toPromise`!). Is `trusted` the right name for this? It could also be `unsafe` or `trustedUnsafe` or `trustMeIPromiseIHaveValidatedThisHasACatchHandler` (okay, *probably* not that last one).

- [x] The names of the variants and their constructors. The variants themselves will not crop up as much here, since it should be unusual—not impossible!—to directly match on their state (see discussion on this below!), but as of opening the PR, they do not directly match `Result`, even though the APIs are very similar, and they currently also do *not* match.
    - `Task.resolved()` and `State.Resolved`-cf. `Result.ok()`, `Promise.resolve()`, and `State.Resolved`
    - `Task.rejected()` and `State.Rejected`—cf. `Result.err()`, `Promise.reject()`, and `State.Err`

- [x] The names of the functions returned by `Task.withResolvers`. I personally like `resolveWith(aValue)` better than `resolve(aValue)`, and one of the selling points to my mind of True Myth has always been that we give things better names than average JS API names (or at least names we like better!)… but the asymmetry with `Promise` might be reason not to do that here?

[^result-try]: Notably, *not* on the class itself, though. They are module-level functions in `true-myth/result`, *not* static constructor functions. But I expect `Task.from(somePromise)` or whatever name we land on to be *massively* more common than the `tryOr` for `Result` is in practice.

### Exposing state values

On the one hand, most interactions with a `Task` should, like a `Promise`, be done via the callbacks or by `await`-ing it. However, there are times it can be *extremely* useful to have direct access to the state of an async operation. For example, if you wanted to build a *reactive* async data abstraction _a la_ [How Elm Slays a UI Antipattern][hesauia], `Task` could a great primitive for doing that! Every time I have built one of those, I have found it needful to expose the current state:[^templating]

[hesauia]: http://blog.jenkster.com/2016/06/how-elm-slays-a-ui-antipattern.html

```svelte
<template>
  {#if @task.isPending}
    {#yield to='pending'}
  {:else if @task.isResolved}
    {#yield to='resolved' @task.value}
  {:else}
    {#yield to='reject' @task.reason}
  {/if}
</template>
```

That being said, it is also not clear to me at the moment exactly how someone consuming `Task` could build a reactive version of it without some kind of delegation (proxying, subclassing, etc.), because whether using [signals][signalis] or [autotracking][autotracking] or even something like React’s [`useState`][use-state], you still need a “trigger” for *when you update the underlying state*. Even with a very thin proxy around the `Task` as defined here, you would still need to attach a callback to do that:

[signalis]: https://www.npmjs.com/package/@signalis/core
[autotracking]: https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/
[use-state]: https://react.dev/reference/react/useState

```ts
import Task from 'true-myth/task';
import { createSignal } from '@signalis/core';

class TaskHandler<T, E> implements ProxyHandler<typeof Task<T, E>> {
  #signal = createSignal();

  construct(
    target: typeof Task<T, E>,
    args: ConstructorParameters<typeof Task<T, E>>
  ): Task<T, E> {
    let theTask = new target(...args);
    theTask.toPromise().finally(() => (this.#signal.value = null));
    return theTask;
  }
}

function reactiveTask<T, E>(): typeof Task<T, E> {
  return new Proxy(Task, new TaskHandler<T, E>());
}
```

However, because `Task` exposes its own state, you *only* need to use a `.finally` to trigger a single update to have everything else become reactive automatically. I used [signalis][signalis] in this example, because I quite like it (and I had a tiny bit of input on it!) but you could implement this the exact same way using a rune in Svelte or with `setState` in React or with `tracked` in Glimmer.[^granularity] This seems like a valuable tradeoff to me.

The downside (or may be just “weird side”) is: it lets you inspect a `Task`’s state directly in imperative *non*-async code. That could let you do some strange things, though off the top of my head it is not obvious to me how you would do something *broken* with it, particularly since there is no write access to the task state outside its own body.



[^templating]: This templating language example is something like a mix between Glimmer and Svelte, not anything real.

[^granularity]: If you are worried about the level of granularity here, there is actually no more granular you can get than this! The only time there is a relevant state change is *any* time the promise resolves; by contract, this `Task` implementation will only resolve once, and it will always resolve successfully.
