### PR TITLE
internal: Pin to the oldest TS version we support for dev

### DIFF
--- a/.github/workflows/Publish Docs.yml
+++ b/.github/workflows/Publish Docs.yml
@@ -18,6 +18,9 @@ jobs:
 
       - run: pnpm install
 
+      - name: Update to latest supported TS version to match TypeDoc requirements
+        run: pnpm add --save-dev typescript@latest
+
       - name: Build docs
         run: pnpm doc
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rimraf": "^6.0.0",
     "shelljs": "^0.8.5",
     "typedoc": "^0.27.0",
-    "typescript": "~5.7",
+    "typescript": "4.7.4",
     "vitest": "^2.0.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@release-it-plugins/lerna-changelog':
         specifier: ^7.0.0
-        version: 7.0.0(release-it@17.11.0(typescript@5.7.2))
+        version: 7.0.0(release-it@17.11.0(typescript@4.7.4))
       '@types/node':
         specifier: ^22.0.0
         version: 22.10.5
@@ -25,7 +25,7 @@ importers:
         version: 3.4.2
       release-it:
         specifier: ^17.0.1
-        version: 17.11.0(typescript@5.7.2)
+        version: 17.11.0(typescript@4.7.4)
       rimraf:
         specifier: ^6.0.0
         version: 6.0.1
@@ -34,10 +34,10 @@ importers:
         version: 0.8.5
       typedoc:
         specifier: ^0.27.0
-        version: 0.27.6(typescript@5.7.2)
+        version: 0.27.6(typescript@4.7.4)
       typescript:
-        specifier: ~5.7
-        version: 5.7.2
+        specifier: 4.7.4
+        version: 4.7.4
       vitest:
         specifier: ^2.0.1
         version: 2.0.5(@types/node@22.10.5)
@@ -1969,9 +1969,9 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
-    engines: {node: '>=14.17'}
+  typescript@4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -2407,13 +2407,13 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@release-it-plugins/lerna-changelog@7.0.0(release-it@17.11.0(typescript@5.7.2))':
+  '@release-it-plugins/lerna-changelog@7.0.0(release-it@17.11.0(typescript@4.7.4))':
     dependencies:
       execa: 5.1.1
       lerna-changelog: 2.2.0
       lodash: 4.17.21
       mdast-util-from-markdown: 1.3.1
-      release-it: 17.11.0(typescript@5.7.2)
+      release-it: 17.11.0(typescript@4.7.4)
       tmp: 0.2.3
       validate-peer-dependencies: 2.2.0
       which: 2.0.2
@@ -2790,14 +2790,14 @@ snapshots:
       graceful-fs: 4.2.11
       xdg-basedir: 5.1.0
 
-  cosmiconfig@9.0.0(typescript@5.7.2):
+  cosmiconfig@9.0.0(typescript@4.7.4):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.7.2
+      typescript: 4.7.4
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3903,14 +3903,14 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  release-it@17.11.0(typescript@5.7.2):
+  release-it@17.11.0(typescript@4.7.4):
     dependencies:
       '@iarna/toml': 2.2.5
       '@octokit/rest': 20.1.1
       async-retry: 1.3.3
       chalk: 5.4.1
       ci-info: 4.1.0
-      cosmiconfig: 9.0.0(typescript@5.7.2)
+      cosmiconfig: 9.0.0(typescript@4.7.4)
       execa: 8.0.0
       git-url-parse: 14.0.0
       globby: 14.0.2
@@ -4177,16 +4177,16 @@ snapshots:
 
   type-fest@4.26.1: {}
 
-  typedoc@0.27.6(typescript@5.7.2):
+  typedoc@0.27.6(typescript@4.7.4):
     dependencies:
       '@gerrit0/mini-shiki': 1.24.1
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      typescript: 5.7.2
+      typescript: 4.7.4
       yaml: 2.6.1
 
-  typescript@5.7.2: {}
+  typescript@4.7.4: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
This has tripped me up repeatedly while developing `Task`, because it's too easy to implicitly depend on more recent improvements to TS.