### PR TITLE
Task: add `safe`, `safelyTry`, `safelyTryOr`, and `safelyTryOrElse`

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -1484,13 +1484,13 @@ export function safe<
   @param onError A function to use to transform the
 */
 export function safe<
-  F extends (...params: never[]) => unknown,
+  F extends (...params: never[]) => PromiseLike<unknown>,
   P extends Parameters<F>,
   R extends Awaited<ReturnType<F>>,
   E,
 >(fn: F, onError: (reason: unknown) => E): (...params: P) => Task<R, E>;
 export function safe<
-  F extends (...params: never[]) => unknown,
+  F extends (...params: never[]) => PromiseLike<unknown>,
   P extends Parameters<F>,
   R extends Awaited<ReturnType<F>>,
   E,


### PR DESCRIPTION
- The `safe` function, like the just-landed function in the `result` module, transforms a function which produces a `Promise` into one that produces a `Task` instead, while otherwise maintaining the function's signature and semantics.

- The `safely` versions of `try`, `tryOr`, and `tryOrElse` require a function which produces the `Promise` from which the `Task` will be constructed, rather than accepting the `Promise` directly. This is a slight inconvenience, but it has an important upside: these versions of the functions can guarantee that they will handle and absorb any errors thrown during construction of the `Promise` as well.

Once these have been released, we can deprecate the existing `Task.try`, `Task.tryOr`, and `Task.tryOrElse` functions in favor of these functions and once we release 9.0, we can also remove them and rename the module- scope functions to have slightly nicer names (mostly without the prefix, although `try` cannot be used there), with the added benefit that the module will become more tree-shake-able that way.