### PR TITLE
Task: deprecate `Task.try`, `Task.tryOr`, and `Task.tryOrElse`

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -107,6 +107,9 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
     @param promise The promise from which to create the `Task`.
 
     @group Constructors
+
+    @deprecated This will be removed at 9.0. Switch to the module-level function
+      {@linkcode safelyTry}, which accepts a callback instead.
    */
   static try<T>(promise: Promise<T>): Task<T, unknown> {
     return new Task((resolve, reject) => {
@@ -130,6 +133,9 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
       into a known `E`.
 
     @group Constructors
+
+    @deprecated This will be removed at 9.0. Switch to the module-level function
+      {@linkcode safelyTryOr}, which accepts a callback instead.
    */
   static tryOr<T, E>(promise: Promise<T>, rejectionValue: E): Task<T, E> {
     return new Task((resolve, reject) => {
@@ -149,6 +155,9 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
       a known `E`.
 
     @group Constructors
+
+    @deprecated This will be removed at 9.0. Switch to the module-level function
+      {@linkcode safelyTryOrElse}, which accepts a callback instead.
    */
   static tryOrElse<T, E>(promise: Promise<T>, onRejection: (reason: unknown) => E): Task<T, E> {
     return new Task((resolve, reject) => {


### PR DESCRIPTION
It turns out (see discussion in #892 and #906) that these are not particularly safe: They assume that the argument is constructed safely, and it is *extremely* easy to end up constructing them in a way that is *not* safe, because a chain of calls which ultimately produces a promise can throw *before* or *outside* the construction of the promise. That is a JS problem, technically, but given the whole point of these types are to make it *easy* to do the right thing, and right now it is too easy to do the *wrong* thing.

Additionally, we want to move to only exporting their safer versions from module scope instead, for the sake of bundle size: items on classes (including static items) are generally *not* tree-shake-able, whereas items in module scope (especially pure functions in module scope!) generally *are*.

At present, I propose that we will remove these in favor of module-scoped functions (see again #906) in an upcoming 9.0 release. At that point, we can also introduce module-scoped versions *mostly* matching these names—the exception being `try`, which is allowed as a method name because it can be disambiguated from the `try` keyword when invoked as a method (`Task.try`), but not as a standalone identifier (`try`). Figuring out exactly how to name that will be a future exercise, however!