### PR TITLE
Task: introduce `safeNullable` function

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -5,6 +5,7 @@
  */
 
 import { curry1, safeToString } from './-private/utils.js';
+import Maybe from './maybe.js';
 import Result, { map as mapResult, mapErr, match as matchResult } from './result.js';
 import Unit from './unit.js';
 
@@ -1449,7 +1450,6 @@ export function safe<
   F extends (...params: never[]) => unknown,
   P extends Parameters<F>,
   R extends Awaited<ReturnType<F>>,
-  E,
 >(fn: F): (...params: P) => Task<R, unknown>;
 /**
   Given a function which returns a `Promise` and a function to transform thrown
@@ -1506,4 +1506,100 @@ export function safe<
 >(fn: F, onError?: (reason: unknown) => E): (...params: P) => Task<R, unknown> {
   let handleError = onError ?? ((e: unknown) => e);
   return (...params) => safelyTryOrElse(handleError, () => fn(...params) as R);
+}
+
+/**
+  Given a function which returns a `Promise` of a nullable type, return
+  a new function with the same parameters but which returns a {@linkcode
+  Task} of a {@linkcode Maybe} instead.
+
+  If you wish to transform the error directly, rather than with a combinator,
+  see the other overload, which accepts an error handler.
+
+  This is basically just a convenience for something you could do yourself by
+  chaining `safe` with `Maybe.of`:
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+  import { safe, safeNullable } from 'true-myth/task';
+
+  async function numberOrNull(value: number): Promise<number | null> {
+    return Math.random() > 0.5 ? value : null;
+  }
+
+  // Using this helper
+  const safeNumberOrNull = safeNullable(numberOrNull);
+
+  // Using `safe` and `Maybe.of` manually
+  const moreWorkThisWay= safe(numberOrNull);
+  let theTask = moreWorkThisWay(123).map((n) => Maybe.of(n));
+  ```
+
+  The convenience is high, though, since you can now use this to create fully
+  safe abstractions to use throughout your codebase, rather than having to
+  remember to do the additional call to `map` the `Task`’s resolution value into
+  a `Maybe` at each call site.
+
+  @param fn A function to wrap so it never throws an error or produces a
+    `Promise` rejection.
+*/
+export function safeNullable<
+  F extends (...params: never[]) => PromiseLike<unknown>,
+  P extends Parameters<F>,
+  R extends Awaited<ReturnType<F>>,
+>(fn: F): (...params: P) => Task<Maybe<NonNullable<R>>, unknown>;
+/**
+  Given a function which returns a `Promise` and a function to transform thrown
+  errors or `Promise` rejections resulting from calling that function, return a
+  new function with the same parameters but which returns a {@linkcode Task}.
+
+  To catch all errors but leave them unhandled and `unknown`, see the other
+  overload.
+
+  This is basically just a convenience for something you could do yourself by
+  chaining `safe` with `Maybe.of`:
+
+  ```ts
+  import Maybe from 'true-myth/maybe';
+  import { safe, safeNullable } from 'true-myth/task';
+
+  async function numberOrNull(value: number): Promise<number | null> {
+    return Math.random() > 0.5 ? value : null;
+  }
+
+  // Using this helper
+  const safeNumberOrNull = safeNullable(numberOrNull);
+
+  // Using `safe` and `Maybe.of` manually
+  const moreWorkThisWay= safe(numberOrNull);
+  let theTask = moreWorkThisWay(123).map((n) => Maybe.of(n));
+  ```
+
+  The convenience is high, though, since you can now use this to create fully
+  safe abstractions to use throughout your codebase, rather than having to
+  remember to do the additional call to `map` the `Task`’s resolution value into
+  a `Maybe` at each call site.
+
+  @param fn A function to wrap so it never throws an error or produces a
+    `Promise` rejection.
+  @param onError A function to use to transform the
+*/
+export function safeNullable<
+  F extends (...params: never[]) => PromiseLike<unknown>,
+  P extends Parameters<F>,
+  R extends Awaited<ReturnType<F>>,
+  E,
+>(fn: F, onError: (reason: unknown) => E): (...params: P) => Task<Maybe<NonNullable<R>>, E>;
+export function safeNullable<
+  F extends (...params: never[]) => PromiseLike<unknown>,
+  P extends Parameters<F>,
+  R extends Awaited<ReturnType<F>>,
+  E,
+>(fn: F, onError?: (reason: unknown) => E): (...params: P) => Task<Maybe<NonNullable<R>>, unknown> {
+  let handleError = onError ?? ((e: unknown) => e);
+  return (...params) =>
+    safelyTryOrElse(handleError, async () => {
+      let theValue = (await fn(...params)) as R;
+      return Maybe.of(theValue) as Maybe<NonNullable<R>>;
+    });
 }


### PR DESCRIPTION
Because we cannot trivially compose the `safe` functions from the `task` and `maybe` modules, courtesy of the intermediate `Promise`, we need a dedicated handler for this scenario.