### PR TITLE
v9.0: remove deprecated code

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1554,13 +1554,6 @@ export function safe<
 }
 
 /**
-  @alias for {@linkcode safe}.
-  @deprecated Switch to using {@linkcode safe} instead. This will be removed at
-    9.0.
- */
-export const wrapReturn = safe;
-
-/**
   The public interface for the {@linkcode Maybe} class *as a value*: a
   constructor and the associated static properties.
  */

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -551,31 +551,6 @@ describe('`Maybe` pure functions', () => {
     expectTypeOf(querySelector).toEqualTypeOf<() => Maybe<string>>();
   });
 
-  test('`wrapReturn`', () => {
-    const empty = '';
-    const emptyResult = MaybeNS.nothing();
-
-    const full = 'hello';
-    const fullResult = MaybeNS.just(full.length);
-
-    const mayBeNull = (s: string): number | null => (s.length > 0 ? s.length : null);
-    const mayNotBeNull = MaybeNS.wrapReturn(mayBeNull);
-
-    expect(mayNotBeNull(empty)).toEqual(emptyResult);
-    expect(mayNotBeNull(full)).toEqual(fullResult);
-
-    const mayBeUndefined = (s: string): number | undefined => (s.length > 0 ? s.length : undefined);
-    const mayNotBeUndefined = MaybeNS.wrapReturn(mayBeUndefined);
-
-    expect(mayNotBeUndefined(empty)).toEqual(emptyResult);
-    expect(mayNotBeUndefined(full)).toEqual(fullResult);
-
-    const returnsNullable = (): string | null => null;
-
-    const querySelector = MaybeNS.wrapReturn(returnsNullable);
-    expectTypeOf(querySelector).toEqualTypeOf<() => Maybe<string>>();
-  });
-
   test('`isJust` with a Just', () => {
     const testJust: Maybe<string> = MaybeNS.just('test');
 


### PR DESCRIPTION
Note: landing this on `main` does not oblige us *not* to make further releases (e.g. bug fixes) against v8.x. We will just need to do like we did for the v5.x series: make an 8.x release branch to keep working against if that comes up!