### PR TITLE
Bump minimum TS version to 5.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,8 +31,7 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        ts-version:
-          ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', 'next']
+        ts-version: ['5.3', '5.4', '5.5', '5.6', '5.7', 'next']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img src='https://img.shields.io/badge/Node-18%20LTS%20%7C%2020%20LTS%20%7C%2022-darkgreen' alt='supported Node versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L59'>
-    <img src='https://img.shields.io/badge/TypeScript-4.7%20%3C=%205.7%20%7C%20next-3178c6' alt='supported TypeScript versions'>
+    <img src='https://img.shields.io/badge/TypeScript-5.3%20%3C=%205.7%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/true-myth/true-myth/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rimraf": "^6.0.0",
     "shelljs": "^0.8.5",
     "typedoc": "^0.27.0",
-    "typescript": "4.7.4",
+    "typescript": "5.3.3",
     "vitest": "^2.0.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@release-it-plugins/lerna-changelog':
         specifier: ^7.0.0
-        version: 7.0.0(release-it@17.11.0(typescript@4.7.4))
+        version: 7.0.0(release-it@17.11.0(typescript@5.3.3))
       '@types/node':
         specifier: ^22.0.0
         version: 22.10.5
@@ -25,7 +25,7 @@ importers:
         version: 3.4.2
       release-it:
         specifier: ^17.0.1
-        version: 17.11.0(typescript@4.7.4)
+        version: 17.11.0(typescript@5.3.3)
       rimraf:
         specifier: ^6.0.0
         version: 6.0.1
@@ -34,10 +34,10 @@ importers:
         version: 0.8.5
       typedoc:
         specifier: ^0.27.0
-        version: 0.27.6(typescript@4.7.4)
+        version: 0.27.6(typescript@5.3.3)
       typescript:
-        specifier: 4.7.4
-        version: 4.7.4
+        specifier: 5.3.3
+        version: 5.3.3
       vitest:
         specifier: ^2.0.1
         version: 2.0.5(@types/node@22.10.5)
@@ -1969,9 +1969,9 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
 
-  typescript@4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -2407,13 +2407,13 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@release-it-plugins/lerna-changelog@7.0.0(release-it@17.11.0(typescript@4.7.4))':
+  '@release-it-plugins/lerna-changelog@7.0.0(release-it@17.11.0(typescript@5.3.3))':
     dependencies:
       execa: 5.1.1
       lerna-changelog: 2.2.0
       lodash: 4.17.21
       mdast-util-from-markdown: 1.3.1
-      release-it: 17.11.0(typescript@4.7.4)
+      release-it: 17.11.0(typescript@5.3.3)
       tmp: 0.2.3
       validate-peer-dependencies: 2.2.0
       which: 2.0.2
@@ -2790,14 +2790,14 @@ snapshots:
       graceful-fs: 4.2.11
       xdg-basedir: 5.1.0
 
-  cosmiconfig@9.0.0(typescript@4.7.4):
+  cosmiconfig@9.0.0(typescript@5.3.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 5.3.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3903,14 +3903,14 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  release-it@17.11.0(typescript@4.7.4):
+  release-it@17.11.0(typescript@5.3.3):
     dependencies:
       '@iarna/toml': 2.2.5
       '@octokit/rest': 20.1.1
       async-retry: 1.3.3
       chalk: 5.4.1
       ci-info: 4.1.0
-      cosmiconfig: 9.0.0(typescript@4.7.4)
+      cosmiconfig: 9.0.0(typescript@5.3.3)
       execa: 8.0.0
       git-url-parse: 14.0.0
       globby: 14.0.2
@@ -4177,16 +4177,16 @@ snapshots:
 
   type-fest@4.26.1: {}
 
-  typedoc@0.27.6(typescript@4.7.4):
+  typedoc@0.27.6(typescript@5.3.3):
     dependencies:
       '@gerrit0/mini-shiki': 1.24.1
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      typescript: 4.7.4
+      typescript: 5.3.3
       yaml: 2.6.1
 
-  typescript@4.7.4: {}
+  typescript@5.3.3: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
TS 5.3 was released in November 2023, so assuming we release this in late January or early February, as seems most likely, that will mean users will have over a year of support. We could conceivably pick 5.4 as well, but it is not presently obvious taht 5.4 would gain us any particular wins in terms of our internals, so I have chosen the slightly more conservative v5.3. The biggest wins for us come earlier or later in the 5.x series, so this seems fine, I think!