### PR TITLE
Bug: `safe` should require `PromiseLike` return types

### DIFF
--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -2007,6 +2007,15 @@ describe('module-scope functions', () => {
         ) => Task<number, unknown>
       >();
 
+      // @ts-expect-error: `safe` only accepts functions which return promises.
+      safe(() => {});
+      // @ts-expect-error: `safe` only accepts functions which return promises.
+      safe(() => 123);
+      // @ts-expect-error: `safe` only accepts functions which return promises.
+      safe(() => true);
+      // @ts-expect-error: `safe` only accepts functions which return promises.
+      safe(() => 'hello');
+
       test('when it throws', async () => {
         let theTask = safeExample(123, { throwErr: true });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();


### PR DESCRIPTION
By allowing non-`PromiseLike` types, this caused an internal error in True Myth’s own implementation. This is a significant downside of using overloads, as well as the unsafe cast of the return type that previously existed in the body of `safe`. Here, get rid of that cast by requiring the argument to be a function that returns a `PromiseLike<T>`, loosen the requirement on `safelyTryOrElse` to require only a `PromiseLike<T>` rather than a `Promise<T>` (given that is all its implementation needs), and add type tests to confirm that this  now produces the expected type errors for functions that do not produce a `PromiseLike`.

Fixes #961

This targets `v8.x` since this is a serious bug on that branch; I will also port it forward to the `main` branch for fixing it in that context once this is merged.