### PR TITLE
Configure Dependabot to update vitest and @vitest/coverage-v8 in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    groups:
+      vitest-packages:
+        patterns:
+          - 'vitest'
+          - '@vitest/coverage-v8'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
This way we won’t end up with annoying things like what was happening in #945 again!