### PR TITLE
Fix type definition of `Strategy`

### DIFF
--- a/src/task/delay.ts
+++ b/src/task/delay.ts
@@ -96,7 +96,7 @@
   );
   ```
  */
-export interface Strategy extends Generator<number> {}
+export interface Strategy extends Iterable<number> {}
 
 /**
   Generate an infinite iterable of integers beginning with `base` and increasing


### PR DESCRIPTION
Using `Generator`, as this did previously, made it difficult to use in concert with `Iterator` subclasses in ES2024. Switching it to a wider definition makes that work correctly while preserving all the existing behavior.

TODO: actually make that true!