### PR TITLE
docs: fix outdated reference to `Result.tryOrElse`

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -422,18 +422,23 @@ export const err = ResultImpl.err;
   function returns.
 
   ```ts
+  import { tryOrElse } from 'true-myth/result';
+
   const aSuccessfulOperation = () => 2 + 2;
 
-  const anOkResult = Result.tryOrElse(
+  const anOkResult = tryOrElse(
     (e) => e,
     aSuccessfulOperation
   ); // => Ok(4)
 
   const thisOperationThrows = () => throw 'Bummer'
 
-  const anErrResult = Result.tryOrElse((e) => e, () => {
-    thisOperationThrows();
-  }); // => Err('Bummer')
+  const anErrResult = tryOrElse(
+    (e) => e,
+    () => {
+      thisOperationThrows();
+    }
+  ); // => Err('Bummer')
  ```
 
   @param onError A function that takes `e` exception and returns what will

--- a/src/task.ts
+++ b/src/task.ts
@@ -1476,11 +1476,13 @@ export function fromPromise<T>(
   > This does not (and by definition cannot) handle errors that happen during
   > construction of the `Result`, because those happen before this is called.
   > See {@linkcode tryOr} and {@linkcode tryOrElse} as well as the corresponding
-  > `Result.tryOr` and `Result.tryOrElse` methods for synchronous functions.
+  > {@linkcode "result".tryOr result.tryOr} and {@linkcode "result".tryOrElse
+  > result.tryOrElse} methods for synchronous functions.
 
   ## Examples
 
-  Given an `Ok`, `fromResult` will produces a {@linkcode Resolved} task.
+  Given an {@linkcode "result".Ok Ok<T, E>}, `fromResult` will produces a
+  {@linkcode Resolved Resolved<T, E>} task.
 
   ```ts
   import { fromResult } from 'true-myth/task';


### PR DESCRIPTION
Fixes #974 (in conjunction with landing this same fix as part of #988).