### PR TITLE
Feature: generalize inference for `andThen` and `orElse` [backport]

### DIFF
--- a/src/-private/utils.ts
+++ b/src/-private/utils.ts
@@ -13,7 +13,7 @@ export const isVoid = (value: unknown): value is undefined | null =>
   typeof value === 'undefined' || value === null;
 
 /** @internal */
-export function curry1<T, U>(op: (t: T) => U, item?: T) {
+export function curry1<T, U>(op: (t: T) => U, item?: T): U | ((t: T) => U) {
   return item !== undefined ? op(item) : op;
 }
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -32,6 +32,12 @@ export type MaybeJSON<T> = JustJSON<T> | NothingJSON;
 
 type Repr<T> = [tag: 'Just', value: T] | [tag: 'Nothing'];
 
+declare const IsMaybe: unique symbol;
+type AnyMaybe = Maybe<{}>;
+
+type SomeMaybe<T> = { [IsMaybe]: T };
+type ValueFor<R extends AnyMaybe> = R extends SomeMaybe<infer T> ? T : never;
+
 /**
   A single instance of the `Nothing` object, to minimize memory usage. No matter
   how many `Maybe`s are floating around, there will always be exactly and only
@@ -47,6 +53,8 @@ class MaybeImpl<T> {
   // instance, but TS cannot see that: it is only set for `Nothing` instances
   // when `NOTHING` does not already exist.
   private repr!: Repr<T>;
+
+  declare readonly [IsMaybe]: T;
 
   constructor(value?: T | null | undefined) {
     if (isVoid(value)) {
@@ -201,8 +209,10 @@ class MaybeImpl<T> {
   }
 
   /** Method variant for {@linkcode orElse} */
+  orElse(orElseFn: () => Maybe<T>): Maybe<T>;
+  orElse<R extends AnyMaybe>(orElseFn: () => R): Maybe<ValueFor<R>>;
   orElse(orElseFn: () => Maybe<T>): Maybe<T> {
-    return this.repr[0] === 'Just' ? (this as Maybe<T>) : orElseFn();
+    return (this.repr[0] === 'Just' ? this : orElseFn()) as Maybe<T>;
   }
 
   /** Method variant for {@linkcode and} */
@@ -211,6 +221,8 @@ class MaybeImpl<T> {
   }
 
   /** Method variant for {@linkcode andThen} */
+  andThen<U>(andThenFn: (t: T) => Maybe<U>): Maybe<U>;
+  andThen<R extends AnyMaybe>(andThenFn: (t: T) => R): Maybe<ValueFor<R>>;
   andThen<U>(andThenFn: (t: T) => Maybe<U>): Maybe<U> {
     return (this.repr[0] === 'Just' ? andThenFn(this.repr[1]) : this) as Maybe<U>;
   }
@@ -709,7 +721,14 @@ export function and<T, U>(
                 `Just`, otherwise `Nothing` if `maybe` is a `Nothing`.
  */
 export function andThen<T, U>(thenFn: (t: T) => Maybe<U>, maybe: Maybe<T>): Maybe<U>;
+export function andThen<T, R extends AnyMaybe>(
+  thenFn: (t: T) => R,
+  maybe: Maybe<T>
+): Maybe<ValueFor<R>>;
 export function andThen<T, U>(thenFn: (t: T) => Maybe<U>): (maybe: Maybe<T>) => Maybe<U>;
+export function andThen<T, R extends AnyMaybe>(
+  thenFn: (t: T) => R
+): (maybe: Maybe<T>) => Maybe<ValueFor<R>>;
 export function andThen<T, U>(
   thenFn: (t: T) => Maybe<U>,
   maybe?: Maybe<T>
@@ -771,12 +790,17 @@ export function or<T>(
   @returns      The `maybe` if it is `Just`, or the `Maybe` returned by `elseFn`
                 if the `maybe` is `Nothing`.
  */
-export function orElse<T>(elseFn: () => Maybe<T>, maybe: Maybe<T>): Maybe<T>;
-export function orElse<T>(elseFn: () => Maybe<T>): (maybe: Maybe<T>) => Maybe<T>;
-export function orElse<T>(
-  elseFn: () => Maybe<T>,
+export function orElse<T, R extends AnyMaybe>(
+  elseFn: () => R,
+  maybe: Maybe<T>
+): Maybe<ValueFor<R>>;
+export function orElse<T, R extends AnyMaybe>(
+  elseFn: () => R
+): (maybe: Maybe<T>) => Maybe<ValueFor<R>>;
+export function orElse<T, R extends AnyMaybe>(
+  elseFn: () => R,
   maybe?: Maybe<T>
-): Maybe<T> | ((maybe: Maybe<T>) => Maybe<T>) {
+): Maybe<ValueFor<R>> | ((maybe: Maybe<T>) => Maybe<ValueFor<R>>) {
   const op = (m: Maybe<T>) => m.orElse(elseFn);
   return curry1(op, maybe);
 }
@@ -1125,12 +1149,12 @@ export function equals<T>(mb: Maybe<T>, ma?: Maybe<T>): boolean | ((a: Maybe<T>)
   @param maybeFn maybe a function from T to U
   @param maybe maybe a T to apply to `fn`
  */
-export function ap<T, U extends {}>(maybeFn: Maybe<(t: T) => U>, maybe: Maybe<T>): Maybe<U>;
-export function ap<T, U extends {}>(maybeFn: Maybe<(t: T) => U>): (maybe: Maybe<T>) => Maybe<U>;
+export function ap<T, U extends {}>(maybeFn: Maybe<(t: T) => U>, maybe: Maybe<T>): Maybe<T | U>;
+export function ap<T, U extends {}>(maybeFn: Maybe<(t: T) => U>): (maybe: Maybe<T>) => Maybe<T | U>;
 export function ap<T, U extends {}>(
   maybeFn: Maybe<(t: T) => U>,
   maybe?: Maybe<T>
-): Maybe<U> | ((val: Maybe<T>) => Maybe<U>) {
+): Maybe<T | U> | ((val: Maybe<T>) => Maybe<T | U>) {
   const op = (m: Maybe<T>) => maybeFn.ap(m);
   return curry1(op, maybe);
 }
@@ -1346,8 +1370,8 @@ export type Unwrapped<T> = T extends Maybe<infer U> ? U : T;
 export type TransposedArray<T extends ReadonlyArray<Maybe<unknown>>> =
   // Array only extends T when the item is *not* `readonly`.
   Array<unknown> extends T
-    ? Maybe<{ -readonly [K in keyof T]: Unwrapped<T[K]> }>
-    : Maybe<{ [K in keyof T]: Unwrapped<T[K]> }>;
+  ? Maybe<{ -readonly [K in keyof T]: Unwrapped<T[K]> }>
+  : Maybe<{ [K in keyof T]: Unwrapped<T[K]> }>;
 
 /**
   Safely extract a key from an object, returning {@linkcode Just} if the key has
@@ -1549,7 +1573,7 @@ export function safe<
   F extends AnyFunction,
   P extends Parameters<F>,
   R extends NonNullable<ReturnType<F>>,
->(fn: F): (...params: P) => Maybe<R> {
+  >(fn: F): (...params: P) => Maybe<R> {
   return (...params) => Maybe.of(fn(...params) as R);
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -36,9 +36,22 @@ export type ResultJSON<T, E> = OkJSON<T> | ErrJSON<E>;
 
 type Repr<T, E> = [tag: 'Ok', value: T] | [tag: 'Err', error: E];
 
+declare const IsResult: unique symbol;
+type AnyResult = Result<unknown, unknown>;
+
+type SomeResult<T, E> = { [IsResult]: [T, E] };
+
+type TypesFor<R extends AnyResult> =
+  R extends SomeResult<infer T, infer E> ? { ok: T; err: E } : never;
+
+type OkFor<R extends AnyResult> = TypesFor<R>['ok'];
+type ErrFor<R extends AnyResult> = TypesFor<R>['err'];
+
 // Defines the *implementation*, but not the *types*. See the exports below.
 class ResultImpl<T, E> {
   private constructor(private repr: Repr<T, E>) {}
+
+  declare readonly [IsResult]: [T, E];
 
   /**
     Create an instance of {@linkcode Ok}.
@@ -167,8 +180,10 @@ class ResultImpl<T, E> {
   }
 
   /** Method variant for {@linkcode orElse} */
+  orElse<F>(orElseFn: (err: E) => Result<T, F>): Result<T, F>;
+  orElse<R extends AnyResult>(orElseFn: (err: E) => R): Result<T | OkFor<R>, ErrFor<R>>;
   orElse<F>(orElseFn: (err: E) => Result<T, F>): Result<T, F> {
-    return (this.repr[0] === 'Ok' ? this : orElseFn(this.repr[1])) as Result<T, F>;
+    return this.repr[0] === 'Ok' ? (this as Ok<T, E>).cast() : orElseFn(this.repr[1]);
   }
 
   /** Method variant for {@linkcode and} */
@@ -178,8 +193,10 @@ class ResultImpl<T, E> {
   }
 
   /** Method variant for {@linkcode andThen} */
+  andThen<U>(andThenFn: (t: T) => Result<U, E>): Result<U, E>;
+  andThen<R extends AnyResult>(andThenFn: (t: T) => R): Result<OkFor<R>, E | ErrFor<R>>;
   andThen<U>(andThenFn: (t: T) => Result<U, E>): Result<U, E> {
-    return (this.repr[0] === 'Ok' ? andThenFn(this.repr[1]) : this) as Result<U, E>;
+    return this.repr[0] === 'Ok' ? andThenFn(this.repr[1]) : (this as Err<T, E>).cast();
   }
 
   /** Method variant for {@linkcode unwrapOr} */
@@ -784,17 +801,17 @@ export function and<T, U, E>(
   @param thenFn  The function to apply to the wrapped `T` if `maybe` is `Just`.
   @param result  The `Maybe` to evaluate and possibly apply a function to.
  */
-export function andThen<T, U, E>(
-  thenFn: (t: T) => Result<U, E>,
+export function andThen<T, E, R extends AnyResult>(
+  thenFn: (t: T) => R,
   result: Result<T, E>
-): Result<U, E>;
-export function andThen<T, U, E>(
-  thenFn: (t: T) => Result<U, E>
-): (result: Result<T, E>) => Result<U, E>;
-export function andThen<T, U, E>(
-  thenFn: (t: T) => Result<U, E>,
+): Result<OkFor<R>, E | ErrFor<R>>;
+export function andThen<T, E, R extends AnyResult>(
+  thenFn: (t: T) => R
+): (result: Result<T, E>) => Result<OkFor<R>, E | ErrFor<R>>;
+export function andThen<T, E, R extends AnyResult>(
+  thenFn: (t: T) => R,
   result?: Result<T, E>
-): Result<U, E> | ((result: Result<T, E>) => Result<U, E>) {
+): Result<OkFor<R>, E | ErrFor<R>> | ((result: Result<T, E>) => Result<OkFor<R>, E | ErrFor<R>>) {
   const op = (r: Result<T, E>) => r.andThen(thenFn);
   return curry1(op, result);
 }
@@ -858,17 +875,17 @@ export function or<T, E, F>(
   @returns      The `result` if it is `Ok`, or the `Result` returned by `elseFn`
                 if `result` is an `Err.
  */
-export function orElse<T, E, F>(
-  elseFn: (err: E) => Result<T, F>,
+export function orElse<T, E, R extends AnyResult>(
+  elseFn: (err: E) => R,
   result: Result<T, E>
-): Result<T, F>;
-export function orElse<T, E, F>(
-  elseFn: (err: E) => Result<T, F>
-): (result: Result<T, E>) => Result<T, F>;
-export function orElse<T, E, F>(
-  elseFn: (err: E) => Result<T, F>,
+): Result<T | OkFor<R>, ErrFor<R>>;
+export function orElse<T, E, R extends AnyResult>(
+  elseFn: (err: E) => R
+): (result: Result<T, E>) => Result<T | OkFor<R>, ErrFor<R>>;
+export function orElse<T, E, R extends AnyResult>(
+  elseFn: (err: E) => R,
   result?: Result<T, E>
-): Result<T, F> | ((result: Result<T, E>) => Result<T, F>) {
+): Result<T | OkFor<R>, ErrFor<R>> | ((result: Result<T, E>) => Result<T | OkFor<R>, ErrFor<R>>) {
   const op = (r: Result<T, E>) => r.orElse(elseFn);
   return curry1(op, result);
 }

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -419,10 +419,8 @@ describe('`Task`', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 'hello';
-          let theTask = Task.resolve<number, string>(123).and(
-            Task.reject<number, string>(theReason)
-          );
-          expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+          let theTask = Task.resolve<number, string>(123).and(Task.reject(theReason));
+          expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
@@ -431,9 +429,7 @@ describe('`Task`', () => {
       describe('when the first Task rejects', () => {
         test('when the second Task resolves', async () => {
           let theReason = 123;
-          let theTask = Task.reject<string, number>(theReason).and(
-            Task.resolve<number, number>(456)
-          );
+          let theTask = Task.reject(theReason).and(Task.resolve(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
@@ -441,10 +437,8 @@ describe('`Task`', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 123;
-          let theTask = Task.reject<string, number>(theReason).and(
-            Task.reject<string, number>(456)
-          );
-          expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
+          let theTask = Task.reject(theReason).and(Task.reject(456));
+          expectTypeOf(theTask).toEqualTypeOf<Task<never, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
@@ -452,10 +446,10 @@ describe('`Task`', () => {
 
       // Matches the text in the docs.
       test('all combinations', async () => {
-        let resolvedA = Task.resolve<string, string>('A');
-        let resolvedB = Task.resolve<string, string>('B');
-        let rejectedA = Task.reject<string, string>('bad');
-        let rejectedB = Task.reject<string, string>('lame');
+        let resolvedA = Task.resolve('A');
+        let resolvedB = Task.resolve('B');
+        let rejectedA = Task.reject('bad');
+        let rejectedB = Task.reject('lame');
 
         let aAndB = resolvedA.and(resolvedB);
         await aAndB;
@@ -488,7 +482,7 @@ describe('`Task`', () => {
 
       describe('when the first `Task` resolves', () => {
         test('when the second is pending', async () => {
-          let theTask = Task.resolve<number, string>(123).andThen((n) => {
+          let theTask = Task.resolve(123).andThen((n) => {
             return new Task<number, string>((resolve) => {
               resolve(Math.round(n / 2));
             });
@@ -524,7 +518,7 @@ describe('`Task`', () => {
       describe('when the first `Task` rejects', () => {
         test('when the second is pending', async () => {
           let theReason = 'alas!';
-          let theTask = Task.reject<number, string>(theReason).andThen((n) => {
+          let theTask = Task.reject(theReason).andThen((n) => {
             return new Task<number, string>((resolve) => {
               resolve(Math.round(n / 2));
             });
@@ -550,13 +544,49 @@ describe('`Task`', () => {
         test('when the second `Task` rejects', async () => {
           let theReason = 'nope';
           let theTask = Task.reject<number, string>(theReason).andThen((n) =>
-            Task.reject<number, string>(n % 2 == 0 ? 'yep' : 'nope')
+            Task.reject(n % 2 == 0 ? 'yep' : 'nope')
           );
-          expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+          expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
 
           let result = await theTask;
           expect(unwrapErr(result)).toEqual(theReason);
         });
+      });
+
+      test('with multiple types in the resolution and rejection', async () => {
+        class Branded<T extends string> {
+          declare readonly _name: T;
+        }
+
+        class RejA extends Branded<'rej-a'> { }
+        class RejB extends Branded<'rej-b'> { }
+
+        class ResA extends Branded<'res-a'> { }
+        class ResB extends Branded<'res-b'> { }
+
+        let theTask = new Task<Branded<'res'>, Branded<'rej'>>(() => { }).andThen((_) => {
+          if (Math.random() < 0.1) {
+            return Task.resolve(new ResA());
+          }
+
+          if (Math.random() < 0.2) {
+            return Task.reject(new RejA());
+          }
+
+          if (Math.random() < 0.3) {
+            return Task.resolve(new ResB());
+          }
+
+          return Task.reject(new RejB());
+        });
+
+        if (theTask.isResolved) {
+          // Does *not* absorb initial type.
+          expectTypeOf(theTask.value).toEqualTypeOf<ResA | ResB>();
+        } else if (theTask.isRejected) {
+          // Absorbs initial type as well.
+          expectTypeOf(theTask.reason).toEqualTypeOf<Branded<'rej'> | RejA | RejB>();
+        }
       });
     });
 
@@ -585,9 +615,7 @@ describe('`Task`', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 'hello';
-          let theTask = Task.resolve<number, string>(123).or(
-            Task.reject<number, string>(theReason)
-          );
+          let theTask = Task.resolve(123).or(Task.reject(theReason));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toEqual(123);
@@ -596,7 +624,7 @@ describe('`Task`', () => {
 
       describe('when the first Task rejects', () => {
         test('when the second is pending', async () => {
-          let theFirst = Task.reject<unknown, string>('blergh');
+          let theFirst = Task.reject('blergh');
           let theSecond = new Task<number, never>(noOp);
 
           let theChain = theFirst.or(theSecond);
@@ -610,16 +638,16 @@ describe('`Task`', () => {
         });
 
         test('when the second Task resolves', async () => {
-          let theTask = Task.reject<string, number>(123).or(Task.resolve<string, number>('hello'));
-          expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
+          let theTask = Task.reject(123).or(Task.resolve('hello'));
+          expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toBe('hello');
         });
 
         test('when the second Task rejects', async () => {
           let theReason = 123;
-          let theTask = Task.reject<string, number>(theReason).or(Task.reject<string, number>(456));
-          expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
+          let theTask = Task.reject(theReason).or(Task.reject(456));
+          expectTypeOf(theTask).toEqualTypeOf<Task<never, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(456);
         });
@@ -627,10 +655,10 @@ describe('`Task`', () => {
 
       // Matches the text in the docs.
       test('all combinations', async () => {
-        let resolvedA = Task.resolve<string, string>('A');
-        let resolvedB = Task.resolve<string, string>('B');
-        let rejectedA = Task.reject<string, string>('bad');
-        let rejectedB = Task.reject<string, string>('lame');
+        let resolvedA = Task.resolve('A');
+        let resolvedB = Task.resolve('B');
+        let rejectedA = Task.reject('bad');
+        let rejectedB = Task.reject('lame');
 
         let aOrB = resolvedA.or(resolvedB);
         await aOrB;
@@ -663,7 +691,7 @@ describe('`Task`', () => {
 
       describe('when the first `Task` resolves', () => {
         test('when the second is pending', async () => {
-          let theFirst = Task.resolve<number, string>(123);
+          let theFirst = Task.resolve(123);
           let theSecond = new Task<number, boolean>(noOp);
           let theChain = theFirst.orElse(() => theSecond);
 
@@ -714,9 +742,9 @@ describe('`Task`', () => {
 
         test('when the second `Task` resolves', async () => {
           let theTask = Task.reject<number, string>('nope').orElse((reason) =>
-            Task.resolve<number, string>(reason.length)
+            Task.resolve(reason.length)
           );
-          expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
+          expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
           let result = await theTask;
           expect(unwrap(result)).toBe(4);
@@ -724,13 +752,49 @@ describe('`Task`', () => {
 
         test('when the second `Task` rejects', async () => {
           let theTask = Task.reject<number, string>('first error').orElse((reason) =>
-            Task.reject<number, boolean>(reason.includes("'"))
+            Task.reject(reason.includes("'"))
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, boolean>>();
 
           let result = await theTask;
           expect(unwrapErr(result)).toBe(false);
         });
+      });
+
+      test('with multiple types in the resolution and rejection', async () => {
+        class Branded<T extends string> {
+          declare readonly _name: T;
+        }
+
+        class RejA extends Branded<'rej-a'> { }
+        class RejB extends Branded<'rej-b'> { }
+
+        class ResA extends Branded<'res-a'> { }
+        class ResB extends Branded<'res-b'> { }
+
+        let theTask = new Task<Branded<'res'>, Branded<'rej'>>(() => { }).orElse((_) => {
+          if (Math.random() < 0.1) {
+            return Task.resolve(new ResA());
+          }
+
+          if (Math.random() < 0.2) {
+            return Task.reject(new RejA());
+          }
+
+          if (Math.random() < 0.3) {
+            return Task.resolve(new ResB());
+          }
+
+          return Task.reject(new RejB());
+        });
+
+        if (theTask.isResolved) {
+          // Absorbs initial type as well.
+          expectTypeOf(theTask.value).toEqualTypeOf<Branded<'res'> | ResA | ResB>();
+        } else if (theTask.isRejected) {
+          // Does *not* absorb initial type.
+          expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
+        }
       });
     });
 
@@ -755,7 +819,7 @@ describe('`Task`', () => {
         // Will never resolve, but should be collected at the end of the test.
         // Note that this test passes when, and only when, no test assertions
         // run at all.
-        let task = new Task(() => {});
+        let task = new Task(() => { });
         task.match({
           Resolved: () => expect.unreachable(),
           Rejected: () => expect.unreachable(),
@@ -1988,9 +2052,9 @@ describe('module-scope functions', () => {
         throwErr = false,
         rejectPromise = false,
       }: { throwErr?: boolean; rejectPromise?: boolean } = {
-        throwErr: false,
-        rejectPromise: false,
-      }
+          throwErr: false,
+          rejectPromise: false,
+        }
     ): Promise<number> {
       if (throwErr) {
         throw new Error(ERROR_MESSAGE);
@@ -2009,7 +2073,7 @@ describe('module-scope functions', () => {
       >();
 
       // @ts-expect-error: `safe` only accepts functions which return promises.
-      safe(() => {});
+      safe(() => { });
       // @ts-expect-error: `safe` only accepts functions which return promises.
       safe(() => 123);
       // @ts-expect-error: `safe` only accepts functions which return promises.
@@ -2109,10 +2173,10 @@ describe('module-scope functions', () => {
         rejectPromise = false,
         returnNull = false,
       }: { throwErr?: boolean; rejectPromise?: boolean; returnNull?: boolean } = {
-        throwErr: false,
-        rejectPromise: false,
-        returnNull: false,
-      }
+          throwErr: false,
+          rejectPromise: false,
+          returnNull: false,
+        }
     ): Promise<number | null> {
       if (throwErr) {
         throw new Error(ERROR_MESSAGE);
@@ -2547,9 +2611,7 @@ describe('module-scope functions', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 'hello';
-          let theTask = and(Task.reject<number, string>(theReason))(
-            Task.resolve<number, string>(123)
-          );
+          let theTask = and(Task.reject<number, string>(theReason))(Task.resolve(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
@@ -2559,9 +2621,7 @@ describe('module-scope functions', () => {
       describe('when the first Task rejects', () => {
         test('when the second Task resolves', async () => {
           let theReason = 123;
-          let theTask = and(Task.resolve<number, number>(456))(
-            Task.reject<string, number>(theReason)
-          );
+          let theTask = and(Task.resolve<number, number>(456))(Task.reject(theReason));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
@@ -2569,9 +2629,7 @@ describe('module-scope functions', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 123;
-          let theTask = and(Task.reject<string, number>(456))(
-            Task.reject<string, number>(theReason)
-          );
+          let theTask = and(Task.reject<string, number>(456))(Task.reject(theReason));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
@@ -2644,6 +2702,42 @@ describe('module-scope functions', () => {
         expect(unwrapErr(result)).toEqual(theReason);
       });
     });
+
+    test('with multiple types in the resolution and rejection', async () => {
+      class Branded<T extends string> {
+        declare readonly _name: T;
+      }
+
+      class RejA extends Branded<'rej-a'> { }
+      class RejB extends Branded<'rej-b'> { }
+
+      class ResA extends Branded<'res-a'> { }
+      class ResB extends Branded<'res-b'> { }
+
+      let theTask = andThen((_) => {
+        if (Math.random() < 0.1) {
+          return Task.resolve(new ResA());
+        }
+
+        if (Math.random() < 0.2) {
+          return Task.reject(new RejA());
+        }
+
+        if (Math.random() < 0.3) {
+          return Task.resolve(new ResB());
+        }
+
+        return Task.reject(new RejB());
+      }, new Task<Branded<'res'>, Branded<'rej'>>(() => { }));
+
+      if (theTask.isResolved) {
+        // Does *not* absorb initial type.
+        expectTypeOf(theTask.value).toEqualTypeOf<ResA | ResB>();
+      } else if (theTask.isRejected) {
+        // Absorbs initial type as well.
+        expectTypeOf(theTask.reason).toEqualTypeOf<Branded<'rej'> | RejA | RejB>();
+      }
+    });
   });
 
   describe('or', () => {
@@ -2670,14 +2764,14 @@ describe('module-scope functions', () => {
 
       describe('when the first Task rejects', () => {
         test('when the second Task resolves', async () => {
-          let theTask = or(Task.resolve('B'), Task.reject<string, number>(123));
+          let theTask = or(Task.resolve('B'), Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toBe('B');
         });
 
         test('when the second Task rejects', async () => {
-          let theTask = or(Task.reject<string, number>(456), Task.reject<string, number>(123));
+          let theTask = or(Task.reject<string, number>(456), Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toBe(456);
@@ -2696,9 +2790,7 @@ describe('module-scope functions', () => {
 
         test('when the second Task rejects', async () => {
           let theReason = 'hello';
-          let theTask = or(Task.reject<number, string>(theReason))(
-            Task.resolve<number, string>(123)
-          );
+          let theTask = or(Task.reject<number, string>(theReason))(Task.resolve(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, string>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toBe(123);
@@ -2707,14 +2799,14 @@ describe('module-scope functions', () => {
 
       describe('when the first Task rejects', () => {
         test('when the second Task resolves', async () => {
-          let theTask = or(Task.resolve('B'))(Task.reject<string, number>(123));
+          let theTask = or(Task.resolve('B'))(Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toBe('B');
         });
 
         test('when the second Task rejects', async () => {
-          let theTask = or(Task.reject<string, number>(456))(Task.reject<string, number>(123));
+          let theTask = or(Task.reject<string, number>(456))(Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toBe(456);
@@ -2751,6 +2843,42 @@ describe('module-scope functions', () => {
 
       let result = await theTask;
       expect(unwrapErr(result)).toBe(11);
+    });
+
+    test('with multiple types in the resolution and rejection', async () => {
+      class Branded<T extends string> {
+        declare readonly _name: T;
+      }
+
+      class RejA extends Branded<'rej-a'> { }
+      class RejB extends Branded<'rej-b'> { }
+
+      class ResA extends Branded<'res-a'> { }
+      class ResB extends Branded<'res-b'> { }
+
+      let theTask = orElse((_) => {
+        if (Math.random() < 0.1) {
+          return Task.resolve(new ResA());
+        }
+
+        if (Math.random() < 0.2) {
+          return Task.reject(new RejA());
+        }
+
+        if (Math.random() < 0.3) {
+          return Task.resolve(new ResB());
+        }
+
+        return Task.reject(new RejB());
+      }, new Task<Branded<'res'>, Branded<'rej'>>(() => { }));
+
+      if (theTask.isResolved) {
+        // Absorbs initial type as well.
+        expectTypeOf(theTask.value).toEqualTypeOf<Branded<'res'> | ResA | ResB>();
+      } else if (theTask.isRejected) {
+        // Does *not* absorb initial type.
+        expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
+      }
     });
   });
 
@@ -3037,8 +3165,8 @@ describe('module-scope functions', () => {
     });
 
     test('type checks when explicitly passed a `Strategy`', () => {
-      let retryable = () => new Task(() => {});
-      let strategy = function* (): Strategy {};
+      let retryable = () => new Task(() => { });
+      let strategy = function* (): Strategy { };
       expectTypeOf(withRetries).toBeCallableWith(retryable, strategy());
     });
   });
@@ -3233,7 +3361,7 @@ function stringify(reason: unknown): string {
   return JSON.stringify(reason, null, 2);
 }
 
-function noOp() {}
+function noOp() { }
 
 function* take<T>(iterable: Iterable<T>, count: number): IterableIterator<T> {
   let taken = 0;
@@ -3252,12 +3380,12 @@ function printError(e: Error): string {
   let maybeCause =
     e.cause instanceof Error ? Maybe.just(printError(e.cause)) :
 
-    Maybe.of(
-      // @ts-ignore: work around a bug in older TypeScript versions where the
-      // lib definitions incorrectly required `cause` to be an `Error`. That is
-      // the best practice, but it is not required.
-      e.cause?.toString()
-    );
+      Maybe.of(
+        // @ts-ignore: work around a bug in older TypeScript versions where the
+        // lib definitions incorrectly required `cause` to be an `Error`. That is
+        // the best practice, but it is not required.
+        e.cause?.toString()
+      );
 
   let cause = maybeCause.mapOr('', (cause) => `\n\tcaused by: ${cause}`);
   return `${e.name}: ${e.message}${cause}`;


### PR DESCRIPTION
> [!NOTE]
> Mechanically, I am going to land #1010 against `main` and then backport it to v8.x here. I will release v8.6 with this and #1009, and that should (presumably!) be the end of the 8.x series. After that, I will be releasing v9.0, with the new docs site!

---

Introduce some type machinery to support inferring a distributive type in the output of `andThen` or `orElse` for all the core types, while avoiding circularity in the type definitions.

The fundamental goal here is to make it so that when a user returns a type that is technically a union of the class, `Maybe<A> | Maybe<B>`, we instead produce a union of the type parameter, `Maybe<A | B>`. This can come up quite easily when a user is building up a safe abstraction in idiomatic TS. For example (in line with the user issue that showed us the need for this change), you might be building up a pre-configured web “client” that simply returns object types inline:

```ts
import * as task from 'true-myth/result';

let fetch = safe(window.fetch, (cause) => ({
  kind: 'NetworkError' as const,
  cause,
}));

let get = (url: string) =>
  fetch(new URL(url)).andThen((response) => {
    if (response.status >= 400 && response.status < 500) {
      return Task.reject({
        kind: 'ClientError' as const,
        response,
      });
    }

    if (response.status >= 500 && response.status < 600) {
      return Task.reject({
        kind: 'ServerError' as const,
        response,
      });
    }

    return Task.resolve(response);
  });

let theResult = await get('https://true-myth.js.org');
```

Prior to this change, the type collapsed to `Task<unknown, unknown>` unless constrained explicitly at the `andThen` call site, because the type returned here as TypeScript sees it is not a single `Task` with a union of the custom error object types, but rather multiple distinct `Task` types: one for each custom error object type! This is technically *accurate*, but in practice is not what people expect, and because we constrain the return type to be a `Task`, it is always safe in practice for people to treat it as `Task<A | B>` instead of `Task<A> | Task<B>`, and likewise for the equivalent `Maybe` and `Result` types.

We can get the desired behavior with conditional distributive types. By using a constrained type parameter for the whole returned wrapper type, rather than the fixed type parameters for the wrapper type, we can distribute unions back into the type. For example, with `Task`:

```ts
class Task<T, E> {
  // ...
  
  andThen<R extends Task<unknown, unknown>>(
    fn: (t: T) => R
  ): R extends Task<infer U, infer F> ? Task<U, E | F> : never;
}
```

This type will always safely and correctly produce a `Task<U, E | F>` because of the initial constraint, and indeed will allow gathering up additional types as it goes along with the original error type, but both the `U` and `F` types produced here will be distributed over any union (explicit or implicit) in the return type of the passed `fn`.

Unfortunately, that code as written *does not work* because we define the types *not* as the classes but instead as the union of types derived from them. With `Maybe`, for example:

```ts
interface Just<T> extends MaybeImpl<T> {
  readonly variant: 'Just';
  value: T;
  isJust: true;
  isNothing: false;
}

interface Nothing<T> extends Omit<MaybeImpl<T>, 'value'> {
  readonly variant: 'Nothing';
  isJust: false;
  isNothing: true;
}

type Maybe<T> = Just<T> | Nothing<T>;
```

If we now try to define the return type of `MaybeImpl.prototype.andThen` with this definition of `Maybe`, TypeScript will complain about circular definition of the `Maybe` type, and likewise for `Result` and `Task`.

To work around that, introduce a small bit of additional type machinery:

- Type-only (i.e. `declare`-only) symbols, `IsMaybe`, `IsResult`, and `IsTask`, that are attached to the `Maybe`, `Result`, and `Task` classes respectively, using `declare` syntax, and attaching the type parameters for the classes to the .

- Corresponding `SomeMaybe`, `SomeResult`, and `SomeTask` types that use the declared symbols with their associated use of the type parameters to carry all of the relevant type information *without* any additional runtime overhead *and* without introducing circularity in the type definitions.
  
- A type utility to pluck the type parameters out of those definitions, e.g. `TypesFor<S extends AnyTask>`. This provides enough information to get the required output for `andThen` and `orElse` without any circularity in the definition.

- In `task`, additionally redefine the existing `ResolvesTo` and `RejectsWith` utility types in terms of the new utility. Note that this is not breaking because those types, as well as the types they depend on, are expressly `@internal`.

Fixes #994