### PR TITLE
Task: `withRetries` is callable with any `Strategy` [backport]

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -2349,7 +2349,7 @@ function identity<T>(value: T): T {
  */
 export function withRetries<T, E>(
   retryable: (status: RetryStatus) => Task<T, E | StopRetrying> | StopRetrying,
-  strategy: IterableIterator<number> = (function* () {
+  strategy: Delay.Strategy = (function* () {
     for (let i = 0; i < 3; i++) {
       yield 0;
     }

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -48,6 +48,7 @@ import {
   jitter,
   linear,
   none,
+  type Strategy,
 } from 'true-myth/task/delay';
 import Maybe from 'true-myth/maybe';
 import Result from 'true-myth/result';
@@ -3033,6 +3034,12 @@ describe('module-scope functions', () => {
           /TrueMyth\.Task\.RetryFailed: Stopped retrying after 5 tries \(\d+ms\)/
         );
       });
+    });
+
+    test('type checks when explicitly passed a `Strategy`', () => {
+      let retryable = () => new Task(() => {});
+      let strategy = function* (): Strategy {};
+      expectTypeOf(withRetries).toBeCallableWith(retryable, strategy());
     });
   });
 


### PR DESCRIPTION
Lesson (re)learned: Always, always, *always* add the breaking test first.