### PR TITLE
cleanup: use lowercase name convention for namespaces

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1369,6 +1369,8 @@ export type TransposedArray<T extends ReadonlyArray<Maybe<unknown>>> =
   However, it also works correctly with dictionary types:
 
   ```ts
+  import * as maybe from 'true-myth/maybe';
+
   type Dict<T> = { [key: string]: T };
 
   const score: Dict<number> = {
@@ -1376,9 +1378,9 @@ export type TransposedArray<T extends ReadonlyArray<Maybe<unknown>>> =
     player2: 1
   };
 
-  console.log(Maybe.property('player1', score)); // Just(0)
-  console.log(Maybe.property('player2', score)); // Just(1)
-  console.log(Maybe.property('player3', score)); // Nothing
+  console.log(maybe.property('player1', score)); // Just(0)
+  console.log(maybe.property('player2', score)); // Just(1)
+  console.log(maybe.property('player3', score)); // Nothing
   ```
 
   The order of keys is so that it can be partially applied:
@@ -1386,7 +1388,7 @@ export type TransposedArray<T extends ReadonlyArray<Maybe<unknown>>> =
   ```ts
   type Person = { name?: string };
 
-  const lookupName = Maybe.property('name');
+  const lookupName = maybe.property('name');
 
   const me: Person = { name: 'Chris' };
   console.log(lookupName(me)); // Just('Chris')

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -392,8 +392,8 @@ export const nothing = MaybeImpl.nothing;
   invoke `Maybe.of` with an explicit type parameter:
 
   ```ts
-  import * as Maybe from 'true-myth/maybe';
-  const foo = Maybe.of<string>(null);
+  import * as maybe from 'true-myth/maybe';
+  const foo = maybe.of<string>(null);
   ```
 
   This is usually only important in two cases:

--- a/src/task.ts
+++ b/src/task.ts
@@ -12,7 +12,7 @@ import * as delay from './task/delay.js';
 
 // Make the `delay` namespace available as `task.delay` for convenience, and as
 // `task.Delay` for backward compatibility. This lets people do something like
-// `task.withRetries(aTask, task.delay.exponential(1_000).take(10))`.export {
+// `task.withRetries(aTask, task.delay.exponential(1_000).take(10))`.
 export {
   /**
     Re-exports `true-myth/task/delay` as a namespace object for convenience.
@@ -1401,10 +1401,10 @@ export function fromPromise<T>(
 
   ```ts
 
-  import * as Task from 'true-myth/task';
+  import * as task from 'true-myth/task';
   import { ok } from 'true-myth/result';
 
-  let theTask = Task.fromResult(ok(123));
+  let theTask = task.fromResult(ok(123));
   ```
 
   As an alternative, it can be useful to rename the import:
@@ -2117,20 +2117,20 @@ function identity<T>(value: T): T {
   will simply reject immediately.
 
   ```ts
-  import * as Task from 'true-myth/task';
-  import * as Delay from 'true-myth/task/delay';
+  import * as task from 'true-myth/task';
+  import * as delay from 'true-myth/task/delay';
 
   let theTask = withRetries(
-    () => Task.fromPromise(fetch('https://example.com')).andThen((res) => {
+    () => task.fromPromise(fetch('https://example.com')).andThen((res) => {
         if (res.status === 200) {
-          return Task.fromPromise(res.json());
+          return task.fromPromise(res.json());
         } else if (res.status === 408) {
-          return Task.reject(res.statusText);
+          return task.reject(res.statusText);
         } else {
-          return Task.stopRetrying(res.statusText);
+          return task.stopRetrying(res.statusText);
         }
       }),
-    Delay.fibonacci().map(Delay.jitter).take(10)
+    delay.fibonacci().map(delay.jitter).take(10)
   );
   ```
 
@@ -2165,18 +2165,18 @@ function identity<T>(value: T): T {
   it is set:
 
   ```ts
-  import * as Task from 'true-myth/task';
+  import * as task from 'true-myth/task';
   import { fibonacci, jitter } from 'true-myth/task/delay';
   import { doSomethingThatMayFailWithAppError } from 'someplace/in/my-app';
 
-  let theTask = Task.withRetries(
+  let theTask = task.withRetries(
     () => {
       doSomethingThatMayFailWithAppError().orElse((rejection) => {
         if (rejection.isFatal) {
-          return Task.stopRetrying("It was fatal!", { cause: rejection });
+          return task.stopRetrying("It was fatal!", { cause: rejection });
         }
 
-        return Task.reject(rejection);
+        return task.reject(rejection);
       });
     },
     fibonacci().map(jitter).take(20)
@@ -2196,24 +2196,24 @@ function identity<T>(value: T): T {
   times or if the total elapsed time exceeds 10 seconds.
 
   ```ts
-  import * as Task from 'true-myth/task';
+  import * as task from 'true-myth/task';
   import { exponential, jitter } from 'true-myth/task/delay';
 
-  let theResult = await Task.withRetries(
+  let theResult = await task.withRetries(
     ({ count, elapsed }) => {
       if (count > 10) {
-        return Task.stopRetrying(`Tried too many times: ${count}`);
+        return task.stopRetrying(`Tried too many times: ${count}`);
       }
 
       if (elapsed > 10_000) {
-        return Task.stopRetrying(`Took too long: ${elapsed}ms`);
+        return task.stopRetrying(`Took too long: ${elapsed}ms`);
       }
 
-      return Task.fromPromise(fetch('https://www.example.com/'))
-        .andThen((res) => Task.fromPromise(res.json()))
+      return task.fromPromise(fetch('https://www.example.com/'))
+        .andThen((res) => task.fromPromise(res.json()))
         .orElse((cause) => {
           let message = `Attempt #${count} failed`;
-          return Task.reject(new Error(message, { cause }));
+          return task.reject(new Error(message, { cause }));
         });
     },
     exponential().map(jitter),
@@ -2232,7 +2232,7 @@ function identity<T>(value: T): T {
   value:
 
   ```ts
-  import * as Task from 'true-myth/task';
+  import * as task from 'true-myth/task';
 
   function* randomIncrease(options?: { from: number }) {
     // always use integral values, and default to one second.
@@ -2243,10 +2243,10 @@ function identity<T>(value: T): T {
     }
   }
 
-  await Task.withRetries(({ count }) => {
+  await task.withRetries(({ count }) => {
     let delay = Math.round(Math.random() * 100);
-    return Task.timer(delay).andThen((time) =>
-      Task.reject(`Rejection #${count} after ${time}ms`),
+    return task.timer(delay).andThen((time) =>
+      task.reject(`Rejection #${count} after ${time}ms`),
     );
   }, randomIncrease(10).take(10));
   ```
@@ -2384,12 +2384,12 @@ export const RETRY_FAILED_NAME = 'TrueMyth.Task.RetryFailed';
   the {@linkcode isRetryFailed} helper function:
 
   ```ts
-  import * as Task from 'true-myth/task';
+  import * as task from 'true-myth/task';
 
   // snip
   let result = await someFnThatReturnsATask();
   if (result.isErr) {
-    if (isRetryFailed(result.error)) {
+    if (task.isRetryFailed(result.error)) {
       if (result.error.cause) {
         console.error('You quit on purpose: ', cause);
       }

--- a/src/task/delay.ts
+++ b/src/task/delay.ts
@@ -79,20 +79,20 @@
   [helpers]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator#iterator_helper_methods
 
   ```ts
-  import * as Task from 'true-myth/task';
+  import * as task from 'true-myth/task';
   import { someRetryableTask } from 'somewhere/in/your-app';
 
-  let usingRandomInRange = Task.withRetries(
+  let usingRandomInRange = task.withRetries(
     someRetryableTask,
     randomInRange(1, 100).take(10)
   );
 
-  let usingRandomInteger = Task.withRetries(
+  let usingRandomInteger = task.withRetries(
     someRetryableTask,
     new RandomInteger().take(10)
   );
 
-  let usingRangeIterator = Task.withRetries(
+  let usingRangeIterator = task.withRetries(
     someRetryableTask,
     new Range(1, 100, 5).take(10)
   );

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, test } from 'vitest';
 
 import Maybe, { Variant, Nothing, Just, Matcher } from 'true-myth/maybe';
-import * as MaybeNS from 'true-myth/maybe';
+import * as maybe from 'true-myth/maybe';
 import { Unit } from 'true-myth/unit';
 
 type Neat = { neat: string };
@@ -10,13 +10,13 @@ const length = (s: string) => s.length;
 
 describe('`Maybe` pure functions', () => {
   test('`just`', () => {
-    const theJust = MaybeNS.just('string');
+    const theJust = maybe.just('string');
     expect(theJust).toBeInstanceOf(Maybe);
     switch (theJust.variant) {
-      case MaybeNS.Variant.Just:
+      case maybe.Variant.Just:
         expect(theJust.value).toBe('string');
         break;
-      case MaybeNS.Variant.Nothing:
+      case maybe.Variant.Nothing:
         expect(true).toBe(false); // Not possible
         break;
       default:
@@ -24,13 +24,13 @@ describe('`Maybe` pure functions', () => {
     }
 
     expect(() =>
-      MaybeNS.just(
+      maybe.just(
         // @ts-expect-error: null is forbidden here
         null
       )
     ).toThrow();
     expect(() =>
-      MaybeNS.just(
+      maybe.just(
         // @ts-expect-error: undefined is forbidden here
         undefined
       )
@@ -45,22 +45,22 @@ describe('`Maybe` pure functions', () => {
   });
 
   test('`nothing`', () => {
-    const theNothing = MaybeNS.nothing();
+    const theNothing = maybe.nothing();
     expect(theNothing).toBeInstanceOf(Maybe);
     switch (theNothing.variant) {
       // @ts-expect-error -- this cannot happen! Should fail to type-check if it
       // *does* happen.
-      case MaybeNS.Variant.Just:
+      case maybe.Variant.Just:
         expect(true).toBe(false); // because this should never happen
         break;
-      case MaybeNS.Variant.Nothing:
+      case maybe.Variant.Nothing:
         expect(true).toBe(true); // yay
         break;
       default:
         expect(false).toBe(true); // because those are the only cases
     }
 
-    const nothingOnType = MaybeNS.nothing<string>();
+    const nothingOnType = maybe.nothing<string>();
     expectTypeOf(nothingOnType).toMatchTypeOf<Maybe<string>>();
   });
 
@@ -73,7 +73,7 @@ describe('`Maybe` pure functions', () => {
     expectTypeOf(Maybe.of(() => 'hello')).toEqualTypeOf<Maybe<() => string>>();
 
     test('with `null', () => {
-      const nothingFromNull = MaybeNS.of<string>(null);
+      const nothingFromNull = maybe.of<string>(null);
       expectTypeOf(nothingFromNull).toEqualTypeOf<Maybe<string>>();
       expect(nothingFromNull.isJust).toBe(false);
       expect(nothingFromNull.isNothing).toBe(true);
@@ -82,7 +82,7 @@ describe('`Maybe` pure functions', () => {
     });
 
     test('with `undefined`', () => {
-      const nothingFromUndefined = MaybeNS.of<number>(undefined);
+      const nothingFromUndefined = maybe.of<number>(undefined);
       expectTypeOf(nothingFromUndefined).toEqualTypeOf<Maybe<number>>();
       expect(nothingFromUndefined.isJust).toBe(false);
       expect(nothingFromUndefined.isNothing).toBe(true);
@@ -91,12 +91,12 @@ describe('`Maybe` pure functions', () => {
     });
 
     test('with values', () => {
-      const aJust = MaybeNS.of<Neat>({ neat: 'strings' });
+      const aJust = maybe.of<Neat>({ neat: 'strings' });
       expectTypeOf(aJust).toEqualTypeOf<Maybe<Neat>>();
-      const aNothing = MaybeNS.of<Neat>(null);
+      const aNothing = maybe.of<Neat>(null);
       expectTypeOf(aNothing).toEqualTypeOf<Maybe<Neat>>();
 
-      const justANumber = MaybeNS.of(42);
+      const justANumber = maybe.of(42);
       expectTypeOf(justANumber).toEqualTypeOf<Maybe<number>>();
       expect(justANumber.isJust).toBe(true);
       expect(justANumber.isNothing).toBe(false);
@@ -105,18 +105,18 @@ describe('`Maybe` pure functions', () => {
   });
 
   test('`map`', () => {
-    const justAString = MaybeNS.just('string');
-    const itsLength = MaybeNS.map(length, justAString);
+    const justAString = maybe.just('string');
+    const itsLength = maybe.map(length, justAString);
     expectTypeOf(itsLength).toEqualTypeOf<Maybe<number>>();
-    expect(itsLength).toEqual(MaybeNS.just('string'.length));
+    expect(itsLength).toEqual(maybe.just('string'.length));
 
-    const none = MaybeNS.nothing<string>();
-    const noLength = MaybeNS.map(length, none);
+    const none = maybe.nothing<string>();
+    const noLength = maybe.map(length, none);
     expectTypeOf(none).toMatchTypeOf<Maybe<string>>();
-    expect(noLength).toEqual(MaybeNS.nothing());
+    expect(noLength).toEqual(maybe.nothing());
 
     expect(() => {
-      MaybeNS.map(
+      maybe.map(
         // @ts-expect-error
         (_val) => null,
         Maybe.of('Hello')
@@ -125,132 +125,128 @@ describe('`Maybe` pure functions', () => {
   });
 
   test('`mapOr`', () => {
-    const justAString = MaybeNS.of('string');
+    const justAString = maybe.of('string');
 
-    expect(MaybeNS.mapOr(0, length, justAString)).toEqual('string'.length);
-    expect(MaybeNS.mapOr(0, length, MaybeNS.of<string>(null))).toEqual(0);
+    expect(maybe.mapOr(0, length, justAString)).toEqual('string'.length);
+    expect(maybe.mapOr(0, length, maybe.of<string>(null))).toEqual(0);
 
-    expect(MaybeNS.mapOr<string, number>(0)(length)(justAString)).toEqual(
-      MaybeNS.mapOr(0, length, justAString)
+    expect(maybe.mapOr<string, number>(0)(length)(justAString)).toEqual(
+      maybe.mapOr(0, length, justAString)
     );
-    expect(MaybeNS.mapOr(0, length)(justAString)).toEqual(MaybeNS.mapOr(0, length, justAString));
+    expect(maybe.mapOr(0, length)(justAString)).toEqual(maybe.mapOr(0, length, justAString));
   });
 
   test('`mapOrElse`', () => {
     const theValue = 'a string';
     const theDefault = 0;
     const toDefault = () => theDefault;
-    const aJust = MaybeNS.just(theValue);
-    const aNothing: Maybe<string> = MaybeNS.nothing();
+    const aJust = maybe.just(theValue);
+    const aNothing: Maybe<string> = maybe.nothing();
 
-    expect(MaybeNS.mapOrElse(toDefault, length, aJust)).toBe(theValue.length);
-    expect(MaybeNS.mapOrElse(toDefault, length, aNothing)).toBe(theDefault);
+    expect(maybe.mapOrElse(toDefault, length, aJust)).toBe(theValue.length);
+    expect(maybe.mapOrElse(toDefault, length, aNothing)).toBe(theDefault);
 
-    expect(MaybeNS.mapOrElse<string, number>(toDefault)(length)(aJust)).toEqual(
-      MaybeNS.mapOrElse(toDefault, length, aJust)
+    expect(maybe.mapOrElse<string, number>(toDefault)(length)(aJust)).toEqual(
+      maybe.mapOrElse(toDefault, length, aJust)
     );
-    expect(MaybeNS.mapOrElse(toDefault, length)(aJust)).toEqual(
-      MaybeNS.mapOrElse(toDefault, length, aJust)
+    expect(maybe.mapOrElse(toDefault, length)(aJust)).toEqual(
+      maybe.mapOrElse(toDefault, length, aJust)
     );
   });
 
   test('`match`', () => {
     const theValue = 'a string';
-    const aJust = MaybeNS.just(theValue);
-    const aNothing: Maybe<string> = MaybeNS.nothing();
+    const aJust = maybe.just(theValue);
+    const aNothing: Maybe<string> = maybe.nothing();
 
     const matcher: Matcher<string, string> = {
       Just: (val) => val + ', yo',
       Nothing: () => 'rats, nothing',
     };
 
-    expect(MaybeNS.match(matcher, aJust)).toEqual('a string, yo');
-    expect(MaybeNS.match(matcher, aNothing)).toEqual('rats, nothing');
+    expect(maybe.match(matcher, aJust)).toEqual('a string, yo');
+    expect(maybe.match(matcher, aNothing)).toEqual('rats, nothing');
 
-    expect(MaybeNS.match(matcher)(aJust)).toEqual(MaybeNS.match(matcher, aJust));
+    expect(maybe.match(matcher)(aJust)).toEqual(maybe.match(matcher, aJust));
   });
 
   test('`and`', () => {
-    const aJust = MaybeNS.just(42);
-    const anotherJust = MaybeNS.just('a string');
-    const aNothing: Maybe<{}> = MaybeNS.nothing();
-    expect(MaybeNS.and(anotherJust, aJust)).toBe(anotherJust);
+    const aJust = maybe.just(42);
+    const anotherJust = maybe.just('a string');
+    const aNothing: Maybe<{}> = maybe.nothing();
+    expect(maybe.and(anotherJust, aJust)).toBe(anotherJust);
 
-    expect(MaybeNS.and(aNothing, aJust)).toEqual(aNothing);
-    expect(MaybeNS.and(aNothing, aJust)).toEqual(aNothing);
-    expect(MaybeNS.and(aNothing, aNothing)).toEqual(aNothing);
+    expect(maybe.and(aNothing, aJust)).toEqual(aNothing);
+    expect(maybe.and(aNothing, aJust)).toEqual(aNothing);
+    expect(maybe.and(aNothing, aNothing)).toEqual(aNothing);
 
-    expect(MaybeNS.and<number, {}>(aNothing)(aJust)).toEqual(MaybeNS.and(aNothing, aJust));
+    expect(maybe.and<number, {}>(aNothing)(aJust)).toEqual(maybe.and(aNothing, aJust));
   });
 
   test('`andThen`', () => {
-    const toMaybeNumber = (x: string) => MaybeNS.just(Number(x));
-    const toNothing = (_: string) => MaybeNS.nothing<number>();
+    const toMaybeNumber = (x: string) => maybe.just(Number(x));
+    const toNothing = (_: string) => maybe.nothing<number>();
 
     const theValue = '42';
-    const theJust = MaybeNS.just(theValue);
+    const theJust = maybe.just(theValue);
     const theExpectedResult = toMaybeNumber(theValue);
-    const noString = MaybeNS.nothing<string>();
-    const noNumber = MaybeNS.nothing<number>();
+    const noString = maybe.nothing<string>();
+    const noNumber = maybe.nothing<number>();
 
-    expect(MaybeNS.andThen(toMaybeNumber, theJust)).toEqual(theExpectedResult);
-    expect(MaybeNS.andThen(toNothing, theJust)).toEqual(noNumber);
-    expect(MaybeNS.andThen(toMaybeNumber, noString)).toEqual(noNumber);
-    expect(MaybeNS.andThen(toNothing, noString)).toEqual(noNumber);
+    expect(maybe.andThen(toMaybeNumber, theJust)).toEqual(theExpectedResult);
+    expect(maybe.andThen(toNothing, theJust)).toEqual(noNumber);
+    expect(maybe.andThen(toMaybeNumber, noString)).toEqual(noNumber);
+    expect(maybe.andThen(toNothing, noString)).toEqual(noNumber);
 
-    expect(MaybeNS.andThen(toMaybeNumber)(theJust)).toEqual(
-      MaybeNS.andThen(toMaybeNumber, theJust)
-    );
+    expect(maybe.andThen(toMaybeNumber)(theJust)).toEqual(maybe.andThen(toMaybeNumber, theJust));
   });
 
   test('`or`', () => {
-    const justAnswer = MaybeNS.of('42');
-    const justWaffles = MaybeNS.of('waffles');
-    const nothing: Maybe<string> = MaybeNS.nothing();
+    const justAnswer = maybe.of('42');
+    const justWaffles = maybe.of('waffles');
+    const nothing: Maybe<string> = maybe.nothing();
 
-    expect(MaybeNS.or(justAnswer, justWaffles)).toBe(justWaffles);
-    expect(MaybeNS.or(nothing, justWaffles)).toBe(justWaffles);
-    expect(MaybeNS.or(justAnswer, nothing)).toBe(justAnswer);
-    expect(MaybeNS.or(nothing, nothing)).toBe(nothing);
+    expect(maybe.or(justAnswer, justWaffles)).toBe(justWaffles);
+    expect(maybe.or(nothing, justWaffles)).toBe(justWaffles);
+    expect(maybe.or(justAnswer, nothing)).toBe(justAnswer);
+    expect(maybe.or(nothing, nothing)).toBe(nothing);
 
-    expect(MaybeNS.or(justAnswer)(justWaffles)).toEqual(MaybeNS.or(justAnswer, justWaffles));
+    expect(maybe.or(justAnswer)(justWaffles)).toEqual(maybe.or(justAnswer, justWaffles));
   });
 
   test('`orElse`', () => {
-    const getWaffles = () => MaybeNS.of('waffles');
-    const just42 = MaybeNS.of('42');
-    expect(MaybeNS.orElse(getWaffles, just42)).toEqual(MaybeNS.just('42'));
-    expect(MaybeNS.orElse(getWaffles, MaybeNS.of(null as string | null))).toEqual(
-      MaybeNS.just('waffles')
+    const getWaffles = () => maybe.of('waffles');
+    const just42 = maybe.of('42');
+    expect(maybe.orElse(getWaffles, just42)).toEqual(maybe.just('42'));
+    expect(maybe.orElse(getWaffles, maybe.of(null as string | null))).toEqual(
+      maybe.just('waffles')
     );
-    expect(MaybeNS.orElse(() => MaybeNS.of(null as string | null), just42)).toEqual(
-      MaybeNS.just('42')
-    );
+    expect(maybe.orElse(() => maybe.of(null as string | null), just42)).toEqual(maybe.just('42'));
     expect(
-      MaybeNS.orElse(() => MaybeNS.of(null as string | null), MaybeNS.of(null as string | null))
-    ).toEqual(MaybeNS.nothing());
+      maybe.orElse(() => maybe.of(null as string | null), maybe.of(null as string | null))
+    ).toEqual(maybe.nothing());
 
-    expect(MaybeNS.orElse(getWaffles)(just42)).toEqual(MaybeNS.orElse(getWaffles, just42));
+    expect(maybe.orElse(getWaffles)(just42)).toEqual(maybe.orElse(getWaffles, just42));
   });
 
   test('`unwrap`', () => {
-    expect((MaybeNS.of('42') as Just<string>).value).toBe('42');
+    expect((maybe.of('42') as Just<string>).value).toBe('42');
     // @ts-expect-error -- `value` isn't accessible without narrowing
-    expect(() => MaybeNS.nothing().value).toThrow();
+    expect(() => maybe.nothing().value).toThrow();
   });
 
   test('`unwrapOr`', () => {
     const theValue = [1, 2, 3];
     const theDefaultValue: number[] = [];
 
-    const theJust = MaybeNS.of(theValue);
-    const theNothing = MaybeNS.nothing();
+    const theJust = maybe.of(theValue);
+    const theNothing = maybe.nothing();
 
-    expect(MaybeNS.unwrapOr(theDefaultValue, theJust)).toEqual(theValue);
-    expect(MaybeNS.unwrapOr(theDefaultValue, theNothing)).toEqual(theDefaultValue);
+    expect(maybe.unwrapOr(theDefaultValue, theJust)).toEqual(theValue);
+    expect(maybe.unwrapOr(theDefaultValue, theNothing)).toEqual(theDefaultValue);
 
-    expect(MaybeNS.unwrapOr(theDefaultValue)(theJust)).toEqual(
-      MaybeNS.unwrapOr(theDefaultValue, theJust)
+    expect(maybe.unwrapOr(theDefaultValue)(theJust)).toEqual(
+      maybe.unwrapOr(theDefaultValue, theJust)
     );
 
     // Make sure you can unwrap to a different type, like undefined
@@ -264,43 +260,43 @@ describe('`Maybe` pure functions', () => {
   test('`unwrapOrElse`', () => {
     const val = 100;
     const getVal = () => val;
-    const just42 = MaybeNS.of(42);
+    const just42 = maybe.of(42);
 
-    expect(MaybeNS.unwrapOrElse(getVal, just42)).toBe(42);
-    expect(MaybeNS.unwrapOrElse(getVal, MaybeNS.nothing())).toBe(val);
+    expect(maybe.unwrapOrElse(getVal, just42)).toBe(42);
+    expect(maybe.unwrapOrElse(getVal, maybe.nothing())).toBe(val);
 
-    expect(MaybeNS.unwrapOrElse(getVal)(just42)).toEqual(MaybeNS.unwrapOrElse(getVal, just42));
+    expect(maybe.unwrapOrElse(getVal)(just42)).toEqual(maybe.unwrapOrElse(getVal, just42));
 
     // test unwrapping to undefined
     const noop = (): undefined => undefined;
-    const undefinedOr42 = MaybeNS.unwrapOrElse(noop, just42);
+    const undefinedOr42 = maybe.unwrapOrElse(noop, just42);
     expectTypeOf(undefinedOr42).toEqualTypeOf<number | undefined>();
     expect(undefinedOr42).toEqual(42);
   });
 
   describe('`toString`', () => {
     test('with simple values', () => {
-      expect(MaybeNS.toString(MaybeNS.of(42))).toEqual('Just(42)');
-      expect(MaybeNS.toString(MaybeNS.nothing<string>())).toEqual('Nothing');
+      expect(maybe.toString(maybe.of(42))).toEqual('Just(42)');
+      expect(maybe.toString(maybe.nothing<string>())).toEqual('Nothing');
     });
 
     test('with complex values', () => {
-      expect(MaybeNS.toString(MaybeNS.of([1, 2, 3]))).toEqual('Just(1,2,3)');
-      expect(MaybeNS.toString(MaybeNS.of({ neato: true }))).toEqual('Just([object Object])');
+      expect(maybe.toString(maybe.of([1, 2, 3]))).toEqual('Just(1,2,3)');
+      expect(maybe.toString(maybe.of({ neato: true }))).toEqual('Just([object Object])');
 
       class HasToString {
         toString() {
           return 'This has toString';
         }
       }
-      expect(MaybeNS.toString(MaybeNS.of(new HasToString()))).toEqual('Just(This has toString)');
+      expect(maybe.toString(maybe.of(new HasToString()))).toEqual('Just(This has toString)');
     });
   });
 
   describe('`toString`', () => {
     test('normal cases', () => {
-      expect(MaybeNS.toString(MaybeNS.of(42))).toEqual('Just(42)');
-      expect(MaybeNS.toString(MaybeNS.nothing<string>())).toEqual('Nothing');
+      expect(maybe.toString(maybe.of(42))).toEqual('Just(42)');
+      expect(maybe.toString(maybe.nothing<string>())).toEqual('Nothing');
     });
 
     test('custom `toString`s', () => {
@@ -309,7 +305,7 @@ describe('`Maybe` pure functions', () => {
         toString: '🤨',
       };
 
-      expect(MaybeNS.toString(Maybe.of(withNotAFunction))).toEqual(
+      expect(maybe.toString(Maybe.of(withNotAFunction))).toEqual(
         `Just(${JSON.stringify(withNotAFunction)})`
       );
 
@@ -320,70 +316,70 @@ describe('`Maybe` pure functions', () => {
         },
       };
 
-      expect(MaybeNS.toString(Maybe.of(withBadFunction))).toEqual(
+      expect(maybe.toString(Maybe.of(withBadFunction))).toEqual(
         `Just(${JSON.stringify(withBadFunction)})`
       );
     });
   });
 
   test('`toJSON`', () => {
-    expect(MaybeNS.toJSON(MaybeNS.of(42))).toEqual({ variant: MaybeNS.Variant.Just, value: 42 });
-    expect(MaybeNS.toJSON(MaybeNS.nothing())).toEqual({ variant: MaybeNS.Variant.Nothing });
-    expect(MaybeNS.toJSON(MaybeNS.of({ a: 42, b: null }))).toEqual({
-      variant: MaybeNS.Variant.Just,
+    expect(maybe.toJSON(maybe.of(42))).toEqual({ variant: maybe.Variant.Just, value: 42 });
+    expect(maybe.toJSON(maybe.nothing())).toEqual({ variant: maybe.Variant.Nothing });
+    expect(maybe.toJSON(maybe.of({ a: 42, b: null }))).toEqual({
+      variant: maybe.Variant.Just,
       value: { a: 42, b: null },
     });
   });
 
   test('`toJSON` through serialization', () => {
-    const actualSerializedJust = JSON.stringify(MaybeNS.of(42));
-    const actualSerializedNothing = JSON.stringify(MaybeNS.nothing());
-    const expectedSerializedJust = JSON.stringify({ variant: MaybeNS.Variant.Just, value: 42 });
-    const expectedSerializedNothing = JSON.stringify({ variant: MaybeNS.Variant.Nothing });
+    const actualSerializedJust = JSON.stringify(maybe.of(42));
+    const actualSerializedNothing = JSON.stringify(maybe.nothing());
+    const expectedSerializedJust = JSON.stringify({ variant: maybe.Variant.Just, value: 42 });
+    const expectedSerializedNothing = JSON.stringify({ variant: maybe.Variant.Nothing });
 
     expect(actualSerializedJust).toEqual(expectedSerializedJust);
     expect(actualSerializedNothing).toEqual(expectedSerializedNothing);
   });
 
   test('`equals`', () => {
-    const a = MaybeNS.of<string>('a');
-    const b = MaybeNS.of<string>('a');
-    const c = MaybeNS.nothing<string>();
-    const d = MaybeNS.nothing<string>();
-    expect(MaybeNS.equals(b, a)).toBe(true);
-    expect(MaybeNS.equals(b)(a)).toBe(true);
-    expect(MaybeNS.equals(c, b)).toBe(false);
-    expect(MaybeNS.equals(c)(b)).toBe(false);
-    expect(MaybeNS.equals(d, c)).toBe(true);
-    expect(MaybeNS.equals(d)(c)).toBe(true);
+    const a = maybe.of<string>('a');
+    const b = maybe.of<string>('a');
+    const c = maybe.nothing<string>();
+    const d = maybe.nothing<string>();
+    expect(maybe.equals(b, a)).toBe(true);
+    expect(maybe.equals(b)(a)).toBe(true);
+    expect(maybe.equals(c, b)).toBe(false);
+    expect(maybe.equals(c)(b)).toBe(false);
+    expect(maybe.equals(d, c)).toBe(true);
+    expect(maybe.equals(d)(c)).toBe(true);
   });
 
   test('`ap`', () => {
     const add = (a: number) => (b: number) => a + b;
-    const maybeAdd = MaybeNS.of(add);
+    const maybeAdd = maybe.of(add);
 
-    expect(maybeAdd.ap(MaybeNS.of(1)).ap(MaybeNS.of(5))).toEqual(MaybeNS.of(6));
+    expect(maybeAdd.ap(maybe.of(1)).ap(maybe.of(5))).toEqual(maybe.of(6));
 
-    const maybeAdd3 = MaybeNS.of<(val: number) => number>(add(3));
-    const val = MaybeNS.of(2);
-    const nada: Maybe<number> = MaybeNS.of(null as number | null | undefined);
+    const maybeAdd3 = maybe.of<(val: number) => number>(add(3));
+    const val = maybe.of(2);
+    const nada: Maybe<number> = maybe.of(null as number | null | undefined);
 
-    expect(MaybeNS.ap(maybeAdd3, val)).toEqual(MaybeNS.just(5));
-    expect(MaybeNS.ap(maybeAdd3)(nada)).toEqual(MaybeNS.nothing());
+    expect(maybe.ap(maybeAdd3, val)).toEqual(maybe.just(5));
+    expect(maybe.ap(maybeAdd3)(nada)).toEqual(maybe.nothing());
   });
 
   test('isInstance', () => {
-    const something: unknown = MaybeNS.just('yay');
-    expect(MaybeNS.isInstance(something)).toBe(true);
+    const something: unknown = maybe.just('yay');
+    expect(maybe.isInstance(something)).toBe(true);
 
-    const nothing = MaybeNS.nothing();
-    expect(MaybeNS.isInstance(nothing)).toBe(true);
+    const nothing = maybe.nothing();
+    expect(maybe.isInstance(nothing)).toBe(true);
 
     const nada = null;
-    expect(MaybeNS.isInstance(nada)).toBe(false);
+    expect(maybe.isInstance(nada)).toBe(false);
 
     const obj = { random: 'nonsense' };
-    expect(MaybeNS.isInstance(obj)).toBe(false);
+    expect(maybe.isInstance(obj)).toBe(false);
   });
 
   describe('array helpers', () => {
@@ -393,14 +389,14 @@ describe('`Maybe` pure functions', () => {
 
       const empty: number[] = [];
 
-      expect(MaybeNS.find(pred, empty).variant).toBe(MaybeNS.Variant.Nothing);
+      expect(maybe.find(pred, empty).variant).toBe(maybe.Variant.Nothing);
 
       const missingTheValue = [1, 2, 3];
-      expect(MaybeNS.find(pred, missingTheValue).variant).toBe(MaybeNS.Variant.Nothing);
+      expect(maybe.find(pred, missingTheValue).variant).toBe(maybe.Variant.Nothing);
 
       const hasTheValue = [1, 2, 3, theValue];
-      const result = MaybeNS.find(pred, hasTheValue);
-      expect(result.variant).toBe(MaybeNS.Variant.Just);
+      const result = maybe.find(pred, hasTheValue);
+      expect(result.variant).toBe(maybe.Variant.Just);
       expect((result as Just<number>).value).toBe(theValue);
 
       type Item = { count: number; name: string };
@@ -412,85 +408,85 @@ describe('`Maybe` pure functions', () => {
         { count: 1, name: 'potato' },
         { count: 10, name: 'waffles' },
       ];
-      const findAtLeast5 = MaybeNS.find(({ count }: Item) => count > 5);
+      const findAtLeast5 = maybe.find(({ count }: Item) => count > 5);
       const found = findAtLeast5(array);
-      expect(found.variant).toBe(MaybeNS.Variant.Just);
+      expect(found.variant).toBe(maybe.Variant.Just);
       expect((found as Just<Item>).value).toEqual(array[1]);
 
       // Type narrowing via predicates.
       // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
       const findByName = <T extends string>(name: T) =>
-        MaybeNS.find((item: Item): item is Item & { name: T } => item.name === name);
+        maybe.find((item: Item): item is Item & { name: T } => item.name === name);
       const waffles = findByName('waffles')(array);
-      expect(waffles.variant).toBe(MaybeNS.Variant.Just);
+      expect(waffles.variant).toBe(maybe.Variant.Just);
       expect((waffles as Just<Item>).value).toEqual(array[1]);
       expectTypeOf(waffles).toMatchTypeOf<Maybe<{ name: 'waffles' }>>();
 
       const readonlyEmpty: readonly number[] = [];
-      const foundReadonly = MaybeNS.find(pred, readonlyEmpty);
+      const foundReadonly = maybe.find(pred, readonlyEmpty);
       expectTypeOf(foundReadonly).toMatchTypeOf<Maybe<number>>();
     });
 
     test('`first`', () => {
-      expect(MaybeNS.first([])).toEqual(MaybeNS.nothing());
-      expect(MaybeNS.first([1])).toEqual(MaybeNS.just(1));
-      expect(MaybeNS.first([1, 2, 3])).toEqual(MaybeNS.just(1));
+      expect(maybe.first([])).toEqual(maybe.nothing());
+      expect(maybe.first([1])).toEqual(maybe.just(1));
+      expect(maybe.first([1, 2, 3])).toEqual(maybe.just(1));
 
       const readonlyEmpty: readonly number[] = [];
-      expect(MaybeNS.first(readonlyEmpty)).toEqual(MaybeNS.nothing());
+      expect(maybe.first(readonlyEmpty)).toEqual(maybe.nothing());
       const readonlyFilled: readonly number[] = [1, 2, 3];
-      expect(MaybeNS.first(readonlyFilled)).toEqual(MaybeNS.just(1));
+      expect(maybe.first(readonlyFilled)).toEqual(maybe.just(1));
     });
 
     test('`last`', () => {
-      expect(MaybeNS.last([])).toEqual(MaybeNS.nothing());
-      expect(MaybeNS.last([1])).toEqual(MaybeNS.just(1));
-      expect(MaybeNS.last([1, 2, 3])).toEqual(MaybeNS.just(3));
+      expect(maybe.last([])).toEqual(maybe.nothing());
+      expect(maybe.last([1])).toEqual(maybe.just(1));
+      expect(maybe.last([1, 2, 3])).toEqual(maybe.just(3));
 
       const readonlyEmpty: readonly number[] = [];
-      expect(MaybeNS.last(readonlyEmpty)).toEqual(MaybeNS.nothing());
+      expect(maybe.last(readonlyEmpty)).toEqual(maybe.nothing());
       const readonlyFilled: readonly number[] = [1, 2, 3];
-      expect(MaybeNS.last(readonlyFilled)).toEqual(MaybeNS.just(3));
+      expect(maybe.last(readonlyFilled)).toEqual(maybe.just(3));
     });
 
     describe('`transposeArray`', () => {
       test('with basic types', () => {
         type ExpectedOutputType = Maybe<Array<string | number>>;
 
-        let onlyJusts = [MaybeNS.just(2), MaybeNS.just('three')];
-        let onlyJustsAll = MaybeNS.transposeArray(onlyJusts);
+        let onlyJusts = [maybe.just(2), maybe.just('three')];
+        let onlyJustsAll = maybe.transposeArray(onlyJusts);
         expectTypeOf(onlyJustsAll).toEqualTypeOf<ExpectedOutputType>();
-        expect(onlyJustsAll).toEqual(MaybeNS.just([2, 'three']));
+        expect(onlyJustsAll).toEqual(maybe.just([2, 'three']));
 
-        let hasNothing = [MaybeNS.just(2), MaybeNS.nothing<string>()];
-        let hasNothingAll = MaybeNS.transposeArray(hasNothing);
+        let hasNothing = [maybe.just(2), maybe.nothing<string>()];
+        let hasNothingAll = maybe.transposeArray(hasNothing);
         expectTypeOf(hasNothingAll).toEqualTypeOf<ExpectedOutputType>();
-        expect(hasNothingAll).toEqual(MaybeNS.nothing());
+        expect(hasNothingAll).toEqual(maybe.nothing());
       });
 
       test('with arrays', () => {
         type ExpectedOutputType = Maybe<Array<number | string[]>>;
 
-        let nestedArrays = [MaybeNS.just(1), MaybeNS.just(['two', 'three'])];
-        let nestedArraysAll = MaybeNS.transposeArray(nestedArrays);
+        let nestedArrays = [maybe.just(1), maybe.just(['two', 'three'])];
+        let nestedArraysAll = maybe.transposeArray(nestedArrays);
 
         expectTypeOf(nestedArraysAll).toEqualTypeOf<ExpectedOutputType>();
-        expect(nestedArraysAll).toEqual(MaybeNS.just([1, ['two', 'three']]));
+        expect(nestedArraysAll).toEqual(maybe.just([1, ['two', 'three']]));
       });
 
       test('with tuples', () => {
         type ExpectedOutputType = Maybe<readonly [number, string]>;
 
-        let theInput = [MaybeNS.just(123), MaybeNS.just('hello')] as const;
-        let theOutput = MaybeNS.transposeArray(theInput);
+        let theInput = [maybe.just(123), maybe.just('hello')] as const;
+        let theOutput = maybe.transposeArray(theInput);
 
         expectTypeOf(theOutput).toEqualTypeOf<ExpectedOutputType>();
-        expect(theOutput).toEqual(MaybeNS.just([123, 'hello']));
+        expect(theOutput).toEqual(maybe.just([123, 'hello']));
       });
 
       test('with readonly arrays', () => {
         let theInput: readonly Maybe<number>[] = [Maybe.just(1), Maybe.just(2)];
-        let theOutput = MaybeNS.transposeArray(theInput);
+        let theOutput = maybe.transposeArray(theInput);
         expectTypeOf(theOutput).toEqualTypeOf<Maybe<readonly number[]>>();
         expect(theOutput).toEqual(Maybe.just([1, 2]));
       });
@@ -500,61 +496,61 @@ describe('`Maybe` pure functions', () => {
   test('`property`', () => {
     type Person = { name?: string };
     let chris: Person = { name: 'chris' };
-    expect(MaybeNS.property('name', chris)).toEqual(MaybeNS.just('chris'));
+    expect(maybe.property('name', chris)).toEqual(maybe.just('chris'));
 
     let nobody: Person = {};
-    expect(MaybeNS.property('name', nobody)).toEqual(MaybeNS.nothing());
+    expect(maybe.property('name', nobody)).toEqual(maybe.nothing());
 
     type Dict<T> = { [key: string]: T };
     let dict: Dict<string> = { quux: 'warble' };
-    expect(MaybeNS.property('quux', dict)).toEqual(MaybeNS.just('warble'));
-    expect(MaybeNS.property('wat', dict)).toEqual(MaybeNS.nothing());
+    expect(maybe.property('quux', dict)).toEqual(maybe.just('warble'));
+    expect(maybe.property('wat', dict)).toEqual(maybe.nothing());
   });
 
   test('`get`', () => {
     type Person = { name?: string };
     let chris: Person = { name: 'chris' };
-    let justChris: Maybe<Person> = MaybeNS.just(chris);
-    expect(MaybeNS.get('name', justChris)).toEqual(MaybeNS.just('chris'));
+    let justChris: Maybe<Person> = maybe.just(chris);
+    expect(maybe.get('name', justChris)).toEqual(maybe.just('chris'));
 
-    let nobody: Maybe<Person> = MaybeNS.nothing();
-    expect(MaybeNS.get('name', nobody)).toEqual(MaybeNS.nothing());
+    let nobody: Maybe<Person> = maybe.nothing();
+    expect(maybe.get('name', nobody)).toEqual(maybe.nothing());
 
     type Dict<T> = { [key: string]: T };
-    let dict = MaybeNS.just({ quux: 'warble' } as Dict<string>);
-    expect(MaybeNS.get('quux', dict)).toEqual(MaybeNS.just('warble'));
-    expect(MaybeNS.get('wat', dict)).toEqual(MaybeNS.nothing());
+    let dict = maybe.just({ quux: 'warble' } as Dict<string>);
+    expect(maybe.get('quux', dict)).toEqual(maybe.just('warble'));
+    expect(maybe.get('wat', dict)).toEqual(maybe.nothing());
   });
 
   test('`safe`', () => {
     const empty = '';
-    const emptyResult = MaybeNS.nothing();
+    const emptyResult = maybe.nothing();
 
     const full = 'hello';
-    const fullResult = MaybeNS.just(full.length);
+    const fullResult = maybe.just(full.length);
 
     const mayBeNull = (s: string): number | null => (s.length > 0 ? s.length : null);
-    const mayNotBeNull = MaybeNS.safe(mayBeNull);
+    const mayNotBeNull = maybe.safe(mayBeNull);
 
     expect(mayNotBeNull(empty)).toEqual(emptyResult);
     expect(mayNotBeNull(full)).toEqual(fullResult);
 
     const mayBeUndefined = (s: string): number | undefined => (s.length > 0 ? s.length : undefined);
-    const mayNotBeUndefined = MaybeNS.safe(mayBeUndefined);
+    const mayNotBeUndefined = maybe.safe(mayBeUndefined);
 
     expect(mayNotBeUndefined(empty)).toEqual(emptyResult);
     expect(mayNotBeUndefined(full)).toEqual(fullResult);
 
     const returnsNullable = (): string | null => null;
 
-    const querySelector = MaybeNS.safe(returnsNullable);
+    const querySelector = maybe.safe(returnsNullable);
     expectTypeOf(querySelector).toEqualTypeOf<() => Maybe<string>>();
   });
 
   test('`isJust` with a Just', () => {
-    const testJust: Maybe<string> = MaybeNS.just('test');
+    const testJust: Maybe<string> = maybe.just('test');
 
-    if (MaybeNS.isJust(testJust)) {
+    if (maybe.isJust(testJust)) {
       expect(testJust.value).toEqual('test');
     } else {
       expect.fail('Expected a Just');
@@ -562,21 +558,21 @@ describe('`Maybe` pure functions', () => {
   });
 
   test('`isJust` with a Nothing', () => {
-    const testNothing: Maybe<string> = MaybeNS.nothing();
+    const testNothing: Maybe<string> = maybe.nothing();
 
-    expect(MaybeNS.isJust(testNothing)).toEqual(false);
+    expect(maybe.isJust(testNothing)).toEqual(false);
   });
 
   test('`isNothing` with a Just', () => {
-    const testJust: Maybe<string> = MaybeNS.just('test');
+    const testJust: Maybe<string> = maybe.just('test');
 
-    expect(MaybeNS.isNothing(testJust)).toEqual(false);
+    expect(maybe.isNothing(testJust)).toEqual(false);
   });
 
   test('`isNothing` with a Nothing', () => {
-    const testNothing: Maybe<string> = MaybeNS.nothing();
+    const testNothing: Maybe<string> = maybe.nothing();
 
-    expect(MaybeNS.isNothing(testNothing)).toEqual(true);
+    expect(maybe.isNothing(testNothing)).toEqual(true);
   });
 });
 
@@ -584,25 +580,25 @@ describe('`Maybe` pure functions', () => {
 // know to be correct from other tests. Instead, this test just checks whether
 // the types are narrowed as they should be.
 test('narrowing', () => {
-  const oneJust = MaybeNS.of(Unit);
+  const oneJust = maybe.of(Unit);
   if (oneJust.isJust) {
     expectTypeOf(oneJust).toEqualTypeOf<Just<Unit>>();
     expect(oneJust.value).toBeDefined();
   }
 
   // As above, narrowing directly on the type rather than with the lookup.
-  const anotherJust = MaybeNS.of(Unit);
+  const anotherJust = maybe.of(Unit);
   if (anotherJust.variant === Variant.Just) {
     expectTypeOf(anotherJust).toEqualTypeOf<Just<Unit>>();
     expect(anotherJust.value).toBeDefined();
   }
 
-  const oneNothing = MaybeNS.nothing();
+  const oneNothing = maybe.nothing();
   if (oneNothing.isNothing) {
     expectTypeOf(oneNothing).toEqualTypeOf<Nothing<unknown>>();
   }
 
-  const anotherNothing = MaybeNS.nothing();
+  const anotherNothing = maybe.nothing();
   if (anotherNothing.variant === Variant.Nothing) {
     expectTypeOf(anotherNothing).toEqualTypeOf<Nothing<unknown>>();
   }
@@ -753,7 +749,7 @@ describe('`Maybe` class', () => {
 
     test('`orElse` method', () => {
       const theJust = new Maybe(12);
-      const getAnotherJust = () => MaybeNS.just(42);
+      const getAnotherJust = () => maybe.just(42);
 
       expect(theJust.orElse(getAnotherJust)).toEqual(theJust);
     });
@@ -803,17 +799,17 @@ describe('`Maybe` class', () => {
     });
 
     test('`toString` method', () => {
-      expect(MaybeNS.of(42).toString()).toEqual('Just(42)');
+      expect(maybe.of(42).toString()).toEqual('Just(42)');
     });
 
     test('`toJSON` method', () => {
-      expect(MaybeNS.of({ x: 42 }).toJSON()).toEqual({
-        variant: MaybeNS.Variant.Just,
+      expect(maybe.of({ x: 42 }).toJSON()).toEqual({
+        variant: maybe.Variant.Just,
         value: { x: 42 },
       });
-      expect(MaybeNS.of(MaybeNS.of(42)).toJSON()).toEqual({
-        variant: MaybeNS.Variant.Just,
-        value: { variant: MaybeNS.Variant.Just, value: 42 },
+      expect(maybe.of(maybe.of(42)).toJSON()).toEqual({
+        variant: maybe.Variant.Just,
+        value: { variant: maybe.Variant.Just, value: 42 },
       });
     });
 
@@ -834,7 +830,7 @@ describe('`Maybe` class', () => {
 
       const result = fn.ap(val);
 
-      expect(result.equals(MaybeNS.of('3'))).toBe(true);
+      expect(result.equals(maybe.of('3'))).toBe(true);
     });
 
     test('`property` method', () => {
@@ -846,7 +842,7 @@ describe('`Maybe` class', () => {
         .get('with')
         .get('deeper')
         .get('key names');
-      expect(deepResult).toEqual(MaybeNS.just('like this'));
+      expect(deepResult).toEqual(maybe.just('like this'));
 
       const allEmpty: DeepType = {};
       const emptyResult = new Maybe(allEmpty)
@@ -854,7 +850,7 @@ describe('`Maybe` class', () => {
         .get('with')
         .get('deeper')
         .get('key names');
-      expect(emptyResult).toEqual(MaybeNS.nothing());
+      expect(emptyResult).toEqual(maybe.nothing());
     });
   });
 
@@ -922,7 +918,7 @@ describe('`Maybe` class', () => {
     });
 
     test('`match` method', () => {
-      const nietzsche = MaybeNS.nothing();
+      const nietzsche = maybe.nothing();
       const soDeepMan = [
         'Whoever fights monsters should see to it that in the process he does not become a monster.',
         'And if you gaze long enough into an abyss, the abyss will gaze back into you.',
@@ -938,14 +934,14 @@ describe('`Maybe` class', () => {
 
     test('`or` method', () => {
       const theNothing = new Maybe<boolean>(); // the worst: optional booleans!
-      const theDefaultValue = MaybeNS.just(false);
+      const theDefaultValue = maybe.just(false);
 
       expect(theNothing.or(theDefaultValue)).toBe(theDefaultValue);
     });
 
     test('`orElse` method', () => {
       const theNothing = new Maybe<{ here: string[] }>();
-      const justTheFallback = MaybeNS.just({ here: ['to', 'see'] });
+      const justTheFallback = maybe.just({ here: ['to', 'see'] });
       const getTheFallback = () => justTheFallback;
 
       expect(theNothing.orElse(getTheFallback)).toEqual(justTheFallback);
@@ -962,7 +958,7 @@ describe('`Maybe` class', () => {
     test('`andThen` method', () => {
       const theNothing = new Maybe();
       const theDefaultValue = 'string';
-      const getDefaultValue = () => MaybeNS.just(theDefaultValue);
+      const getDefaultValue = () => maybe.just(theDefaultValue);
 
       expect(theNothing.andThen(getDefaultValue)).toEqual(theNothing);
     });
@@ -986,14 +982,14 @@ describe('`Maybe` class', () => {
     });
 
     test('`toString` method', () => {
-      expect(MaybeNS.nothing().toString()).toEqual('Nothing');
+      expect(maybe.nothing().toString()).toEqual('Nothing');
     });
 
     test('`toJSON` method', () => {
-      expect(MaybeNS.nothing().toJSON()).toEqual({ variant: MaybeNS.Variant.Nothing });
-      expect(MaybeNS.of(MaybeNS.nothing()).toJSON()).toEqual({
-        variant: MaybeNS.Variant.Just,
-        value: { variant: MaybeNS.Variant.Nothing },
+      expect(maybe.nothing().toJSON()).toEqual({ variant: maybe.Variant.Nothing });
+      expect(maybe.of(maybe.nothing()).toJSON()).toEqual({
+        variant: maybe.Variant.Just,
+        value: { variant: maybe.Variant.Nothing },
       });
     });
 
@@ -1022,7 +1018,7 @@ describe('`Maybe` class', () => {
         .get('with')
         .get('deeper')
         .get('key names');
-      expect(result).toEqual(MaybeNS.nothing());
+      expect(result).toEqual(maybe.nothing());
     });
   });
 });

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, test } from 'vitest';
 
 import Result, { Ok, Variant, Err } from 'true-myth/result';
-import * as ResultNS from 'true-myth/result';
+import * as result from 'true-myth/result';
 import Unit from 'true-myth/unit';
 
 const length = (x: { length: number }) => x.length;
@@ -9,7 +9,7 @@ const double = (x: number) => x * 2;
 
 describe('`Result` pure functions', () => {
   test('`ok`', () => {
-    const theOk = ResultNS.ok(42);
+    const theOk = result.ok(42);
     expect(theOk).toBeInstanceOf(Result);
     switch (theOk.variant) {
       case Variant.Ok:
@@ -22,9 +22,9 @@ describe('`Result` pure functions', () => {
         expect(false).toBe(true); // because those are the only cases
     }
 
-    const withUnit = ResultNS.ok();
+    const withUnit = result.ok();
     expectTypeOf(withUnit).toEqualTypeOf<Result<Unit, never>>();
-    expect(withUnit).toEqual(ResultNS.ok(Unit));
+    expect(withUnit).toEqual(result.ok(Unit));
 
     const withUnitFromImport = Result.ok();
     expectTypeOf(withUnitFromImport).toEqualTypeOf<Result<Unit, never>>();
@@ -37,7 +37,7 @@ describe('`Result` pure functions', () => {
 
   test('`err`', () => {
     const reason = 'oh teh noes';
-    const theErr = ResultNS.err(reason);
+    const theErr = result.err(reason);
     expect(theErr).toBeInstanceOf(Result);
     switch (theErr.variant) {
       case Variant.Ok:
@@ -50,24 +50,24 @@ describe('`Result` pure functions', () => {
         expect(false).toBe(true); // because those are the only cases
     }
 
-    const withUnit = ResultNS.err();
+    const withUnit = result.err();
     expectTypeOf(withUnit).toEqualTypeOf<Result<never, Unit>>();
-    expect(withUnit).toEqual(ResultNS.err(Unit));
+    expect(withUnit).toEqual(result.err(Unit));
   });
 
   test('`tryOr`', () => {
     const message = 'dang';
     const goodOperation = () => 2 + 2;
 
-    expect(ResultNS.tryOr(message, goodOperation)).toEqual(ResultNS.ok(4));
-    expect(ResultNS.tryOr(message)(goodOperation)).toEqual(ResultNS.ok(4));
+    expect(result.tryOr(message, goodOperation)).toEqual(result.ok(4));
+    expect(result.tryOr(message)(goodOperation)).toEqual(result.ok(4));
 
     const badOperation = () => {
       throw new Error('Danger, danger, Will Robinson');
     };
 
-    expect(ResultNS.tryOr(message, badOperation)).toEqual(ResultNS.err(message));
-    expect(ResultNS.tryOr(message)(badOperation)).toEqual(ResultNS.err(message));
+    expect(result.tryOr(message, badOperation)).toEqual(result.err(message));
+    expect(result.tryOr(message)(badOperation)).toEqual(result.err(message));
   });
 
   test('`tryOrElse`', () => {
@@ -80,68 +80,66 @@ describe('`Result` pure functions', () => {
       throw 'kablooey';
     };
 
-    const res = ResultNS.tryOrElse(handleError, operation);
+    const res = result.tryOrElse(handleError, operation);
     expect(res).toBeInstanceOf(Result);
     expect(res.variant).toBe(Variant.Ok);
 
-    const res2 = ResultNS.tryOrElse(handleError, badOperation);
+    const res2 = result.tryOrElse(handleError, badOperation);
     expect(res2).toBeInstanceOf(Result);
     expect(res2.variant).toBe(Variant.Err);
   });
 
   test('`map`', () => {
     const theValue = 42;
-    const anOk = ResultNS.ok(theValue);
-    const doubledOk = ResultNS.ok(double(theValue));
-    expect(ResultNS.map(double, anOk)).toEqual(doubledOk);
+    const anOk = result.ok(theValue);
+    const doubledOk = result.ok(double(theValue));
+    expect(result.map(double, anOk)).toEqual(doubledOk);
 
-    const anErr: Result<number, string> = ResultNS.err('some nonsense');
-    expect(ResultNS.map(double, anErr)).toEqual(anErr);
+    const anErr: Result<number, string> = result.err('some nonsense');
+    expect(result.map(double, anErr)).toEqual(anErr);
   });
 
   test('`mapOr`', () => {
     const theDefault = 0;
 
     const theValue = 5;
-    const anOk: Result<number, string> = ResultNS.ok(theValue);
-    expect(ResultNS.mapOr(theDefault, double, anOk)).toEqual(double(theValue));
+    const anOk: Result<number, string> = result.ok(theValue);
+    expect(result.mapOr(theDefault, double, anOk)).toEqual(double(theValue));
 
-    const anErr: Result<number, string> = ResultNS.err('blah');
-    expect(ResultNS.mapOr(theDefault, double, anErr)).toEqual(theDefault);
+    const anErr: Result<number, string> = result.err('blah');
+    expect(result.mapOr(theDefault, double, anErr)).toEqual(theDefault);
 
-    expect(ResultNS.mapOr<number, number, string>(theDefault)(double)(anOk)).toEqual(
-      ResultNS.mapOr(theDefault, double, anOk)
+    expect(result.mapOr<number, number, string>(theDefault)(double)(anOk)).toEqual(
+      result.mapOr(theDefault, double, anOk)
     );
-    expect(ResultNS.mapOr(theDefault, double)(anOk)).toEqual(
-      ResultNS.mapOr(theDefault, double, anOk)
-    );
+    expect(result.mapOr(theDefault, double)(anOk)).toEqual(result.mapOr(theDefault, double, anOk));
   });
 
   test('`mapOrElse`', () => {
     const description = 'that was not good';
     const getDefault = (reason: number) => `${description}: ${reason}`;
 
-    const anOk: Result<number, number> = ResultNS.ok(5);
-    expect(ResultNS.mapOrElse(getDefault, String, anOk)).toEqual(String(5));
+    const anOk: Result<number, number> = result.ok(5);
+    expect(result.mapOrElse(getDefault, String, anOk)).toEqual(String(5));
 
     const errValue = 10;
-    const anErr = ResultNS.err(10);
-    expect(ResultNS.mapOrElse(getDefault, String, anErr)).toEqual(`${description}: ${errValue}`);
+    const anErr = result.err(10);
+    expect(result.mapOrElse(getDefault, String, anErr)).toEqual(`${description}: ${errValue}`);
 
-    expect(ResultNS.mapOrElse(getDefault)(String)(anErr)).toEqual(
-      ResultNS.mapOrElse(getDefault, String, anErr)
+    expect(result.mapOrElse(getDefault)(String)(anErr)).toEqual(
+      result.mapOrElse(getDefault, String, anErr)
     );
-    expect(ResultNS.mapOrElse(getDefault, String)(anErr)).toEqual(
-      ResultNS.mapOrElse(getDefault, String, anErr)
+    expect(result.mapOrElse(getDefault, String)(anErr)).toEqual(
+      result.mapOrElse(getDefault, String, anErr)
     );
   });
 
   test('`match`', () => {
-    const nobody = ResultNS.ok('ok');
-    const toErrIs = ResultNS.err('human');
+    const nobody = result.ok('ok');
+    const toErrIs = result.err('human');
 
     expect(
-      ResultNS.match(
+      result.match(
         {
           Ok: (val) => val,
           Err: (err) => err,
@@ -150,7 +148,7 @@ describe('`Result` pure functions', () => {
       )
     ).toBe('ok');
     expect(
-      ResultNS.match(
+      result.match(
         {
           Ok: (val) => val,
           Err: (err) => err,
@@ -161,74 +159,74 @@ describe('`Result` pure functions', () => {
   });
 
   test('`mapErr`', () => {
-    const anOk: Result<number, number> = ResultNS.ok(10);
-    expect(ResultNS.mapErr(double, anOk)).toEqual(anOk);
+    const anOk: Result<number, number> = result.ok(10);
+    expect(result.mapErr(double, anOk)).toEqual(anOk);
 
     const theErrValue = 20;
-    const anErr = ResultNS.err(theErrValue);
-    const doubledErr = ResultNS.err(double(theErrValue));
-    expect(ResultNS.mapErr(double, anErr)).toEqual(doubledErr);
+    const anErr = result.err(theErrValue);
+    const doubledErr = result.err(double(theErrValue));
+    expect(result.mapErr(double, anErr)).toEqual(doubledErr);
   });
 
   test('`and`', () => {
-    const nextOk = ResultNS.ok('not a number');
-    const nextErr = ResultNS.err('not bueno');
+    const nextOk = result.ok('not a number');
+    const nextErr = result.err('not bueno');
 
-    const anOk = ResultNS.ok(0);
-    expect(ResultNS.and(nextOk, anOk)).toEqual(nextOk);
-    expect(ResultNS.and(nextErr, anOk)).toEqual(nextErr);
+    const anOk = result.ok(0);
+    expect(result.and(nextOk, anOk)).toEqual(nextOk);
+    expect(result.and(nextErr, anOk)).toEqual(nextErr);
 
-    const anErr = ResultNS.err('potatoes');
-    expect(ResultNS.and(nextOk, anErr)).toEqual(anErr);
-    expect(ResultNS.and(nextErr, anErr)).toEqual(anErr);
+    const anErr = result.err('potatoes');
+    expect(result.and(nextOk, anErr)).toEqual(anErr);
+    expect(result.and(nextErr, anErr)).toEqual(anErr);
   });
 
   test('`andThen`', () => {
     const theValue = 'a string';
-    const toLengthResult = (s: string) => ResultNS.ok<number, string>(length(s));
+    const toLengthResult = (s: string) => result.ok<number, string>(length(s));
     const expected = toLengthResult(theValue);
 
-    const anOk = ResultNS.ok(theValue);
-    expect(ResultNS.andThen(toLengthResult, anOk)).toEqual(expected);
+    const anOk = result.ok(theValue);
+    expect(result.andThen(toLengthResult, anOk)).toEqual(expected);
 
-    const anErr: Result<string, string> = ResultNS.err('something wrong');
-    expect(ResultNS.andThen(toLengthResult, anErr)).toEqual(anErr);
+    const anErr: Result<string, string> = result.err('something wrong');
+    expect(result.andThen(toLengthResult, anErr)).toEqual(anErr);
   });
 
   test('`or`', () => {
-    const orOk: Result<number, string> = ResultNS.ok(0);
-    const orErr: Result<number, string> = ResultNS.err('something boring');
+    const orOk: Result<number, string> = result.ok(0);
+    const orErr: Result<number, string> = result.err('something boring');
 
     type Err = { [key: string]: string };
 
-    const anOk: Result<number, Err> = ResultNS.ok(42);
-    expect(ResultNS.or(orOk, anOk)).toEqual(anOk);
-    expect(ResultNS.or(orErr, anOk)).toEqual(anOk);
+    const anOk: Result<number, Err> = result.ok(42);
+    expect(result.or(orOk, anOk)).toEqual(anOk);
+    expect(result.or(orErr, anOk)).toEqual(anOk);
 
-    const anErr: Result<number, Err> = ResultNS.err({ oh: 'my' });
-    expect(ResultNS.or(orOk, anErr)).toEqual(orOk);
-    expect(ResultNS.or(orErr, anErr)).toEqual(orErr);
+    const anErr: Result<number, Err> = result.err({ oh: 'my' });
+    expect(result.or(orOk, anErr)).toEqual(orOk);
+    expect(result.or(orErr, anErr)).toEqual(orErr);
   });
 
   test('`orElse`', () => {
-    const orElseOk: Result<number, string> = ResultNS.ok(1);
+    const orElseOk: Result<number, string> = result.ok(1);
     const getAnOk = () => orElseOk;
 
-    const orElseErr: Result<number, string> = ResultNS.err('oh my');
+    const orElseErr: Result<number, string> = result.err('oh my');
     const getAnErr = () => orElseErr;
 
-    const anOk: Result<number, string> = ResultNS.ok(0);
-    expect(ResultNS.orElse(getAnOk, anOk)).toEqual(anOk);
-    expect(ResultNS.orElse(getAnErr, anOk)).toEqual(anOk);
+    const anOk: Result<number, string> = result.ok(0);
+    expect(result.orElse(getAnOk, anOk)).toEqual(anOk);
+    expect(result.orElse(getAnErr, anOk)).toEqual(anOk);
 
-    const anErr: Result<number, string> = ResultNS.err('boom');
-    expect(ResultNS.orElse(getAnOk, anErr)).toEqual(orElseOk);
-    expect(ResultNS.orElse(getAnErr, anErr)).toEqual(orElseErr);
+    const anErr: Result<number, string> = result.err('boom');
+    expect(result.orElse(getAnOk, anErr)).toEqual(orElseOk);
+    expect(result.orElse(getAnErr, anErr)).toEqual(orElseErr);
   });
 
   test('`value` property', () => {
     const theValue = 'hooray';
-    const anOk = ResultNS.ok(theValue);
+    const anOk = result.ok(theValue);
 
     if (anOk.isOk) {
       expect(() => anOk.value).not.toThrow();
@@ -238,7 +236,7 @@ describe('`Result` pure functions', () => {
     }
 
     const theErrValue = 'oh no';
-    const anErr = ResultNS.err(theErrValue);
+    const anErr = result.err(theErrValue);
     if (anErr.isErr) {
       // @ts-expect-error
       expect(() => anErr.value).toThrow();
@@ -249,7 +247,7 @@ describe('`Result` pure functions', () => {
 
   test('`error` property', () => {
     const theValue = 'hooray';
-    const anOk = ResultNS.ok(theValue);
+    const anOk = result.ok(theValue);
 
     if (anOk.isOk) {
       // @ts-expect-error
@@ -259,7 +257,7 @@ describe('`Result` pure functions', () => {
     }
 
     const theErrValue = 'oh no';
-    const anErr = ResultNS.err(theErrValue);
+    const anErr = result.err(theErrValue);
     if (anErr.isErr) {
       expect(() => anErr.error).not.toThrow();
       expect(anErr.error).toBe(theErrValue);
@@ -272,19 +270,19 @@ describe('`Result` pure functions', () => {
     const defaultValue = 'pancakes are awesome';
 
     const theValue = 'waffles are tasty';
-    const anOk = ResultNS.ok(theValue);
-    expect(ResultNS.unwrapOr(defaultValue, anOk)).toBe(theValue);
+    const anOk = result.ok(theValue);
+    expect(result.unwrapOr(defaultValue, anOk)).toBe(theValue);
 
-    const anErr = ResultNS.err('pumpkins are not');
-    expect(ResultNS.unwrapOr(defaultValue, anErr)).toBe(defaultValue);
+    const anErr = result.err('pumpkins are not');
+    expect(result.unwrapOr(defaultValue, anErr)).toBe(defaultValue);
     // make sure you can unwrap to a different type, like undefined
     expectTypeOf(anOk).toEqualTypeOf<Result<string, never>>();
-    const anOkOrUndefined = ResultNS.unwrapOr(undefined, anOk);
+    const anOkOrUndefined = result.unwrapOr(undefined, anOk);
     expectTypeOf(anOkOrUndefined).toEqualTypeOf<string | undefined>();
     expect(anOkOrUndefined).toEqual(theValue);
 
     expectTypeOf(anErr).toEqualTypeOf<Result<never, string>>();
-    const anErrOrUndefined = ResultNS.unwrapOr(undefined, anErr);
+    const anErrOrUndefined = result.unwrapOr(undefined, anErr);
     expectTypeOf(anErrOrUndefined).toEqualTypeOf<undefined>(); // undefined ≡ never | undefined
     expect(anErrOrUndefined).toEqual(undefined);
   });
@@ -295,21 +293,21 @@ describe('`Result` pure functions', () => {
     const errToOk = (e: LocalError) => `What went wrong? ${e.reason}`;
 
     const theValue = 'Red 5';
-    const anOk = ResultNS.ok<string, LocalError>(theValue);
-    expect(ResultNS.unwrapOrElse(errToOk, anOk)).toBe(theValue);
+    const anOk = result.ok<string, LocalError>(theValue);
+    expect(result.unwrapOrElse(errToOk, anOk)).toBe(theValue);
 
     const theErrValue = { reason: 'bad thing' };
-    const anErr = ResultNS.err<string, LocalError>(theErrValue);
-    expect(ResultNS.unwrapOrElse(errToOk, anErr)).toBe(errToOk(theErrValue));
+    const anErr = result.err<string, LocalError>(theErrValue);
+    expect(result.unwrapOrElse(errToOk, anErr)).toBe(errToOk(theErrValue));
 
     // test unwrapping to undefined
     const noop = (): undefined => undefined;
 
-    const anOkOrUndefined = ResultNS.unwrapOrElse(noop, anOk);
+    const anOkOrUndefined = result.unwrapOrElse(noop, anOk);
     expectTypeOf(anOkOrUndefined).toEqualTypeOf<string | undefined>();
     expect(anOkOrUndefined).toEqual(theValue);
 
-    const anErrOrUndefined = ResultNS.unwrapOrElse(noop, anErr);
+    const anErrOrUndefined = result.unwrapOrElse(noop, anErr);
     expectTypeOf(anErrOrUndefined).toEqualTypeOf<string | undefined>();
     expect(anErrOrUndefined).toEqual(undefined);
   });
@@ -319,11 +317,11 @@ describe('`Result` pure functions', () => {
       const theValue = { thisIsReally: 'something' };
       const errValue = ['oh', 'no'];
 
-      const anOk = ResultNS.ok<typeof theValue, typeof errValue>(theValue);
-      expect(ResultNS.toString(anOk)).toEqual(`Ok(${theValue.toString()})`);
+      const anOk = result.ok<typeof theValue, typeof errValue>(theValue);
+      expect(result.toString(anOk)).toEqual(`Ok(${theValue.toString()})`);
 
-      const anErr = ResultNS.err<typeof theValue, typeof errValue>(errValue);
-      expect(ResultNS.toString(anErr)).toEqual(`Err(${errValue.toString()})`);
+      const anErr = result.err<typeof theValue, typeof errValue>(errValue);
+      expect(result.toString(anErr)).toEqual(`Err(${errValue.toString()})`);
     });
 
     test('custom `toString`s', () => {
@@ -332,7 +330,7 @@ describe('`Result` pure functions', () => {
         toString: '🤨',
       };
 
-      expect(ResultNS.toString(Result.ok(withNotAFunction))).toEqual(
+      expect(result.toString(Result.ok(withNotAFunction))).toEqual(
         `Ok(${JSON.stringify(withNotAFunction)})`
       );
 
@@ -343,7 +341,7 @@ describe('`Result` pure functions', () => {
         },
       };
 
-      expect(ResultNS.toString(Result.err(withBadFunction))).toEqual(
+      expect(result.toString(Result.err(withBadFunction))).toEqual(
         `Err(${JSON.stringify(withBadFunction)})`
       );
     });
@@ -351,18 +349,18 @@ describe('`Result` pure functions', () => {
 
   test('`toJSON`', () => {
     const theValue = { thisIsReally: 'something', b: null };
-    const anOk = ResultNS.ok(theValue);
-    expect(ResultNS.toJSON(anOk)).toEqual({ variant: Variant.Ok, value: theValue });
+    const anOk = result.ok(theValue);
+    expect(result.toJSON(anOk)).toEqual({ variant: Variant.Ok, value: theValue });
 
     const errValue = ['oh', 'no', null];
-    const anErr = ResultNS.err(errValue);
-    expect(ResultNS.toJSON(anErr)).toEqual({ variant: Variant.Err, error: errValue });
+    const anErr = result.err(errValue);
+    expect(result.toJSON(anErr)).toEqual({ variant: Variant.Err, error: errValue });
   });
 
   test('`toJSON` through serialization', () => {
-    const actualSerializedOk = JSON.stringify(ResultNS.ok(42));
-    const actualSerializedErr = JSON.stringify(ResultNS.err({ someInfo: 'error' }));
-    const actualSerializedUnitErr = JSON.stringify(ResultNS.err());
+    const actualSerializedOk = JSON.stringify(result.ok(42));
+    const actualSerializedErr = JSON.stringify(result.err({ someInfo: 'error' }));
+    const actualSerializedUnitErr = JSON.stringify(result.err());
     const expectedSerializedOk = JSON.stringify({ variant: Variant.Ok, value: 42 });
     const expectedSerializedErr = JSON.stringify({
       variant: Variant.Err,
@@ -379,48 +377,48 @@ describe('`Result` pure functions', () => {
   });
 
   test('`equals`', () => {
-    const a = ResultNS.ok<string, string>('a');
-    const b = ResultNS.ok<string, string>('a');
-    const c = ResultNS.err<string, string>('error');
-    const d = ResultNS.err<string, string>('error');
-    expect(ResultNS.equals(b, a)).toBe(true);
-    expect(ResultNS.equals(b)(a)).toBe(true);
-    expect(ResultNS.equals(c, b)).toBe(false);
-    expect(ResultNS.equals(c)(b)).toBe(false);
-    expect(ResultNS.equals(d, c)).toBe(true);
-    expect(ResultNS.equals(d)(c)).toBe(true);
+    const a = result.ok<string, string>('a');
+    const b = result.ok<string, string>('a');
+    const c = result.err<string, string>('error');
+    const d = result.err<string, string>('error');
+    expect(result.equals(b, a)).toBe(true);
+    expect(result.equals(b)(a)).toBe(true);
+    expect(result.equals(c, b)).toBe(false);
+    expect(result.equals(c)(b)).toBe(false);
+    expect(result.equals(d, c)).toBe(true);
+    expect(result.equals(d)(c)).toBe(true);
   });
 
   test('`ap`', () => {
     const add = (a: number) => (b: number) => a + b;
-    const okAdd = ResultNS.ok<typeof add, string>(add);
+    const okAdd = result.ok<typeof add, string>(add);
 
-    expect(okAdd.ap(ResultNS.ok(2)).ap(ResultNS.ok(3))).toEqual(ResultNS.ok(5));
+    expect(okAdd.ap(result.ok(2)).ap(result.ok(3))).toEqual(result.ok(5));
 
     const add3 = add(3);
-    const okAdd3 = ResultNS.ok<typeof add3, string>(add(3));
+    const okAdd3 = result.ok<typeof add3, string>(add(3));
 
-    expect(ResultNS.ap(okAdd3, ResultNS.ok(2))).toEqual(ResultNS.ok(5));
+    expect(result.ap(okAdd3, result.ok(2))).toEqual(result.ok(5));
   });
 
   test('isInstance', () => {
-    const ok: unknown = ResultNS.ok('yay');
-    expect(ResultNS.isInstance(ok)).toBe(true);
+    const ok: unknown = result.ok('yay');
+    expect(result.isInstance(ok)).toBe(true);
 
-    const err: unknown = ResultNS.err('oh no');
-    expect(ResultNS.isInstance(err)).toBe(true);
+    const err: unknown = result.err('oh no');
+    expect(result.isInstance(err)).toBe(true);
 
     const nada: unknown = null;
-    expect(ResultNS.isInstance(nada)).toBe(false);
+    expect(result.isInstance(nada)).toBe(false);
 
     const obj: unknown = { random: 'nonsense' };
-    expect(ResultNS.isInstance(obj)).toBe(false);
+    expect(result.isInstance(obj)).toBe(false);
   });
 
   test('`isOk` with an Ok', () => {
-    const testOk: Result<number, string> = ResultNS.ok(42);
+    const testOk: Result<number, string> = result.ok(42);
 
-    if (ResultNS.isOk(testOk)) {
+    if (result.isOk(testOk)) {
       expect(testOk.value).toEqual(42);
     } else {
       expect.fail('Expected an Ok');
@@ -428,21 +426,21 @@ describe('`Result` pure functions', () => {
   });
 
   test('`isOk` with an Err', () => {
-    const testErr: Result<number, string> = ResultNS.err('');
+    const testErr: Result<number, string> = result.err('');
 
-    expect(ResultNS.isOk(testErr)).toEqual(false);
+    expect(result.isOk(testErr)).toEqual(false);
   });
 
   test('`isErr` with an Ok', () => {
-    const testOk: Result<number, string> = ResultNS.ok(42);
+    const testOk: Result<number, string> = result.ok(42);
 
-    expect(ResultNS.isErr(testOk)).toEqual(false);
+    expect(result.isErr(testOk)).toEqual(false);
   });
 
   test('`isErr` with an Err', () => {
-    const testErr: Result<number, string> = ResultNS.err('');
+    const testErr: Result<number, string> = result.err('');
 
-    expect(ResultNS.isErr(testErr)).toEqual(true);
+    expect(result.isErr(testErr)).toEqual(true);
   });
 
   describe('`safe` function', () => {
@@ -460,7 +458,7 @@ describe('`Result` pure functions', () => {
     }
 
     describe('without an error handler', () => {
-      let safeExample = ResultNS.safe(example);
+      let safeExample = result.safe(example);
       expectTypeOf(safeExample).toEqualTypeOf<
         (value: number, should?: { throwErr?: boolean }) => Result<string, unknown>
       >();
@@ -486,7 +484,7 @@ describe('`Result` pure functions', () => {
     });
 
     describe('with an error handler', () => {
-      let safeExample = ResultNS.safe(example, (reason) => JSON.stringify(reason, null, 2));
+      let safeExample = result.safe(example, (reason) => JSON.stringify(reason, null, 2));
       expectTypeOf(safeExample).toEqualTypeOf<
         (value: number, should?: { throwErr?: boolean }) => Result<string, string>
       >();
@@ -516,25 +514,25 @@ describe('`Result` pure functions', () => {
 // know to be correct from other tests. Instead, this test just checks whether
 // the types are narrowed as they should be.
 test('narrowing', () => {
-  const oneOk = ResultNS.ok();
+  const oneOk = result.ok();
   if (oneOk.isOk) {
     expectTypeOf(oneOk).toEqualTypeOf<Ok<Unit, never>>();
     expect(oneOk.value).toBeDefined();
   }
 
-  const anotherOk = ResultNS.ok();
+  const anotherOk = result.ok();
   if (anotherOk.variant === Variant.Ok) {
     expectTypeOf(anotherOk).toEqualTypeOf<Ok<Unit, never>>();
     expect(anotherOk.value).toBeDefined();
   }
 
-  const oneErr = ResultNS.err();
+  const oneErr = result.err();
   if (oneErr.isErr) {
     expectTypeOf(oneErr).toEqualTypeOf<Err<never, Unit>>();
     expect(oneErr.error).toBeDefined();
   }
 
-  const anotherErr = ResultNS.err();
+  const anotherErr = result.err();
   if (anotherErr.variant === Variant.Err) {
     expectTypeOf(anotherErr).toEqualTypeOf<Err<never, Unit>>();
     expect(anotherErr.error).toBeDefined();
@@ -849,39 +847,39 @@ describe('`ResultNS.Err` class', () => {
   test('`and` method', () => {
     const theErr = Result.err('blarg');
 
-    const anOk = ResultNS.ok<string, string>('neat');
+    const anOk = result.ok<string, string>('neat');
     expect(theErr.and(anOk)).toEqual(theErr);
 
-    const anotherErr = ResultNS.err('oh no');
+    const anotherErr = result.err('oh no');
     expect(theErr.and(anotherErr)).toEqual(theErr);
   });
 
   test('`andThen` method', () => {
     const theErr = Result.err<string[], number>(42);
 
-    const getAnOk = (strings: string[]) => ResultNS.ok<number, number>(length(strings));
+    const getAnOk = (strings: string[]) => result.ok<number, number>(length(strings));
     expect(theErr.andThen(getAnOk)).toEqual(theErr);
 
-    const getAnErr = (_: unknown) => ResultNS.err(0);
+    const getAnErr = (_: unknown) => result.err(0);
     expect(theErr.andThen(getAnErr)).toEqual(theErr);
   });
 
   test('`or` method', () => {
     const theErr: Result<number, string> = Result.err('a shame');
-    const anOk: Result<number, string> = ResultNS.ok(42);
+    const anOk: Result<number, string> = result.ok(42);
     expect(theErr.or(anOk)).toBe(anOk);
 
-    const anotherErr = ResultNS.err<number, number>(10);
+    const anotherErr = result.err<number, number>(10);
     expect(theErr.or(anotherErr)).toBe(anotherErr);
   });
 
   test('`orElse` method', () => {
     const theErr = Result.err<string, string>('what sorrow');
-    const theOk = ResultNS.ok<string, string>('neat!');
+    const theOk = result.ok<string, string>('neat!');
     const getOk = () => theOk;
     expect(theErr.orElse(getOk)).toBe(theOk);
 
-    const anotherErr = ResultNS.err<string, string>('even worse');
+    const anotherErr = result.err<string, string>('even worse');
     const getAnotherErr = () => anotherErr;
     expect(theErr.orElse(getAnotherErr)).toBe(anotherErr);
   });


### PR DESCRIPTION
This is just lightweight prep for some slightly larger fixes.