### PR TITLE
build: Fix documentation build, and always check it.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,3 +39,13 @@ jobs:
       - run: pnpm install
       - run: pnpm add --save-dev typescript@${{ matrix.ts-version }}
       - run: pnpm type-check
+
+  check_docs:
+    name: 'Build docs'
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+      - run: pnpm install
+      - run: pnpm run docs

--- a/.github/workflows/Publish Docs.yml
+++ b/.github/workflows/Publish Docs.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm add --save-dev typescript@latest
 
       - name: Generate docs
-        run: pnpm docs
+        run: pnpm run docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Running `pnpm docs` opens the documentation page for the project, which is on the one hand maybe a nice shortcut but on the other quite annoying in this actual case. Use `pnpm run docs` instead.

Additionally, add a CI check to make sure that docs build successfully. Annoyingly, the dev built for VitePress does *not* do everything that a prod build does, e.g. link checking: reasonable, but annoying.