### PR TITLE
breaking: require Node v20+ for v9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18', '20', '22']
+        node-version: ['20', '22']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ See [the docs](https://true-myth.js.org) for setup, guides, and API docs!
 
 ## Requirements
 
-- Node 18+
+- Node 20+
 - TS 5.3+
 - `tsconfig.json`:
+  - `moduleResolution`: use `"Node16"` or later
+  - `strict: true`
 - `package.json`
   - `type: "module"` (or else use `import()` to import True Myth into a commonJS build)
 

--- a/docs/guide/introduction/getting-started.md
+++ b/docs/guide/introduction/getting-started.md
@@ -4,7 +4,7 @@ True Myth has no additional dependencies and is ready to start using immediately
 
 ## Requirements
 
-- Node 18+
+- Node 20+
 - TS 5.3+
 - `tsconfig.json`:
   - `moduleResolution`: use `"Node16"` or later


### PR DESCRIPTION
Node 18 leaves Maintenance mode in a couple weeks. No reason to keep support for it in v9.