### PR TITLE
Maybe: add a new overload for `Maybe.of(unknown) -> Maybe<{}>`

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -110,9 +110,13 @@ class MaybeImpl<T> {
   static of<F extends (...args: any) => {}>(value: F): Maybe<F>;
   static of<T extends {}, F extends (...args: any) => T | null | undefined>(value: F): never;
   static of<F extends (...args: any) => null | undefined>(value: F): never;
-  // For all other types, allow `null | undefined`, since in those cases we will
-  // produce `Nothing`.
-  static of<T>(value: T | null | undefined): Maybe<T>;
+  // For all other non-null types, allow `null | undefined` implicitly via the
+  // `unknown` type, since in those cases we will produce `Nothing`.
+  static of<T extends {}>(value: T | null | undefined): Maybe<T>;
+  // Finally, with a type that falls back entirely to `unknown`, produce a non-
+  // null type, because that is the one thing we know to be true by construction
+  // in that case.
+  static of<T>(value: T): Maybe<NonNullable<T>>;
   // Then the implementation signature is simply the same as the final overload,
   // because we do not *and cannot* prevent the undesired function types from
   // appearing here at runtime: doing so would require having a value on which
@@ -1243,16 +1247,16 @@ export type AnyArray<T> = Array<T> | ReadonlyArray<T>;
 export function find<T, U extends T>(
   predicate: NarrowingPredicate<T, U>,
   array: AnyArray<T>
-): Maybe<U>;
+): Maybe<NonNullable<U>>;
 export function find<T, U extends T>(
   predicate: NarrowingPredicate<T, U>
-): (array: AnyArray<T>) => Maybe<U>;
-export function find<T>(predicate: Predicate<T>, array: AnyArray<T>): Maybe<T>;
-export function find<T>(predicate: Predicate<T>): (array: AnyArray<T>) => Maybe<T>;
+): (array: AnyArray<T>) => Maybe<NonNullable<U>>;
+export function find<T>(predicate: Predicate<T>, array: AnyArray<T>): Maybe<NonNullable<T>>;
+export function find<T>(predicate: Predicate<T>): (array: AnyArray<T>) => Maybe<NonNullable<T>>;
 export function find<T, U extends T>(
   predicate: NarrowingPredicate<T, U> | Predicate<T>,
   array?: AnyArray<T>
-): Maybe<T> | ((array: AnyArray<T>) => Maybe<T>) {
+): Maybe<NonNullable<T>> | ((array: AnyArray<T>) => Maybe<NonNullable<T>>) {
   const op = (a: AnyArray<T>) => Maybe.of(a.find(predicate));
   return curry1(op, array);
 }
@@ -1274,7 +1278,7 @@ export function find<T, U extends T>(
 
   @param array The array to get the first item from.
  */
-export function first<T>(array: AnyArray<T | null | undefined>): Maybe<T> {
+export function first<T>(array: AnyArray<T>): Maybe<NonNullable<T>> {
   return Maybe.of(array[0]);
 }
 
@@ -1295,7 +1299,7 @@ export function first<T>(array: AnyArray<T | null | undefined>): Maybe<T> {
 
   @param array The array to get the first item from.
  */
-export function last<T>(array: AnyArray<T | null | undefined>): Maybe<T> {
+export function last<T>(array: AnyArray<T | null | undefined>): Maybe<NonNullable<T>> {
   return Maybe.of(array[array.length - 1]);
 }
 

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -61,7 +61,7 @@ describe('`Maybe` pure functions', () => {
     }
 
     const nothingOnType = maybe.nothing<string>();
-    expectTypeOf(nothingOnType).toMatchTypeOf<Maybe<string>>();
+    expectTypeOf(nothingOnType).toExtend<Maybe<string>>();
   });
 
   describe('`of`', () => {
@@ -71,6 +71,9 @@ describe('`Maybe` pure functions', () => {
     let example = (): string | undefined => undefined;
     expectTypeOf(Maybe.of(example)).toBeNever();
     expectTypeOf(Maybe.of(() => 'hello')).toEqualTypeOf<Maybe<() => string>>();
+
+    let unknownVal: unknown = 123;
+    expectTypeOf(Maybe.of(unknownVal)).toEqualTypeOf<Maybe<{}>>();
 
     test('with `null', () => {
       const nothingFromNull = maybe.of<string>(null);
@@ -112,7 +115,7 @@ describe('`Maybe` pure functions', () => {
 
     const none = maybe.nothing<string>();
     const noLength = maybe.map(length, none);
-    expectTypeOf(none).toMatchTypeOf<Maybe<string>>();
+    expectTypeOf(none).toExtend<Maybe<string>>();
     expect(noLength).toEqual(maybe.nothing());
 
     expect(() => {
@@ -228,7 +231,7 @@ describe('`Maybe` pure functions', () => {
 
       expectTypeOf(theOutput).toEqualTypeOf<
         Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
-      >;
+      >();
     });
   });
 
@@ -284,7 +287,7 @@ describe('`Maybe` pure functions', () => {
 
       expectTypeOf(theOutput).toEqualTypeOf<
         Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
-      >;
+      >();
     });
   });
 
@@ -479,11 +482,11 @@ describe('`Maybe` pure functions', () => {
       const waffles = findByName('waffles')(array);
       expect(waffles.variant).toBe(maybe.Variant.Just);
       expect((waffles as Just<Item>).value).toEqual(array[1]);
-      expectTypeOf(waffles).toMatchTypeOf<Maybe<{ name: 'waffles' }>>();
+      expectTypeOf(waffles).toExtend<Maybe<{ name: 'waffles' }>>();
 
       const readonlyEmpty: readonly number[] = [];
       const foundReadonly = maybe.find(pred, readonlyEmpty);
-      expectTypeOf(foundReadonly).toMatchTypeOf<Maybe<number>>();
+      expectTypeOf(foundReadonly).toExtend<Maybe<number>>();
     });
 
     test('`first`', () => {


### PR DESCRIPTION
We know by the way `Maybe` is constructed that when passed an `unknown` value, the result will be `Maybe<{}>`, because the constructor always produces `Nothing` if the value is undefined. We do not know anything *else* about the type, but we do know *that*!

Closes #963