### PR TITLE
Maybe: correctly handle arrays which include null and undefined

### DIFF
--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -491,24 +491,64 @@ describe('`Maybe` pure functions', () => {
 
     test('`first`', () => {
       expect(maybe.first([])).toEqual(maybe.nothing());
-      expect(maybe.first([1])).toEqual(maybe.just(1));
-      expect(maybe.first([1, 2, 3])).toEqual(maybe.just(1));
+      expect(maybe.first([1])).toEqual(maybe.just(maybe.just(1)));
+      expect(maybe.first([1, 2, 3])).toEqual(maybe.just(maybe.just(1)));
 
       const readonlyEmpty: readonly number[] = [];
       expect(maybe.first(readonlyEmpty)).toEqual(maybe.nothing());
       const readonlyFilled: readonly number[] = [1, 2, 3];
-      expect(maybe.first(readonlyFilled)).toEqual(maybe.just(1));
+      expect(maybe.first(readonlyFilled)).toEqual(maybe.just(maybe.just(1)));
+
+      const mixedWithNull = [null, 1, null, 2];
+      const firstOfMixedWithNull = maybe.first(mixedWithNull);
+      expectTypeOf(firstOfMixedWithNull).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
+
+      const mixedWithUndefined = [undefined, 1, undefined, 2];
+      const firstOfMixedWithUndefined = maybe.first(mixedWithUndefined);
+      expectTypeOf(firstOfMixedWithUndefined).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
+
+      const mixedWithBothNullFirst = [null, 1, undefined, 2];
+      const firstOfMixedWithBothNullFirst = maybe.first(mixedWithBothNullFirst);
+      expectTypeOf(firstOfMixedWithBothNullFirst).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
+
+      const mixedWithBothUndefinedFirst = [undefined, 1, null, 2];
+      const firstOfMixedWithBothUndefinedFirst = maybe.first(mixedWithBothUndefinedFirst);
+      expectTypeOf(firstOfMixedWithBothUndefinedFirst).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
     });
 
     test('`last`', () => {
       expect(maybe.last([])).toEqual(maybe.nothing());
-      expect(maybe.last([1])).toEqual(maybe.just(1));
-      expect(maybe.last([1, 2, 3])).toEqual(maybe.just(3));
+      expect(maybe.last([1])).toEqual(maybe.just(maybe.just(1)));
+      expect(maybe.last([1, 2, 3])).toEqual(maybe.just(maybe.just(3)));
 
       const readonlyEmpty: readonly number[] = [];
       expect(maybe.last(readonlyEmpty)).toEqual(maybe.nothing());
       const readonlyFilled: readonly number[] = [1, 2, 3];
-      expect(maybe.last(readonlyFilled)).toEqual(maybe.just(3));
+      expect(maybe.last(readonlyFilled)).toEqual(maybe.just(maybe.just(3)));
+
+      const mixedWithNull = [1, null, 2, null];
+      const lastOfMixedWithNull = maybe.last(mixedWithNull);
+      expectTypeOf(lastOfMixedWithNull).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
+
+      const mixedWithUndefined = [1, undefined, 2, undefined];
+      const lastOfMixedWithUndefined = maybe.last(mixedWithUndefined);
+      expectTypeOf(lastOfMixedWithUndefined).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
+
+      const mixedWithBothNullLast = [1, undefined, 2, null];
+      const lastOfMixedWithBothNullLast = maybe.last(mixedWithBothNullLast);
+      expectTypeOf(lastOfMixedWithBothNullLast).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
+
+      const mixedWithBothUndefinedLast = [1, null, 2, undefined];
+      const lastOfMixedWithBothUndefinedLast = maybe.last(mixedWithBothUndefinedLast);
+      expectTypeOf(lastOfMixedWithBothUndefinedLast).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
     });
 
     describe('`transposeArray`', () => {


### PR DESCRIPTION
With the `first` and `last` helpers, we historically, wrongly, treated these two cases as both producing `Nothing`:

```ts
import { last } from 'true-myth/maybe';

let empty = last([]);
let hasNull = last([null]);
```

These are *not* the same, though! One of them *has* an item in it that is `null`; the other is *empty*.

Update the definitions of `first` and `last` so they now produce nested `Maybe<Maybe<T>>`. Although this is slightly more annoying, it is more correct, and can be flattened easily with `andThen`:

```ts
import { first } from 'true-myth/maybe';

let empty = first([]).andThen((v) => v); // Nothing
let hasUndef = first([undefined]).andThen((v) => v); // Nothing
```

Note: This is a bug fix, but it is also *quite* breaking. As such, it will be part of 9.0 and *not* backported to the 8.x branch.