### PR TITLE
breaking: use lowercase names for root namespace re-exports

### DIFF
--- a/docs/guide/introduction/getting-started.md
+++ b/docs/guide/introduction/getting-started.md
@@ -43,20 +43,24 @@ bun add true-myth
 True Myth is organized into modules within its public API, so you will generally not import from the root of the package, but from the dedicated module for each major type:
 
 ```ts
-import Maybe from 'true-myth/maybe';
-import Result from 'true-myth/result';
-import Task from 'true-myth/task';
+import Maybe, * as maybe from 'true-myth/maybe';
+import Result, * as result from 'true-myth/result';
+import Task, * as task from 'true-myth/task';
 import { exponential, jitter } from 'true-myth/task/delay';
 ```
 
-If for some reason you *need* to import from the root, however,the default export and the full contents of each module are both available there. For example, you can import both the `Maybe` *type* and the contents of the `true-myth/maybe` module as a *namespace* like so:
+If for some reason you *need* to import from the root, however, the default export and the full contents of each module are both available there. For example, you can import both the `Maybe` *type* and the contents of the `true-myth/maybe` module as a *namespace* like so:
 
 ```ts
-import { Maybe, MaybeNS } from 'true-myth';
+import { Maybe, maybe } from 'true-myth';
 ```
 
-:::tip
+If you want to, you can even use a namespace import to reference all the types and namespaces from the root:
 
-This is not idiomatic and may be removed in a future version.
+```ts
+import * as tm from 'true-myth';
 
-:::
+function useMaybe(someMaybe: tm.Maybe<string>) {
+  // ...
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,20 @@
 /**
   This is just here to re-export {@link Maybe}, {@link Result}, {@link Task},
   {@link Unit}, and {@link Toolbelt}, to provide a root-level entry friendly to
-  using with Node with TypeScript versions before 4.7 and its ESM support, as
-  well as for general convenience.
+  using as a namespace.
 
   @packageDocumentation
  */
 
 export { default as Maybe } from './maybe.js';
-export * as MaybeNS from './maybe.js';
+export * as maybe from './maybe.js';
 
 export { default as Result } from './result.js';
-export * as ResultNS from './result.js';
+export * as result from './result.js';
 
 export { default as Unit } from './unit.js';
 
 export { default as Task } from './task.js';
+export * as task from './task.js';
 
-export * as Toolbelt from './toolbelt.js';
+export * as toolbelt from './toolbelt.js';


### PR DESCRIPTION
Imports now look like this (no more `MaybeNS`, `ResultNS`, `TaskNS`, etc.):

```ts
import { Maybe, maybe } from 'true-myth';
```

Or even:

```ts
import * as tm from 'true-myth';

function useMaybe(someMaybe: tm.Maybe<string>) {
  // ...
}
```