### PR TITLE
docs/build: add TS 5.8 to matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,11 +11,11 @@ env:
 
 jobs:
   tests_linux:
-    name: 'Tests: Node ${{ matrix.node-version }}'
+    name: "Tests: Node ${{ matrix.node-version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20', '22']
+        node-version: ["20", "22"]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,12 +26,12 @@ jobs:
       - run: pnpm test
 
   tests_ts:
-    name: 'Tests: TS ${{ matrix.ts-version }}'
+    name: "Tests: TS ${{ matrix.ts-version }}"
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
       matrix:
-        ts-version: ['5.3', '5.4', '5.5', '5.6', '5.7', 'next']
+        ts-version: ["5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "next"]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       - run: pnpm type-check
 
   check_docs:
-    name: 'Build docs'
+    name: "Build docs"
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img src='https://img.shields.io/badge/Node-18%20LTS%20%7C%2020%20LTS%20%7C%2022-darkgreen' alt='supported Node versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/CI.yml#L59'>
-    <img src='https://img.shields.io/badge/TypeScript-5.3%20%3C=%205.7%20%7C%20next-3178c6' alt='supported TypeScript versions'>
+    <img src='https://img.shields.io/badge/TypeScript-5.3%20%3C=%205.8%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/true-myth/true-myth/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/true-myth/true-myth/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>
@@ -72,7 +72,7 @@ For details on using a pure ES modules package in TypeScript, see [the TypeScrip
 
 This project follows the current draft of [the Semantic Versioning for TypeScript Types][semver] specification.
 
-- **Currently supported TypeScript versions:** 5.3, 5.4, 5.5, 5.6, and 5.7
+- **Currently supported TypeScript versions:** 5.3, 5.4, 5.5, 5.6, 5.7, and 5.8
 - **Compiler support policy:** [simple majors][sm]
 - **Public API:** all published, documented types not in a `-private` module and not marked as `@internal` or `@private` are public
 


### PR DESCRIPTION
This was already supported in v9.0, explicitly in the release post, but I failed to add it to CI and the README when it came out.