### PR TITLE
build: check build script in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,16 @@ jobs:
       - run: pnpm install
       - run: pnpm test
 
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+      - run: pnpm install
+      - run: pnpm build
+
   tests_ts:
     name: "Tests: TS ${{ matrix.ts-version }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The vitest config doesn't require this, so it was previously possible to end up with a non-working `build`: and in fact we *did*. This won't let CI pass if `pnpm build` fails.