### PR TITLE
internal: simplify build and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@biomejs/biome": "1.9.4",
     "@release-it-plugins/lerna-changelog": "^7.0.0",
     "@types/markdown-it": "^14.1.2",
-    "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^2.1.9",
     "feed": "^5.0.1",
     "markdown-it-deflist": "^3.0.0",
@@ -81,6 +80,7 @@
     "typedoc-plugin-markdown": "^4.6.3",
     "typedoc-vitepress-theme": "^1.1.2",
     "typescript": "5.3.3",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitepress": "^1.6.3",
     "vitest": "^2.1.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
-      '@types/node':
-        specifier: ^24.0.0
-        version: 24.0.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
         version: 2.1.9(vitest@2.1.9(@types/node@24.0.1))
@@ -59,6 +56,9 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.3.3)(vite@5.4.19(@types/node@24.0.1))
       vitepress:
         specifier: ^1.6.3
         version: 1.6.3(@algolia/client-search@5.25.0)(@types/node@24.0.1)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.3.3)
@@ -1318,6 +1318,9 @@ packages:
     resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
     engines: {node: '>=18'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
@@ -2411,6 +2414,16 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2516,6 +2529,14 @@ packages:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
@@ -3261,6 +3282,7 @@ snapshots:
   '@types/node@24.0.1':
     dependencies:
       undici-types: 7.8.0
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -3957,6 +3979,8 @@ snapshots:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
+
+  globrex@0.1.2: {}
 
   graceful-fs@4.2.10: {}
 
@@ -5164,6 +5188,10 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  tsconfck@3.1.6(typescript@5.3.3):
+    optionalDependencies:
+      typescript: 5.3.3
+
   tslib@2.8.1: {}
 
   type-fest@0.21.3: {}
@@ -5193,7 +5221,8 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  undici-types@7.8.0: {}
+  undici-types@7.8.0:
+    optional: true
 
   unicorn-magic@0.1.0: {}
 
@@ -5290,6 +5319,17 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-tsconfig-paths@5.1.4(typescript@5.3.3)(vite@5.4.19(@types/node@24.0.1)):
+    dependencies:
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.3.3)
+    optionalDependencies:
+      vite: 5.4.19(@types/node@24.0.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@5.4.19(@types/node@24.0.1):
     dependencies:

--- a/ts/base.tsconfig.json
+++ b/ts/base.tsconfig.json
@@ -3,22 +3,18 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "Node16",
-    "lib": ["es2022"],
-
+    "lib": [
+      "es2022",
+      // For `setTimeout`.
+      "DOM"
+    ],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-
     "moduleResolution": "Node16",
-
-    // Normally, this is a *very* bad idea. However, here the library *itself*
-    // has no dependencies, and so type checking should always be completely
-    // localized.
-    "skipLibCheck": true
   },
   // as a base, don't include anything: specify that in the other files
   "include": []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,16 @@
       // `package.json`. (This way the tests can run -- and, critically, they
       // are usable in the editor! -- without having to prebuild the `src`
       // directory.)
-      "true-myth": ["./src/index.ts"],
-      "true-myth/*": ["./src/*.ts"]
+      "true-myth": [
+        "./src/index.ts"
+      ],
+      "true-myth/*": [
+        "./src/*.ts"
+      ]
     }
   },
-  "include": ["./src/**/*", "./test/**/*"]
+  "include": [
+    "./src",
+    "./test"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,9 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
-import path from 'path';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
-    alias: {
-      'true-myth': path.resolve(__dirname, './src'),
-    },
     include: ['test/*.test.ts'],
     typecheck: {
       enabled: true,


### PR DESCRIPTION
- Use `vite-tsconfig-paths` and drop `@types/node`. That should make for a *lot* less PR noise. Include the `DOM` library so `setTimeout` is available (it is available in every environment we support).

- Update the TS configs to simplify them while touching them for the vitest update:
    - Use `simple` include rules rather than globs.
    - Stop using `skipLibCheck`: for the very reason we notionally could use it in the first place (we are a zero-deps library) we also do not *need* it.