### PR TITLE
feat: Merge multiple results into one

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -1453,6 +1453,103 @@ export function isInstance<T, E>(item: unknown): item is Result<T, E> {
   return item instanceof ResultImpl;
 }
 
+type AnyResults = readonly AnyResult[];
+
+type OkType<A extends AnyResults> = { [P in keyof A]: OkFor<A[P]> };
+
+type OkForSome<A extends AnyResults> = OkType<A>[number][];
+
+type OkForAll<A extends AnyResults> = [...OkType<A>];
+
+type ErrType<A extends AnyResults> = { [P in keyof A]: ErrFor<A[P]> };
+
+type ErrForSome<A extends AnyResults> = ErrType<A>[number][];
+
+/**
+  A type utility for mapping an input array of results into the appropriate output
+  for `all`.
+
+  @internal
+ */
+export type All<A extends AnyResults> = Result<OkForAll<A>, ErrForSome<A>>;
+
+type ReducedResult<A extends AnyResults> = {
+  readonly oks: OkForSome<A>;
+  readonly errs: ErrForSome<A>;
+};
+
+function isAllOk<A extends AnyResults>(
+  result: ReducedResult<A>
+): result is { oks: OkForAll<A>; errs: [] } {
+  return result.errs.length === 0;
+}
+
+/**
+  Given an array of results, return a new `OK` if all results are {@linkcode Ok} or a new `Err` if some result is {@linkcode Err}.
+
+  ## Examples
+
+  If all results are {@linkcode Ok}:
+
+  ```ts
+  import Result, { all } from 'true-myth/result';
+
+  let result = all([
+    Result.ok(10),
+    Result.ok(100),
+    Result.ok(1000)
+  ]);
+
+  console.log(result.toString()); // Ok(10,100,1000)
+  ```
+
+  If any result is {@linkcode Err}:
+
+  ```ts
+  import Result, { all } from 'true-myth/result';
+
+  let result = all([
+    Result.ok(10),
+    Result.ok(100),
+    Result.err("something went wrong")
+  ]);
+
+  console.log(result.toString()); // Err(something went wrong)
+  ```
+
+  @param results The list of results.
+
+  @template A The type of the array or tuple of results.
+*/
+export function all<const A extends AnyResults>(results: A): All<A> {
+  const reducedResult = results.reduce<ReducedResult<A>>(
+    (resultsReducer, result) => {
+      const { oks: oksReducer, errs: errsReducer } = resultsReducer;
+
+      return result.match({
+        // If the result is an `Ok`, add it to the list of oks.
+        Ok: (value) => {
+          return { oks: [...oksReducer, value], errs: errsReducer };
+        },
+        // If the result is an `Err`, add it to the list of errs.
+        Err: (error) => {
+          return { oks: oksReducer, errs: [...errsReducer, error] };
+        },
+      });
+    },
+    { oks: [], errs: [] }
+  );
+
+  // If there are no errors, it can be safely assumed that all results were `Ok`
+  // and return an `Ok` with the list of oks.
+  if (isAllOk(reducedResult)) {
+    return Result.ok(reducedResult.oks);
+  }
+
+  // If not all taks were `Ok`, return an `Err` with the list of errors.
+  return Result.err(reducedResult.errs);
+}
+
 /**
   The public interface for the {@linkcode Result} class *as a value*: the static
   constructors `ok` and `err` produce a `Result` with that variant.

--- a/src/result.ts
+++ b/src/result.ts
@@ -1472,11 +1472,13 @@ export type All<A extends AnyResults> = Result<
 >;
 
 /**
-  Given an array of results, return a new `OK` if all results are {@linkcode Ok} or a new `Err` if some result is {@linkcode Err}.
+  Given an array of results, return a new {@linkcode Ok} result if all results are {@linkcode Ok}
+  or a new {@linkcode Err} result if some result is {@linkcode Err}.
 
   ## Examples
 
-  If all results are {@linkcode Ok}, return a new `Ok` containing an array of all given `Ok` values:
+  If all results are {@linkcode Ok}, return a new {@linkcode Ok} result containing an array of all
+  given {@linkcode Ok} values:
 
   ```ts
   import Result, { all } from 'true-myth/result';
@@ -1490,7 +1492,8 @@ export type All<A extends AnyResults> = Result<
   console.log(result.toString()); // Ok(10,100,1000)
   ```
 
-  If any result is {@linkcode Err}, return a new `Err` containing the first error encountered:
+  If any result is {@linkcode Err}, return a new {@linkcode Err} result containing the first
+  {@linkcode Err} encountered:
 
   ```ts
   import Result, { all } from 'true-myth/result';
@@ -1505,6 +1508,9 @@ export type All<A extends AnyResults> = Result<
   ```
 
   @param results The list of results.
+  @return A new {@linkcode Result} containing an array of all {@linkcode Ok} values if all
+    results are {@linkcode Ok}, or a new {@linkcode Err} result containing the first
+    {@linkcode Err} encountered.
 
   @template A The type of the array or tuple of results.
 */
@@ -1536,11 +1542,13 @@ export type AllResults<A extends AnyResults> = Result<
 >;
 
 /**
-  Given an array of results, return a new `OK` if all results are {@linkcode Ok} or a new `Err` if some result is {@linkcode Err}.
+  Given an array of results, return a new {@linkcode Ok} result if all results are {@linkcode Ok}
+  or a new {@linkcode Err} result if some result is {@linkcode Err}.
 
   ## Examples
 
-  If all results are {@linkcode Ok}, return a new `Ok` containing an array of all given `Ok` values:
+  If all results are {@linkcode Ok}, return a new {@linkcode Ok} result containing an array of
+  all given {@linkcode Ok} values:
 
   ```ts
   import Result, { all } from 'true-myth/result';
@@ -1554,7 +1562,8 @@ export type AllResults<A extends AnyResults> = Result<
   console.log(result.toString()); // Ok(10,100,1000)
   ```
 
-  If any result is {@linkcode Err}, return a new `Err` containing an array of all errors encountered:
+  If any result is {@linkcode Err}, return a new {@linkcode Err} result containing an array of all
+  {@linkcode Err} encountered:
 
   ```ts
   import Result, { all } from 'true-myth/result';
@@ -1569,6 +1578,9 @@ export type AllResults<A extends AnyResults> = Result<
   ```
 
   @param results The list of results.
+  @return A new {@linkcode Result} containing an array of all {@linkcode Ok} values if all results
+    are {@linkcode Ok}, or a new {@linkcode Err} result containing an array of all {@linkcode Err}
+    encountered.
 
   @template A The type of the array or tuple of results.
 */
@@ -1591,6 +1603,71 @@ export function allResults(results: AnyResults): Result<unknown[], unknown[]> {
   }
 
   return Result.ok(oks);
+}
+
+/**
+  Given an array of results, return a new {@linkcode Ok} result if _any_ of the results is
+  {@linkcode Ok}, or a new {@linkcode Err} result if _all_ the results are {@linkcode Err}.
+
+  ## Examples
+
+  When any result is {@linkcode Ok}, return a new {@linkcode Ok} result containing the value of
+  the first {@linkcode Ok} result:
+
+  ```ts
+  import { any } from 'true-myth/result';
+
+  let result = any([
+    Result.err("something went wrong"),
+    Result.ok(10),
+    Result.err("something else went wrong")
+  ]);
+
+  console.log(result.toString()); // Ok(10);
+  ```
+
+  When all results are {@linkcode Err}, return a new {@linkcode Err} result containing an array of
+  all {@linkcode Err} encountered:
+
+  ```ts
+  import { any } from 'true-myth/result';
+
+  let result = any([
+    Result.err("something went wrong"),
+    Result.err("something else went wrong"),
+    Result.err("even more went wrong")
+  ]);
+
+  console.log(result.toString()); // Err(something went wrong,something else went wrong,even more went wrong)
+  ```
+
+  @param results The list of results to check.
+  @returns A new {@linkcode Result} containing the value of the first {@linkcode Ok} result if any
+    results are {@linkcode Ok}, or a new {@linkcode Err} result containing an array of all
+    {@linkcode Err} encountered if all results are {@linkcode Err}.
+
+  @template A The type of the array or tuple of tasks.
+*/
+export function any(results: []): Result<[], never>;
+export function any<const A extends AnyResults>(
+  results: A
+): Result<ResultTypesFor<A>['ok'], [...ResultTypesFor<A>['err']]>;
+export function any(results: readonly [] | readonly AnyResult[]): Result<unknown, unknown[]> {
+  if (results.length === 0) {
+    return Result.err([]);
+  }
+
+  const errs = [];
+
+  for (const result of results) {
+    if (result.isOk) {
+      return Result.ok(result.value);
+    } else {
+      errs.push(result.error);
+    }
+  }
+
+  return Result.err(errs);
 }
 
 /**

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -576,6 +576,44 @@ describe('`Result` pure functions', () => {
       });
     });
   });
+
+  describe('`all` method', () => {
+    test('with empty results', () => {
+      const empty = result.all([]);
+
+      expect(empty).toEqual(result.ok([]));
+    });
+
+    test('with one Ok', () => {
+      const oneOk = result.all([result.ok(1)]);
+
+      expect(oneOk).toEqual(result.ok([1]));
+    });
+
+    test('with one Err', () => {
+      const oneErr = result.all([result.err('error 1')]);
+
+      expect(oneErr).toEqual(result.err(['error 1']));
+    });
+
+    test('with all Ok', () => {
+      const allOk = result.all([result.ok(1), result.ok(2), result.ok(3)]);
+
+      expect(allOk).toEqual(result.ok([1, 2, 3]));
+    });
+
+    test('with all Err', () => {
+      const allErr = result.all([result.err('error 1'), result.err('error 2')]);
+
+      expect(allErr).toEqual(result.err(['error 1', 'error 2']));
+    });
+
+    test('with some Err', () => {
+      const someErr = result.all([result.ok(1), result.err('error 2'), result.ok(3)]);
+
+      expect(someErr).toEqual(result.err(['error 2']));
+    });
+  });
 });
 
 // We aren't even really concerned with the "runtime" behavior here, which we

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -593,7 +593,7 @@ describe('`Result` pure functions', () => {
     test('with one Err', () => {
       const oneErr = result.all([result.err('error 1')]);
 
-      expect(oneErr).toEqual(result.err(['error 1']));
+      expect(oneErr).toEqual(result.err('error 1'));
     });
 
     test('with all Ok', () => {
@@ -605,14 +605,52 @@ describe('`Result` pure functions', () => {
     test('with all Err', () => {
       const allErr = result.all([result.err('error 1'), result.err('error 2')]);
 
-      expect(allErr).toEqual(result.err(['error 1', 'error 2']));
+      expect(allErr).toEqual(result.err('error 1'));
     });
 
     test('with some Err', () => {
       const someErr = result.all([result.ok(1), result.err('error 2'), result.ok(3)]);
 
-      expect(someErr).toEqual(result.err(['error 2']));
+      expect(someErr).toEqual(result.err('error 2'));
     });
+  });
+});
+
+describe('allResults method', () => {
+  test('with empty results', () => {
+    const empty = result.allResults([]);
+
+    expect(empty).toEqual(result.ok([]));
+  });
+
+  test('with one Ok', () => {
+    const oneOk = result.allResults([result.ok(1)]);
+
+    expect(oneOk).toEqual(result.ok([1]));
+  });
+
+  test('with one Err', () => {
+    const oneErr = result.allResults([result.err('error 1')]);
+
+    expect(oneErr).toEqual(result.err(['error 1']));
+  });
+
+  test('with all Ok', () => {
+    const allOk = result.allResults([result.ok(1), result.ok(2), result.ok(3)]);
+
+    expect(allOk).toEqual(result.ok([1, 2, 3]));
+  });
+
+  test('with all Err', () => {
+    const allErr = result.allResults([result.err('error 1'), result.err('error 2')]);
+
+    expect(allErr).toEqual(result.err(['error 1', 'error 2']));
+  });
+
+  test('with some Err', () => {
+    const someErr = result.allResults([result.ok(1), result.err('error 2'), result.ok(3)]);
+
+    expect(someErr).toEqual(result.err(['error 2']));
   });
 });
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -616,7 +616,7 @@ describe('`Result` pure functions', () => {
   });
 });
 
-describe('allResults method', () => {
+describe('`allResults` method', () => {
   test('with empty results', () => {
     const empty = result.allResults([]);
 
@@ -651,6 +651,44 @@ describe('allResults method', () => {
     const someErr = result.allResults([result.ok(1), result.err('error 2'), result.ok(3)]);
 
     expect(someErr).toEqual(result.err(['error 2']));
+  });
+});
+
+describe('`any` method', () => {
+  test('with empty results', () => {
+    const empty = result.any([]);
+
+    expect(empty).toEqual(result.err([]));
+  });
+
+  test('with one Ok', () => {
+    const oneOk = result.any([result.ok(1)]);
+
+    expect(oneOk).toEqual(result.ok(1));
+  });
+
+  test('with one Err', () => {
+    const oneErr = result.any([result.err('error 1')]);
+
+    expect(oneErr).toEqual(result.err(['error 1']));
+  });
+
+  test('with all Ok', () => {
+    const allOk = result.any([result.ok(1), result.ok(2), result.ok(3)]);
+
+    expect(allOk).toEqual(result.ok(1));
+  });
+
+  test('with all Err', () => {
+    const allErr = result.any([result.err('error 1'), result.err('error 2')]);
+
+    expect(allErr).toEqual(result.err(['error 1', 'error 2']));
+  });
+
+  test('with some Err', () => {
+    const someErr = result.any([result.err('error 1'), result.err('error 2'), result.ok(3)]);
+
+    expect(someErr).toEqual(result.ok(3));
   });
 });
 


### PR DESCRIPTION
- introduce `all` method to transform an array of results into a single result containing all `Ok` or `Err` values
    - if all results are `Ok`, the resulting `Ok` will contain an array of all values
    - if at least one result is `Err`, the resulting `Err` will contain an array of all errors

See also: #206