### PR TITLE
Task: absorb `Result`s in `and`, `andThen`, `or, and `orElse`

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -51,7 +51,7 @@ declare const IsResult: unique symbol;
 /** A convenient way to name `Result<unknown, unknown>`. */
 export type AnyResult = Result<unknown, unknown>;
 
-type SomeResult<T, E> = { [IsResult]: [T, E] };
+export type SomeResult<T, E> = { [IsResult]: [T, E] };
 
 /** @internal */
 export type TypesFor<R extends AnyResult> = R extends SomeResult<infer T, infer E>

--- a/test/integration/standard-schema.test.ts
+++ b/test/integration/standard-schema.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-import { type } from 'arktype';
-import * as effect from 'effect';
-import * as v from 'valibot';
-import * as z from 'zod';
+import { type } from "arktype";
+import * as effect from "effect";
+import * as v from "valibot";
+import * as z from "zod";
 
-import * as result from 'true-myth/result';
+import * as result from "true-myth/result";
 import {
   type AsyncParserFor,
   asyncParserFor,
@@ -13,38 +13,38 @@ import {
   type ParserFor,
   type ParseTask,
   parserFor,
-} from 'true-myth/standard-schema';
-import { unwrapErr } from 'true-myth/test-support';
+} from "true-myth/standard-schema";
+import { unwrapErr } from "true-myth/test-support";
 
 interface Person {
   name?: string | undefined;
   age: number;
 }
 
-describe('Standard Schema 3rd-party integrations', () => {
+describe("Standard Schema 3rd-party integrations", () => {
   // Arktype does not implement support for async morphs:
   //
   // - https://arktype.io/docs/faq#is-there-a-way-to-create-an-async-morph
   // - https://github.com/arktypeio/arktype/issues/462
-  describe('with Arktype', () => {
-    describe('parserFor', () => {
+  describe("with Arktype", () => {
+    describe("parserFor", () => {
       const PersonSchema = type({
-        'name?': 'string',
-        age: 'number>=0',
+        "name?": "string",
+        age: "number>=0",
       });
 
       const parse = parserFor(PersonSchema);
       expectTypeOf(parse).toEqualTypeOf<ParserFor<Person>>();
 
-      test('with a valid user', () => {
+      test("with a valid user", () => {
         expect(parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
-        expect(withName).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        const withName = parse({ age: 38, name: "Chris" });
+        expect(withName).toEqual(result.ok({ age: 38, name: "Chris" }));
         expectTypeOf(withName).toEqualTypeOf<ParseResult<Person>>();
       });
 
-      test('with an invalid user', () => {
+      test("with an invalid user", () => {
         const theResult = parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -55,8 +55,8 @@ describe('Standard Schema 3rd-party integrations', () => {
 
   // Effect is stricter than the others, because of its strong functional
   // programming idiom, so all types are `Readonly`.
-  describe('with Effect Schema', () => {
-    describe('parserFor', () => {
+  describe("with Effect Schema", () => {
+    describe("parserFor", () => {
       const PersonSchema = effect.Schema.Struct({
         name: effect.Schema.optional(effect.Schema.String),
         age: effect.Schema.Number.pipe(effect.Schema.nonNegative()),
@@ -65,15 +65,15 @@ describe('Standard Schema 3rd-party integrations', () => {
       const parse = parserFor(effect.Schema.standardSchemaV1(PersonSchema));
       expectTypeOf(parse).toEqualTypeOf<ParserFor<Readonly<Person>>>();
 
-      test('with a valid user', () => {
+      test("with a valid user", () => {
         expect(parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
-        expect(withName).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        const withName = parse({ age: 38, name: "Chris" });
+        expect(withName).toEqual(result.ok({ age: 38, name: "Chris" }));
         expectTypeOf(withName).toEqualTypeOf<ParseResult<Readonly<Person>>>();
       });
 
-      test('with an invalid user', () => {
+      test("with an invalid user", () => {
         const theResult = parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -81,30 +81,32 @@ describe('Standard Schema 3rd-party integrations', () => {
       });
     });
 
-    describe('asyncParserFor', () => {
+    describe("asyncParserFor", () => {
       // Define an async transformation so we have something to work with. This is
       // pretty silly: it just supplies the same transformation more than once!
       // But it gives us a useful test.
       const AsyncSchema = effect.Schema.Struct({
         name: effect.Schema.optional(effect.Schema.String),
         age: effect.Schema.Number.pipe(
-          effect.Schema.filterEffect((age) => effect.Effect.promise(async () => age >= 0))
+          effect.Schema.filterEffect((age) =>
+            effect.Effect.promise(async () => age >= 0),
+          ),
         ),
       });
 
       const parse = asyncParserFor(effect.Schema.standardSchemaV1(AsyncSchema));
       expectTypeOf(parse).toEqualTypeOf<AsyncParserFor<Readonly<Person>>>();
 
-      test('with a valid user', async () => {
+      test("with a valid user", async () => {
         expect(await parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
+        const withName = parse({ age: 38, name: "Chris" });
         expectTypeOf(withName).toEqualTypeOf<ParseTask<Readonly<Person>>>();
         const theResult = await withName;
-        expect(theResult).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        expect(theResult).toEqual(result.ok({ age: 38, name: "Chris" }));
       });
 
-      test('with an invalid user', async () => {
+      test("with an invalid user", async () => {
         const theResult = await parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -113,8 +115,8 @@ describe('Standard Schema 3rd-party integrations', () => {
     });
   });
 
-  describe('with Valibot', () => {
-    describe('parserFor', () => {
+  describe("with Valibot", () => {
+    describe("parserFor", () => {
       const PersonSchema = v.object({
         name: v.optional(v.string()),
         age: v.pipe(v.number(), v.minValue(0)),
@@ -123,15 +125,15 @@ describe('Standard Schema 3rd-party integrations', () => {
       const parse = parserFor(PersonSchema);
       expectTypeOf(parse).toEqualTypeOf<ParserFor<Person>>();
 
-      test('with a valid user', () => {
+      test("with a valid user", () => {
         expect(parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
-        expect(withName).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        const withName = parse({ age: 38, name: "Chris" });
+        expect(withName).toEqual(result.ok({ age: 38, name: "Chris" }));
         expectTypeOf(withName).toEqualTypeOf<ParseResult<Person>>();
       });
 
-      test('with an invalid user', () => {
+      test("with an invalid user", () => {
         const theResult = parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -139,30 +141,30 @@ describe('Standard Schema 3rd-party integrations', () => {
       });
     });
 
-    describe('asyncParserFor', () => {
+    describe("asyncParserFor", () => {
       const PersonSchema = v.objectAsync({
         name: v.pipe(v.optional(v.string())),
         // Define an async refinement so we have something to work with. The
         // actual value here is not especially interesting.
         age: v.pipeAsync(
           v.number(),
-          v.checkAsync((val) => val >= 0)
+          v.checkAsync((val) => val >= 0),
         ),
       });
 
       const parse = asyncParserFor(PersonSchema);
       expectTypeOf(parse).toEqualTypeOf<AsyncParserFor<Person>>();
 
-      test('with a valid user', async () => {
+      test("with a valid user", async () => {
         expect(await parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
+        const withName = parse({ age: 38, name: "Chris" });
         expectTypeOf(withName).toEqualTypeOf<ParseTask<Person>>();
         const theResult = await withName;
-        expect(theResult).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        expect(theResult).toEqual(result.ok({ age: 38, name: "Chris" }));
       });
 
-      test('with an invalid user', async () => {
+      test("with an invalid user", async () => {
         const theResult = await parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -171,8 +173,8 @@ describe('Standard Schema 3rd-party integrations', () => {
     });
   });
 
-  describe('with Zod', () => {
-    describe('parserFor', () => {
+  describe("with Zod", () => {
+    describe("parserFor", () => {
       const PersonSchema = z.object({
         name: z.string().optional(),
         age: z.number().nonnegative(),
@@ -181,15 +183,15 @@ describe('Standard Schema 3rd-party integrations', () => {
       const parse = parserFor(PersonSchema);
       expectTypeOf(parse).toEqualTypeOf<ParserFor<Person>>();
 
-      test('with a valid user', () => {
+      test("with a valid user", () => {
         expect(parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
-        expect(withName).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        const withName = parse({ age: 38, name: "Chris" });
+        expect(withName).toEqual(result.ok({ age: 38, name: "Chris" }));
         expectTypeOf(withName).toEqualTypeOf<ParseResult<Person>>();
       });
 
-      test('with an invalid user', () => {
+      test("with an invalid user", () => {
         const theResult = parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -197,7 +199,7 @@ describe('Standard Schema 3rd-party integrations', () => {
       });
     });
 
-    describe('asyncParserFor', () => {
+    describe("asyncParserFor", () => {
       const PersonSchema = z.object({
         name: z.optional(z.string()),
         // Define an async refinement so we have something to work with. The
@@ -208,16 +210,16 @@ describe('Standard Schema 3rd-party integrations', () => {
       const parse = asyncParserFor(PersonSchema);
       expectTypeOf(parse).toEqualTypeOf<AsyncParserFor<Person>>();
 
-      test('with a valid user', async () => {
+      test("with a valid user", async () => {
         expect(await parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
+        const withName = parse({ age: 38, name: "Chris" });
         expectTypeOf(withName).toEqualTypeOf<ParseTask<Person>>();
         const theResult = await withName;
-        expect(theResult).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        expect(theResult).toEqual(result.ok({ age: 38, name: "Chris" }));
       });
 
-      test('with an invalid user', async () => {
+      test("with an invalid user", async () => {
         const theResult = await parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);

--- a/test/interop.test.ts
+++ b/test/interop.test.ts
@@ -1,10 +1,10 @@
-import { safeToString } from 'true-myth/-private/utils';
-import { Maybe, safe as maybeSafe } from 'true-myth/maybe';
-import { Result, safe as resultSafe } from 'true-myth/result';
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { safeToString } from "true-myth/-private/utils";
+import { Maybe, safe as maybeSafe } from "true-myth/maybe";
+import { Result, safe as resultSafe } from "true-myth/result";
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-describe('nested Result and Maybe', () => {
-  test('Result of Maybe', () => {
+describe("nested Result and Maybe", () => {
+  test("Result of Maybe", () => {
     function inferenceFun(): Result<Maybe<string>, number> {
       return Result.ok(Maybe.nothing());
     }
@@ -12,8 +12,8 @@ describe('nested Result and Maybe', () => {
   });
 });
 
-describe('composing safe', () => {
-  const ERR_MESSAGE = 'lol, too high';
+describe("composing safe", () => {
+  const ERR_MESSAGE = "lol, too high";
 
   function print(value: number): string {
     return `you win! ${value}, yay`;
@@ -29,20 +29,24 @@ describe('composing safe', () => {
     }
   }
 
-  test('with a handler with Result', () => {
+  test("with a handler with Result", () => {
     let safe = resultSafe(maybeSafe(fnThatMayThrow));
-    expectTypeOf(safe).toEqualTypeOf<(input: number) => Result<Maybe<string>, unknown>>();
+    expectTypeOf(safe).toEqualTypeOf<
+      (input: number) => Result<Maybe<string>, unknown>
+    >();
 
     expect(safe(1)).toEqual(Result.err(new Error(ERR_MESSAGE)));
     expect(safe(0)).toEqual(Result.ok(Maybe.nothing()));
     expect(safe(0.5)).toEqual(Result.ok(Maybe.just(print(0.5))));
   });
 
-  test('without a handler with Result', () => {
+  test("without a handler with Result", () => {
     const onError = (err: unknown) => safeToString(err);
 
     let safe = resultSafe(maybeSafe(fnThatMayThrow), onError);
-    expectTypeOf(safe).toEqualTypeOf<(input: number) => Result<Maybe<string>, string>>();
+    expectTypeOf(safe).toEqualTypeOf<
+      (input: number) => Result<Maybe<string>, string>
+    >();
 
     expect(safe(1)).toEqual(Result.err(onError(new Error(ERR_MESSAGE))));
     expect(safe(0)).toEqual(Result.ok(Maybe.nothing()));

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -1,20 +1,20 @@
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-import Maybe, { Variant, Nothing, Just, Matcher } from 'true-myth/maybe';
-import * as maybe from 'true-myth/maybe';
-import { Unit } from 'true-myth/unit';
+import Maybe, { Variant, Nothing, Just, Matcher } from "true-myth/maybe";
+import * as maybe from "true-myth/maybe";
+import { Unit } from "true-myth/unit";
 
 type Neat = { neat: string };
 
 const length = (s: string) => s.length;
 
-describe('`Maybe` pure functions', () => {
-  test('`just`', () => {
-    const theJust = maybe.just('string');
+describe("`Maybe` pure functions", () => {
+  test("`just`", () => {
+    const theJust = maybe.just("string");
     expect(theJust).toBeInstanceOf(Maybe);
     switch (theJust.variant) {
       case maybe.Variant.Just:
-        expect(theJust.value).toBe('string');
+        expect(theJust.value).toBe("string");
         break;
       case maybe.Variant.Nothing:
         expect(true).toBe(false); // Not possible
@@ -26,14 +26,14 @@ describe('`Maybe` pure functions', () => {
     expect(() =>
       maybe.just(
         // @ts-expect-error: null is forbidden here
-        null
-      )
+        null,
+      ),
     ).toThrow();
     expect(() =>
       maybe.just(
         // @ts-expect-error: undefined is forbidden here
-        undefined
-      )
+        undefined,
+      ),
     ).toThrow();
 
     expectTypeOf(Maybe.just(() => null)).toBeNever();
@@ -41,10 +41,12 @@ describe('`Maybe` pure functions', () => {
 
     let example = (): string | undefined => undefined;
     expectTypeOf(Maybe.just(example)).toBeNever();
-    expectTypeOf(Maybe.just(() => 'hello')).toEqualTypeOf<Maybe<() => string>>();
+    expectTypeOf(Maybe.just(() => "hello")).toEqualTypeOf<
+      Maybe<() => string>
+    >();
   });
 
-  test('`nothing`', () => {
+  test("`nothing`", () => {
     const theNothing = maybe.nothing();
     expect(theNothing).toBeInstanceOf(Maybe);
     switch (theNothing.variant) {
@@ -64,18 +66,18 @@ describe('`Maybe` pure functions', () => {
     expectTypeOf(nothingOnType).toExtend<Maybe<string>>();
   });
 
-  describe('`of`', () => {
+  describe("`of`", () => {
     expectTypeOf(Maybe.of(() => null)).toBeNever();
     expectTypeOf(Maybe.of(() => undefined)).toBeNever();
 
     let example = (): string | undefined => undefined;
     expectTypeOf(Maybe.of(example)).toBeNever();
-    expectTypeOf(Maybe.of(() => 'hello')).toEqualTypeOf<Maybe<() => string>>();
+    expectTypeOf(Maybe.of(() => "hello")).toEqualTypeOf<Maybe<() => string>>();
 
     let unknownVal: unknown = 123;
     expectTypeOf(Maybe.of(unknownVal)).toEqualTypeOf<Maybe<{}>>();
 
-    test('with `null', () => {
+    test("with `null", () => {
       const nothingFromNull = maybe.of<string>(null);
       expectTypeOf(nothingFromNull).toEqualTypeOf<Maybe<string>>();
       expect(nothingFromNull.isJust).toBe(false);
@@ -84,7 +86,7 @@ describe('`Maybe` pure functions', () => {
       expect(() => nothingFromNull.value).toThrow();
     });
 
-    test('with `undefined`', () => {
+    test("with `undefined`", () => {
       const nothingFromUndefined = maybe.of<number>(undefined);
       expectTypeOf(nothingFromUndefined).toEqualTypeOf<Maybe<number>>();
       expect(nothingFromUndefined.isJust).toBe(false);
@@ -93,8 +95,8 @@ describe('`Maybe` pure functions', () => {
       expect(() => nothingFromUndefined.value).toThrow();
     });
 
-    test('with values', () => {
-      const aJust = maybe.of<Neat>({ neat: 'strings' });
+    test("with values", () => {
+      const aJust = maybe.of<Neat>({ neat: "strings" });
       expectTypeOf(aJust).toEqualTypeOf<Maybe<Neat>>();
       const aNothing = maybe.of<Neat>(null);
       expectTypeOf(aNothing).toEqualTypeOf<Maybe<Neat>>();
@@ -107,11 +109,11 @@ describe('`Maybe` pure functions', () => {
     });
   });
 
-  test('`map`', () => {
-    const justAString = maybe.just('string');
+  test("`map`", () => {
+    const justAString = maybe.just("string");
     const itsLength = maybe.map(length, justAString);
     expectTypeOf(itsLength).toEqualTypeOf<Maybe<number>>();
-    expect(itsLength).toEqual(maybe.just('string'.length));
+    expect(itsLength).toEqual(maybe.just("string".length));
 
     const none = maybe.nothing<string>();
     const noLength = maybe.map(length, none);
@@ -122,25 +124,27 @@ describe('`Maybe` pure functions', () => {
       maybe.map(
         // @ts-expect-error
         (_val) => null,
-        Maybe.of('Hello')
+        Maybe.of("Hello"),
       );
     }).toThrow();
   });
 
-  test('`mapOr`', () => {
-    const justAString = maybe.of('string');
+  test("`mapOr`", () => {
+    const justAString = maybe.of("string");
 
-    expect(maybe.mapOr(0, length, justAString)).toEqual('string'.length);
+    expect(maybe.mapOr(0, length, justAString)).toEqual("string".length);
     expect(maybe.mapOr(0, length, maybe.of<string>(null))).toEqual(0);
 
     expect(maybe.mapOr<string, number>(0)(length)(justAString)).toEqual(
-      maybe.mapOr(0, length, justAString)
+      maybe.mapOr(0, length, justAString),
     );
-    expect(maybe.mapOr(0, length)(justAString)).toEqual(maybe.mapOr(0, length, justAString));
+    expect(maybe.mapOr(0, length)(justAString)).toEqual(
+      maybe.mapOr(0, length, justAString),
+    );
   });
 
-  test('`mapOrElse`', () => {
-    const theValue = 'a string';
+  test("`mapOrElse`", () => {
+    const theValue = "a string";
     const theDefault = 0;
     const toDefault = () => theDefault;
     const aJust = maybe.just(theValue);
@@ -150,32 +154,32 @@ describe('`Maybe` pure functions', () => {
     expect(maybe.mapOrElse(toDefault, length, aNothing)).toBe(theDefault);
 
     expect(maybe.mapOrElse<string, number>(toDefault)(length)(aJust)).toEqual(
-      maybe.mapOrElse(toDefault, length, aJust)
+      maybe.mapOrElse(toDefault, length, aJust),
     );
     expect(maybe.mapOrElse(toDefault, length)(aJust)).toEqual(
-      maybe.mapOrElse(toDefault, length, aJust)
+      maybe.mapOrElse(toDefault, length, aJust),
     );
   });
 
-  test('`match`', () => {
-    const theValue = 'a string';
+  test("`match`", () => {
+    const theValue = "a string";
     const aJust = maybe.just(theValue);
     const aNothing: Maybe<string> = maybe.nothing();
 
     const matcher: Matcher<string, string> = {
-      Just: (val) => val + ', yo',
-      Nothing: () => 'rats, nothing',
+      Just: (val) => val + ", yo",
+      Nothing: () => "rats, nothing",
     };
 
-    expect(maybe.match(matcher, aJust)).toEqual('a string, yo');
-    expect(maybe.match(matcher, aNothing)).toEqual('rats, nothing');
+    expect(maybe.match(matcher, aJust)).toEqual("a string, yo");
+    expect(maybe.match(matcher, aNothing)).toEqual("rats, nothing");
 
     expect(maybe.match(matcher)(aJust)).toEqual(maybe.match(matcher, aJust));
   });
 
-  test('`and`', () => {
+  test("`and`", () => {
     const aJust = maybe.just(42);
-    const anotherJust = maybe.just('a string');
+    const anotherJust = maybe.just("a string");
     const aNothing: Maybe<{}> = maybe.nothing();
     expect(maybe.and(anotherJust, aJust)).toBe(anotherJust);
 
@@ -183,15 +187,17 @@ describe('`Maybe` pure functions', () => {
     expect(maybe.and(aNothing, aJust)).toEqual(aNothing);
     expect(maybe.and(aNothing, aNothing)).toEqual(aNothing);
 
-    expect(maybe.and<number, {}>(aNothing)(aJust)).toEqual(maybe.and(aNothing, aJust));
+    expect(maybe.and<number, {}>(aNothing)(aJust)).toEqual(
+      maybe.and(aNothing, aJust),
+    );
   });
 
-  describe('`andThen`', () => {
-    test('basic functionality', () => {
+  describe("`andThen`", () => {
+    test("basic functionality", () => {
       const toMaybeNumber = (x: string) => maybe.just(Number(x));
       const toNothing = (_: string) => maybe.nothing<number>();
 
-      const theValue = '42';
+      const theValue = "42";
       const theJust = maybe.just(theValue);
       const theExpectedResult = toMaybeNumber(theValue);
       const noString = maybe.nothing<string>();
@@ -202,10 +208,12 @@ describe('`Maybe` pure functions', () => {
       expect(maybe.andThen(toMaybeNumber, noString)).toEqual(noNumber);
       expect(maybe.andThen(toNothing, noString)).toEqual(noNumber);
 
-      expect(maybe.andThen(toMaybeNumber)(theJust)).toEqual(maybe.andThen(toMaybeNumber, theJust));
+      expect(maybe.andThen(toMaybeNumber)(theJust)).toEqual(
+        maybe.andThen(toMaybeNumber, theJust),
+      );
     });
 
-    test('with multiple types in the returned `Maybe` instances', () => {
+    test("with multiple types in the returned `Maybe` instances", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
@@ -213,31 +221,31 @@ describe('`Maybe` pure functions', () => {
       let theOutput = maybe.andThen(
         (_) => {
           if (Math.random() < 0.1) {
-            return maybe.just(new Branded('just-a'));
+            return maybe.just(new Branded("just-a"));
           }
 
           if (Math.random() < 0.2) {
-            return maybe.nothing<Branded<'empty'>>();
+            return maybe.nothing<Branded<"empty">>();
           }
 
           if (Math.random() < 0.3) {
-            return maybe.just(new Branded('just-b'));
+            return maybe.just(new Branded("just-b"));
           }
 
-          return maybe.nothing<Branded<'empty'>>();
+          return maybe.nothing<Branded<"empty">>();
         },
-        Maybe.of(new Branded('just'))
+        Maybe.of(new Branded("just")),
       );
 
       expectTypeOf(theOutput).toEqualTypeOf<
-        Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
+        Maybe<Branded<"just-a"> | Branded<"just-b"> | Branded<"empty">>
       >();
     });
   });
 
-  test('`or`', () => {
-    const justAnswer = maybe.of('42');
-    const justWaffles = maybe.of('waffles');
+  test("`or`", () => {
+    const justAnswer = maybe.of("42");
+    const justWaffles = maybe.of("waffles");
     const nothing: Maybe<string> = maybe.nothing();
 
     expect(maybe.or(justAnswer, justWaffles)).toBe(justWaffles);
@@ -245,59 +253,68 @@ describe('`Maybe` pure functions', () => {
     expect(maybe.or(justAnswer, nothing)).toBe(justAnswer);
     expect(maybe.or(nothing, nothing)).toBe(nothing);
 
-    expect(maybe.or(justAnswer)(justWaffles)).toEqual(maybe.or(justAnswer, justWaffles));
+    expect(maybe.or(justAnswer)(justWaffles)).toEqual(
+      maybe.or(justAnswer, justWaffles),
+    );
   });
 
-  describe('`orElse`', () => {
-    test('basic functionality', () => {
-      const getWaffles = () => maybe.of('waffles');
-      const just42 = maybe.of('42');
-      expect(maybe.orElse(getWaffles, just42)).toEqual(maybe.just('42'));
+  describe("`orElse`", () => {
+    test("basic functionality", () => {
+      const getWaffles = () => maybe.of("waffles");
+      const just42 = maybe.of("42");
+      expect(maybe.orElse(getWaffles, just42)).toEqual(maybe.just("42"));
       expect(maybe.orElse(getWaffles, maybe.of(null as string | null))).toEqual(
-        maybe.just('waffles')
+        maybe.just("waffles"),
       );
-      expect(maybe.orElse(() => maybe.of(null as string | null), just42)).toEqual(maybe.just('42'));
       expect(
-        maybe.orElse(() => maybe.of(null as string | null), maybe.of(null as string | null))
+        maybe.orElse(() => maybe.of(null as string | null), just42),
+      ).toEqual(maybe.just("42"));
+      expect(
+        maybe.orElse(
+          () => maybe.of(null as string | null),
+          maybe.of(null as string | null),
+        ),
       ).toEqual(maybe.nothing());
 
-      expect(maybe.orElse(getWaffles)(just42)).toEqual(maybe.orElse(getWaffles, just42));
+      expect(maybe.orElse(getWaffles)(just42)).toEqual(
+        maybe.orElse(getWaffles, just42),
+      );
     });
 
-    test('with multiple types in the returned `Maybe` instances', () => {
+    test("with multiple types in the returned `Maybe` instances", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
       let theOutput = maybe.orElse(() => {
         if (Math.random() < 0.1) {
-          return maybe.just(new Branded('just-a'));
+          return maybe.just(new Branded("just-a"));
         }
 
         if (Math.random() < 0.2) {
-          return maybe.nothing<Branded<'empty'>>();
+          return maybe.nothing<Branded<"empty">>();
         }
 
         if (Math.random() < 0.3) {
-          return maybe.just(new Branded('just-b'));
+          return maybe.just(new Branded("just-b"));
         }
 
-        return maybe.nothing<Branded<'empty'>>();
-      }, Maybe.nothing<'empty-start'>());
+        return maybe.nothing<Branded<"empty">>();
+      }, Maybe.nothing<"empty-start">());
 
       expectTypeOf(theOutput).toEqualTypeOf<
-        Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
+        Maybe<Branded<"just-a"> | Branded<"just-b"> | Branded<"empty">>
       >();
     });
   });
 
-  test('`unwrap`', () => {
-    expect((maybe.of('42') as Just<string>).value).toBe('42');
+  test("`unwrap`", () => {
+    expect((maybe.of("42") as Just<string>).value).toBe("42");
     // @ts-expect-error -- `value` isn't accessible without narrowing
     expect(() => maybe.nothing().value).toThrow();
   });
 
-  test('`unwrapOr`', () => {
+  test("`unwrapOr`", () => {
     const theValue = [1, 2, 3];
     const theDefaultValue: number[] = [];
 
@@ -305,10 +322,12 @@ describe('`Maybe` pure functions', () => {
     const theNothing = maybe.nothing();
 
     expect(maybe.unwrapOr(theDefaultValue, theJust)).toEqual(theValue);
-    expect(maybe.unwrapOr(theDefaultValue, theNothing)).toEqual(theDefaultValue);
+    expect(maybe.unwrapOr(theDefaultValue, theNothing)).toEqual(
+      theDefaultValue,
+    );
 
     expect(maybe.unwrapOr(theDefaultValue)(theJust)).toEqual(
-      maybe.unwrapOr(theDefaultValue, theJust)
+      maybe.unwrapOr(theDefaultValue, theJust),
     );
 
     // Make sure you can unwrap to a different type, like undefined
@@ -319,7 +338,7 @@ describe('`Maybe` pure functions', () => {
     expect(theJustOrUndefined).toEqual(theValue);
   });
 
-  test('`unwrapOrElse`', () => {
+  test("`unwrapOrElse`", () => {
     const val = 100;
     const getVal = () => val;
     const just42 = maybe.of(42);
@@ -327,7 +346,9 @@ describe('`Maybe` pure functions', () => {
     expect(maybe.unwrapOrElse(getVal, just42)).toBe(42);
     expect(maybe.unwrapOrElse(getVal, maybe.nothing())).toBe(val);
 
-    expect(maybe.unwrapOrElse(getVal)(just42)).toEqual(maybe.unwrapOrElse(getVal, just42));
+    expect(maybe.unwrapOrElse(getVal)(just42)).toEqual(
+      maybe.unwrapOrElse(getVal, just42),
+    );
 
     // test unwrapping to undefined
     const noop = (): undefined => undefined;
@@ -336,39 +357,43 @@ describe('`Maybe` pure functions', () => {
     expect(undefinedOr42).toEqual(42);
   });
 
-  describe('`toString`', () => {
-    test('with simple values', () => {
-      expect(maybe.toString(maybe.of(42))).toEqual('Just(42)');
-      expect(maybe.toString(maybe.nothing<string>())).toEqual('Nothing');
+  describe("`toString`", () => {
+    test("with simple values", () => {
+      expect(maybe.toString(maybe.of(42))).toEqual("Just(42)");
+      expect(maybe.toString(maybe.nothing<string>())).toEqual("Nothing");
     });
 
-    test('with complex values', () => {
-      expect(maybe.toString(maybe.of([1, 2, 3]))).toEqual('Just(1,2,3)');
-      expect(maybe.toString(maybe.of({ neato: true }))).toEqual('Just([object Object])');
+    test("with complex values", () => {
+      expect(maybe.toString(maybe.of([1, 2, 3]))).toEqual("Just(1,2,3)");
+      expect(maybe.toString(maybe.of({ neato: true }))).toEqual(
+        "Just([object Object])",
+      );
 
       class HasToString {
         toString() {
-          return 'This has toString';
+          return "This has toString";
         }
       }
-      expect(maybe.toString(maybe.of(new HasToString()))).toEqual('Just(This has toString)');
+      expect(maybe.toString(maybe.of(new HasToString()))).toEqual(
+        "Just(This has toString)",
+      );
     });
   });
 
-  describe('`toString`', () => {
-    test('normal cases', () => {
-      expect(maybe.toString(maybe.of(42))).toEqual('Just(42)');
-      expect(maybe.toString(maybe.nothing<string>())).toEqual('Nothing');
+  describe("`toString`", () => {
+    test("normal cases", () => {
+      expect(maybe.toString(maybe.of(42))).toEqual("Just(42)");
+      expect(maybe.toString(maybe.nothing<string>())).toEqual("Nothing");
     });
 
-    test('custom `toString`s', () => {
+    test("custom `toString`s", () => {
       const withNotAFunction = {
-        whyThough: 'because JS bro',
-        toString: '🤨',
+        whyThough: "because JS bro",
+        toString: "🤨",
       };
 
       expect(maybe.toString(Maybe.of(withNotAFunction))).toEqual(
-        `Just(${JSON.stringify(withNotAFunction)})`
+        `Just(${JSON.stringify(withNotAFunction)})`,
       );
 
       const withBadFunction = {
@@ -379,12 +404,12 @@ describe('`Maybe` pure functions', () => {
       };
 
       expect(maybe.toString(Maybe.of(withBadFunction))).toEqual(
-        `Just(${JSON.stringify(withBadFunction)})`
+        `Just(${JSON.stringify(withBadFunction)})`,
       );
     });
   });
 
-  test('`toJSON`', () => {
+  test("`toJSON`", () => {
     expect(maybe.toJSON(maybe.of(42))).toEqual({
       variant: maybe.Variant.Just,
       value: 42,
@@ -398,7 +423,7 @@ describe('`Maybe` pure functions', () => {
     });
   });
 
-  test('`toJSON` through serialization', () => {
+  test("`toJSON` through serialization", () => {
     const actualSerializedJust = JSON.stringify(maybe.of(42));
     const actualSerializedNothing = JSON.stringify(maybe.nothing());
     const expectedSerializedJust = JSON.stringify({
@@ -413,9 +438,9 @@ describe('`Maybe` pure functions', () => {
     expect(actualSerializedNothing).toEqual(expectedSerializedNothing);
   });
 
-  test('`equals`', () => {
-    const a = maybe.of<string>('a');
-    const b = maybe.of<string>('a');
+  test("`equals`", () => {
+    const a = maybe.of<string>("a");
+    const b = maybe.of<string>("a");
     const c = maybe.nothing<string>();
     const d = maybe.nothing<string>();
     expect(maybe.equals(b, a)).toBe(true);
@@ -426,7 +451,7 @@ describe('`Maybe` pure functions', () => {
     expect(maybe.equals(d)(c)).toBe(true);
   });
 
-  test('`ap`', () => {
+  test("`ap`", () => {
     const add = (a: number) => (b: number) => a + b;
     const maybeAdd = maybe.of(add);
 
@@ -440,8 +465,8 @@ describe('`Maybe` pure functions', () => {
     expect(maybe.ap(maybeAdd3)(nada)).toEqual(maybe.nothing());
   });
 
-  test('isInstance', () => {
-    const something: unknown = maybe.just('yay');
+  test("isInstance", () => {
+    const something: unknown = maybe.just("yay");
     expect(maybe.isInstance(something)).toBe(true);
 
     const nothing = maybe.nothing();
@@ -450,12 +475,12 @@ describe('`Maybe` pure functions', () => {
     const nada = null;
     expect(maybe.isInstance(nada)).toBe(false);
 
-    const obj = { random: 'nonsense' };
+    const obj = { random: "nonsense" };
     expect(maybe.isInstance(obj)).toBe(false);
   });
 
-  describe('array helpers', () => {
-    test('`find`', () => {
+  describe("array helpers", () => {
+    test("`find`", () => {
       const theValue = 4;
       const pred = (v: number) => v === theValue;
 
@@ -464,7 +489,9 @@ describe('`Maybe` pure functions', () => {
       expect(maybe.find(pred, empty).variant).toBe(maybe.Variant.Nothing);
 
       const missingTheValue = [1, 2, 3];
-      expect(maybe.find(pred, missingTheValue).variant).toBe(maybe.Variant.Nothing);
+      expect(maybe.find(pred, missingTheValue).variant).toBe(
+        maybe.Variant.Nothing,
+      );
 
       const hasTheValue = [1, 2, 3, theValue];
       const result = maybe.find(pred, hasTheValue);
@@ -477,8 +504,8 @@ describe('`Maybe` pure functions', () => {
       // This is more about testing the types with the currying; it's functionally
       // covered already.
       const array: Response = [
-        { count: 1, name: 'potato' },
-        { count: 10, name: 'waffles' },
+        { count: 1, name: "potato" },
+        { count: 10, name: "waffles" },
       ];
       const findAtLeast5 = maybe.find(({ count }: Item) => count > 5);
       const found = findAtLeast5(array);
@@ -488,18 +515,20 @@ describe('`Maybe` pure functions', () => {
       // Type narrowing via predicates.
       // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
       const findByName = <T extends string>(name: T) =>
-        maybe.find((item: Item): item is Item & { name: T } => item.name === name);
-      const waffles = findByName('waffles')(array);
+        maybe.find(
+          (item: Item): item is Item & { name: T } => item.name === name,
+        );
+      const waffles = findByName("waffles")(array);
       expect(waffles.variant).toBe(maybe.Variant.Just);
       expect((waffles as Just<Item>).value).toEqual(array[1]);
-      expectTypeOf(waffles).toExtend<Maybe<{ name: 'waffles' }>>();
+      expectTypeOf(waffles).toExtend<Maybe<{ name: "waffles" }>>();
 
       const readonlyEmpty: readonly number[] = [];
       const foundReadonly = maybe.find(pred, readonlyEmpty);
       expectTypeOf(foundReadonly).toExtend<Maybe<number>>();
     });
 
-    test('`first`', () => {
+    test("`first`", () => {
       expect(maybe.first([])).toEqual(maybe.nothing());
       expect(maybe.first([1])).toEqual(maybe.just(maybe.just(1)));
       expect(maybe.first([1, 2, 3])).toEqual(maybe.just(maybe.just(1)));
@@ -516,21 +545,29 @@ describe('`Maybe` pure functions', () => {
 
       const mixedWithUndefined = [undefined, 1, undefined, 2];
       const firstOfMixedWithUndefined = maybe.first(mixedWithUndefined);
-      expectTypeOf(firstOfMixedWithUndefined).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expectTypeOf(firstOfMixedWithUndefined).toEqualTypeOf<
+        Maybe<Maybe<number>>
+      >();
       expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
 
       const mixedWithBothNullFirst = [null, 1, undefined, 2];
       const firstOfMixedWithBothNullFirst = maybe.first(mixedWithBothNullFirst);
-      expectTypeOf(firstOfMixedWithBothNullFirst).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expectTypeOf(firstOfMixedWithBothNullFirst).toEqualTypeOf<
+        Maybe<Maybe<number>>
+      >();
       expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
 
       const mixedWithBothUndefinedFirst = [undefined, 1, null, 2];
-      const firstOfMixedWithBothUndefinedFirst = maybe.first(mixedWithBothUndefinedFirst);
-      expectTypeOf(firstOfMixedWithBothUndefinedFirst).toEqualTypeOf<Maybe<Maybe<number>>>();
+      const firstOfMixedWithBothUndefinedFirst = maybe.first(
+        mixedWithBothUndefinedFirst,
+      );
+      expectTypeOf(firstOfMixedWithBothUndefinedFirst).toEqualTypeOf<
+        Maybe<Maybe<number>>
+      >();
       expect(firstOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
     });
 
-    test('`last`', () => {
+    test("`last`", () => {
       expect(maybe.last([])).toEqual(maybe.nothing());
       expect(maybe.last([1])).toEqual(maybe.just(maybe.just(1)));
       expect(maybe.last([1, 2, 3])).toEqual(maybe.just(maybe.just(3)));
@@ -547,28 +584,36 @@ describe('`Maybe` pure functions', () => {
 
       const mixedWithUndefined = [1, undefined, 2, undefined];
       const lastOfMixedWithUndefined = maybe.last(mixedWithUndefined);
-      expectTypeOf(lastOfMixedWithUndefined).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expectTypeOf(lastOfMixedWithUndefined).toEqualTypeOf<
+        Maybe<Maybe<number>>
+      >();
       expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
 
       const mixedWithBothNullLast = [1, undefined, 2, null];
       const lastOfMixedWithBothNullLast = maybe.last(mixedWithBothNullLast);
-      expectTypeOf(lastOfMixedWithBothNullLast).toEqualTypeOf<Maybe<Maybe<number>>>();
+      expectTypeOf(lastOfMixedWithBothNullLast).toEqualTypeOf<
+        Maybe<Maybe<number>>
+      >();
       expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
 
       const mixedWithBothUndefinedLast = [1, null, 2, undefined];
-      const lastOfMixedWithBothUndefinedLast = maybe.last(mixedWithBothUndefinedLast);
-      expectTypeOf(lastOfMixedWithBothUndefinedLast).toEqualTypeOf<Maybe<Maybe<number>>>();
+      const lastOfMixedWithBothUndefinedLast = maybe.last(
+        mixedWithBothUndefinedLast,
+      );
+      expectTypeOf(lastOfMixedWithBothUndefinedLast).toEqualTypeOf<
+        Maybe<Maybe<number>>
+      >();
       expect(lastOfMixedWithNull).toEqual(Maybe.just(Maybe.nothing()));
     });
 
-    describe('`transposeArray`', () => {
-      test('with basic types', () => {
+    describe("`transposeArray`", () => {
+      test("with basic types", () => {
         type ExpectedOutputType = Maybe<Array<string | number>>;
 
-        let onlyJusts = [maybe.just(2), maybe.just('three')];
+        let onlyJusts = [maybe.just(2), maybe.just("three")];
         let onlyJustsAll = maybe.transposeArray(onlyJusts);
         expectTypeOf(onlyJustsAll).toEqualTypeOf<ExpectedOutputType>();
-        expect(onlyJustsAll).toEqual(maybe.just([2, 'three']));
+        expect(onlyJustsAll).toEqual(maybe.just([2, "three"]));
 
         let hasNothing = [maybe.just(2), maybe.nothing<string>()];
         let hasNothingAll = maybe.transposeArray(hasNothing);
@@ -576,26 +621,29 @@ describe('`Maybe` pure functions', () => {
         expect(hasNothingAll).toEqual(maybe.nothing());
       });
 
-      test('with arrays', () => {
+      test("with arrays", () => {
         type ExpectedOutputType = Maybe<Array<number | string[]>>;
 
-        let nestedArrays = [maybe.just(1), maybe.just(['two', 'three'])];
+        let nestedArrays = [maybe.just(1), maybe.just(["two", "three"])];
         let nestedArraysAll = maybe.transposeArray(nestedArrays);
 
         expectTypeOf(nestedArraysAll).toEqualTypeOf<ExpectedOutputType>();
-        expect(nestedArraysAll).toEqual(maybe.just([1, ['two', 'three']]));
+        expect(nestedArraysAll).toEqual(maybe.just([1, ["two", "three"]]));
       });
 
-      test('with tuples', () => {
+      test("with tuples", () => {
         type ExpectedOutputType = Maybe<readonly [number, string]>;
 
-        let theOutput = maybe.transposeArray([maybe.just(123), maybe.just('hello')]);
+        let theOutput = maybe.transposeArray([
+          maybe.just(123),
+          maybe.just("hello"),
+        ]);
 
         expectTypeOf(theOutput).toEqualTypeOf<ExpectedOutputType>();
-        expect(theOutput).toEqual(maybe.just([123, 'hello']));
+        expect(theOutput).toEqual(maybe.just([123, "hello"]));
       });
 
-      test('with readonly arrays', () => {
+      test("with readonly arrays", () => {
         let theInput: readonly Maybe<number>[] = [Maybe.just(1), Maybe.just(2)];
         let theOutput = maybe.transposeArray(theInput);
         expectTypeOf(theOutput).toEqualTypeOf<Maybe<readonly number[]>>();
@@ -604,53 +652,59 @@ describe('`Maybe` pure functions', () => {
     });
   });
 
-  test('`property`', () => {
+  test("`property`", () => {
     type Person = { name?: string };
-    let chris: Person = { name: 'chris' };
-    expect(maybe.property('name', chris)).toEqual(maybe.just('chris'));
+    let chris: Person = { name: "chris" };
+    expect(maybe.property("name", chris)).toEqual(maybe.just("chris"));
 
     let nobody: Person = {};
-    expect(maybe.property('name', nobody)).toEqual(maybe.nothing());
+    expect(maybe.property("name", nobody)).toEqual(maybe.nothing());
 
     type Dict<T> = { [key: string]: T };
-    let dict: Dict<string> = { quux: 'warble' };
-    expect(maybe.property('quux', dict)).toEqual(maybe.just('warble'));
-    expect(maybe.property('wat', dict)).toEqual(maybe.nothing());
+    let dict: Dict<string> = { quux: "warble" };
+    expect(maybe.property("quux", dict)).toEqual(maybe.just("warble"));
+    expect(maybe.property("wat", dict)).toEqual(maybe.nothing());
   });
 
-  describe('`get`', () => {
-    test('basic form', () => {
+  describe("`get`", () => {
+    test("basic form", () => {
       type Person = { name?: string };
-      let chris: Person = { name: 'chris' };
+      let chris: Person = { name: "chris" };
       let justChris: Maybe<Person> = maybe.just(chris);
-      expect(maybe.get('name', justChris)).toEqual(maybe.just('chris'));
+      expect(maybe.get("name", justChris)).toEqual(maybe.just("chris"));
 
       let nobody: Maybe<Person> = maybe.nothing();
-      expect(maybe.get('name', nobody)).toEqual(maybe.nothing());
+      expect(maybe.get("name", nobody)).toEqual(maybe.nothing());
 
       type Dict<T> = { [key: string]: T };
-      let dict = maybe.just({ quux: 'warble' } as Dict<string>);
-      expect(maybe.get('quux', dict)).toEqual(maybe.just('warble'));
-      expect(maybe.get('wat', dict)).toEqual(maybe.nothing());
+      let dict = maybe.just({ quux: "warble" } as Dict<string>);
+      expect(maybe.get("quux", dict)).toEqual(maybe.just("warble"));
+      expect(maybe.get("wat", dict)).toEqual(maybe.nothing());
     });
 
-    test('curried form', () => {
+    test("curried form", () => {
       type DeepType = {
-        something?: { with?: { deeper?: { 'key names'?: string } } };
+        something?: { with?: { deeper?: { "key names"?: string } } };
       };
 
       const allSet: DeepType = {
-        something: { with: { deeper: { 'key names': 'like this' } } },
+        something: { with: { deeper: { "key names": "like this" } } },
       };
       let fromSet = maybe.get(
-        'key names',
-        maybe.get('deeper', maybe.get('with', maybe.get('something', Maybe.of(allSet))))
+        "key names",
+        maybe.get(
+          "deeper",
+          maybe.get("with", maybe.get("something", Maybe.of(allSet))),
+        ),
       );
 
       const allEmpty: DeepType = {};
       let fromEmpty = maybe.get(
-        'key names',
-        maybe.get('deeper', maybe.get('with', maybe.get('something', Maybe.of(allEmpty))))
+        "key names",
+        maybe.get(
+          "deeper",
+          maybe.get("with", maybe.get("something", Maybe.of(allEmpty))),
+        ),
       );
 
       expect(fromEmpty).toEqual(maybe.nothing());
@@ -661,20 +715,22 @@ describe('`Maybe` pure functions', () => {
     });
   });
 
-  test('`safe`', () => {
-    const empty = '';
+  test("`safe`", () => {
+    const empty = "";
     const emptyResult = maybe.nothing();
 
-    const full = 'hello';
+    const full = "hello";
     const fullResult = maybe.just(full.length);
 
-    const mayBeNull = (s: string): number | null => (s.length > 0 ? s.length : null);
+    const mayBeNull = (s: string): number | null =>
+      s.length > 0 ? s.length : null;
     const mayNotBeNull = maybe.safe(mayBeNull);
 
     expect(mayNotBeNull(empty)).toEqual(emptyResult);
     expect(mayNotBeNull(full)).toEqual(fullResult);
 
-    const mayBeUndefined = (s: string): number | undefined => (s.length > 0 ? s.length : undefined);
+    const mayBeUndefined = (s: string): number | undefined =>
+      s.length > 0 ? s.length : undefined;
     const mayNotBeUndefined = maybe.safe(mayBeUndefined);
 
     expect(mayNotBeUndefined(empty)).toEqual(emptyResult);
@@ -686,29 +742,29 @@ describe('`Maybe` pure functions', () => {
     expectTypeOf(querySelector).toEqualTypeOf<() => Maybe<string>>();
   });
 
-  test('`isJust` with a Just', () => {
-    const testJust: Maybe<string> = maybe.just('test');
+  test("`isJust` with a Just", () => {
+    const testJust: Maybe<string> = maybe.just("test");
 
     if (maybe.isJust(testJust)) {
-      expect(testJust.value).toEqual('test');
+      expect(testJust.value).toEqual("test");
     } else {
-      expect.fail('Expected a Just');
+      expect.fail("Expected a Just");
     }
   });
 
-  test('`isJust` with a Nothing', () => {
+  test("`isJust` with a Nothing", () => {
     const testNothing: Maybe<string> = maybe.nothing();
 
     expect(maybe.isJust(testNothing)).toEqual(false);
   });
 
-  test('`isNothing` with a Just', () => {
-    const testJust: Maybe<string> = maybe.just('test');
+  test("`isNothing` with a Just", () => {
+    const testJust: Maybe<string> = maybe.just("test");
 
     expect(maybe.isNothing(testJust)).toEqual(false);
   });
 
-  test('`isNothing` with a Nothing', () => {
+  test("`isNothing` with a Nothing", () => {
     const testNothing: Maybe<string> = maybe.nothing();
 
     expect(maybe.isNothing(testNothing)).toEqual(true);
@@ -718,7 +774,7 @@ describe('`Maybe` pure functions', () => {
 // We aren't even really concerned with the "runtime" behavior here, which we
 // know to be correct from other tests. Instead, this test just checks whether
 // the types are narrowed as they should be.
-test('narrowing', () => {
+test("narrowing", () => {
   const oneJust = maybe.of(Unit);
   if (oneJust.isJust) {
     expectTypeOf(oneJust).toEqualTypeOf<Just<Unit>>();
@@ -742,30 +798,32 @@ test('narrowing', () => {
     expectTypeOf(anotherNothing).toEqualTypeOf<Nothing<unknown>>();
   }
 
-  expect('this type checked, hooray').toBeTruthy();
+  expect("this type checked, hooray").toBeTruthy();
 });
 
-describe('`Maybe` class', () => {
-  test('basic types', () => {
-    let maybe = Maybe.of('hello');
+describe("`Maybe` class", () => {
+  test("basic types", () => {
+    let maybe = Maybe.of("hello");
     expectTypeOf(maybe);
-    expectTypeOf(maybe).toHaveProperty('isJust');
-    expectTypeOf(maybe).toHaveProperty('isJust');
-    expectTypeOf(maybe).toHaveProperty('isNothing');
+    expectTypeOf(maybe).toHaveProperty("isJust");
+    expectTypeOf(maybe).toHaveProperty("isJust");
+    expectTypeOf(maybe).toHaveProperty("isNothing");
     if (maybe.isJust) {
-      expectTypeOf(maybe).toHaveProperty('value');
+      expectTypeOf(maybe).toHaveProperty("value");
     }
-    expectTypeOf(Maybe).constructorParameters.toEqualTypeOf<[value?: unknown]>();
+    expectTypeOf(Maybe).constructorParameters.toEqualTypeOf<
+      [value?: unknown]
+    >();
   });
 
-  describe('Just instance', () => {
-    test('constructor', () => {
-      const theJust = new Maybe('cool');
+  describe("Just instance", () => {
+    test("constructor", () => {
+      const theJust = new Maybe("cool");
       expect(theJust.variant).toEqual(Variant.Just);
-      expect((theJust as Just<string>).value).toEqual('cool');
+      expect((theJust as Just<string>).value).toEqual("cool");
     });
 
-    test('static constructor', () => {
+    test("static constructor", () => {
       const theJust = Maybe.just(123);
       expect(theJust.variant).toEqual(Variant.Just);
       expect((theJust as Just<number>).value).toEqual(123);
@@ -773,15 +831,15 @@ describe('`Maybe` class', () => {
       expect(() =>
         Maybe.just(
           // @ts-expect-error
-          null
-        )
+          null,
+        ),
       ).toThrow();
 
       expect(() =>
         Maybe.just(
           // @ts-expect-error
-          undefined
-        )
+          undefined,
+        ),
       ).toThrow();
 
       // By definition cannot throw on this since it actually does exist and the
@@ -789,49 +847,49 @@ describe('`Maybe` class', () => {
       expect(() =>
         Maybe.just(
           // @ts-expect-error
-          'Hello' as string | null | undefined
-        )
+          "Hello" as string | null | undefined,
+        ),
       ).not.toThrow();
 
       // Whereas here it should fail both type-checking *and* at runtime.
       expect(() =>
         Maybe.just(
           // @ts-expect-error
-          null as string | null | undefined
-        )
+          null as string | null | undefined,
+        ),
       ).toThrow();
     });
 
-    test('`value` property', () => {
-      const val = 'hallo';
+    test("`value` property", () => {
+      const val = "hallo";
       const theJust = new Maybe(val);
       if (theJust.isJust) {
         expectTypeOf(theJust.isJust).toEqualTypeOf<true>();
-        expectTypeOf(theJust).toHaveProperty('value');
+        expectTypeOf(theJust).toHaveProperty("value");
         expectTypeOf(theJust.value).toEqualTypeOf(val);
         expect(theJust.value).toBe(val);
       } else {
-        expect('wrongly instantiated').toBe(true);
+        expect("wrongly instantiated").toBe(true);
       }
     });
 
-    test('`unwrap` static method', () => {
+    test("`unwrap` static method", () => {
       const val = 42;
       const theJust = new Maybe(42) as Just<number>;
       expect(theJust.value).toEqual(val);
     });
 
-    test('`isJust` property', () => {
+    test("`isJust` property", () => {
       const theJust = new Maybe([]);
       expect(theJust.isJust).toBe(true);
     });
 
-    test('`isNothing` property', () => {
+    test("`isNothing` property", () => {
       const theJust = new Maybe([]);
       expect(theJust.isNothing).toBe(false);
     });
 
-    test('`map` method', () => {
+    test("`map` method", () => {
       const plus2 = (x: number) => x + 2;
       const theValue = 12;
       const theJust = new Maybe(theValue);
@@ -843,12 +901,12 @@ describe('`Maybe` class', () => {
       expect(() => {
         theJust.map(
           // @ts-expect-error
-          (_val) => null
+          (_val) => null,
         );
       }).toThrow();
     });
 
-    test('`mapOr` method', () => {
+    test("`mapOr` method", () => {
       const theValue = 42;
       const theJust = new Maybe(42);
       const theDefault = 1;
@@ -857,129 +915,129 @@ describe('`Maybe` class', () => {
       expect(theJust.mapOr(theDefault, double)).toEqual(double(theValue));
     });
 
-    test('`mapOrElse` method', () => {
-      const theValue = 'this is a string';
+    test("`mapOrElse` method", () => {
+      const theValue = "this is a string";
       const theJust = new Maybe(theValue);
       const aDefault = () => 0;
 
       expect(theJust.mapOrElse(aDefault, length)).toEqual(length(theValue));
     });
 
-    test('`match` method', () => {
-      const theValue = 'this is a string';
+    test("`match` method", () => {
+      const theValue = "this is a string";
       const theJust = new Maybe(theValue);
 
       expect(
         theJust.match({
-          Just: (val) => val + ', yo',
-          Nothing: () => 'rats, nothing',
-        })
-      ).toEqual('this is a string, yo');
+          Just: (val) => val + ", yo",
+          Nothing: () => "rats, nothing",
+        }),
+      ).toEqual("this is a string, yo");
     });
 
-    test('`or` method', () => {
-      const theJust = new Maybe({ neat: 'thing' });
-      const anotherJust = new Maybe({ neat: 'waffles' });
+    test("`or` method", () => {
+      const theJust = new Maybe({ neat: "thing" });
+      const anotherJust = new Maybe({ neat: "waffles" });
       const aNothing = new Maybe<Neat>();
 
       expect(theJust.or(anotherJust)).toEqual(theJust);
       expect(theJust.or(aNothing)).toEqual(theJust);
     });
 
-    describe('`orElse` method', () => {
-      test('`orElse` method', () => {
+    describe("`orElse` method", () => {
+      test("`orElse` method", () => {
         const theJust = new Maybe(12);
         const getAnotherJust = () => maybe.just(42);
 
         expect(theJust.orElse(getAnotherJust)).toEqual(theJust);
       });
 
-      test('with multiple types in the returned `Maybe` instances', () => {
+      test("with multiple types in the returned `Maybe` instances", () => {
         class Branded<T extends string> {
           constructor(public readonly name: T) {}
         }
 
-        let theOutput = Maybe.just(new Branded('just')).orElse(() => {
+        let theOutput = Maybe.just(new Branded("just")).orElse(() => {
           if (Math.random() < 0.1) {
-            return maybe.just(new Branded('just-a'));
+            return maybe.just(new Branded("just-a"));
           }
 
           if (Math.random() < 0.2) {
-            return maybe.nothing<Branded<'empty'>>();
+            return maybe.nothing<Branded<"empty">>();
           }
 
           if (Math.random() < 0.3) {
-            return maybe.just(new Branded('just-b'));
+            return maybe.just(new Branded("just-b"));
           }
 
-          return maybe.nothing<Branded<'empty'>>();
+          return maybe.nothing<Branded<"empty">>();
         });
 
         expectTypeOf(theOutput).toEqualTypeOf<
-          Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
+          Maybe<Branded<"just-a"> | Branded<"just-b"> | Branded<"empty">>
         >;
       });
     });
 
-    test('`and` method', () => {
-      const theJust = new Maybe({ neat: 'thing' });
-      const theConsequentJust = new Maybe(['amazing', { tuple: 'thing' }]);
+    test("`and` method", () => {
+      const theJust = new Maybe({ neat: "thing" });
+      const theConsequentJust = new Maybe(["amazing", { tuple: "thing" }]);
       const aNothing = new Maybe();
 
       expect(theJust.and(theConsequentJust)).toEqual(theConsequentJust);
       expect(theJust.and(aNothing)).toEqual(aNothing);
     });
 
-    describe('`andThen` method', () => {
-      test('basics', () => {
-        const theValue = { Jedi: 'Luke Skywalker' };
+    describe("`andThen` method", () => {
+      test("basics", () => {
+        const theValue = { Jedi: "Luke Skywalker" };
         const theJust = new Maybe(theValue);
         const toDescription = (dict: { [key: string]: string }) =>
           new Maybe(
             Object.keys(dict)
               .map((key) => `${dict[key]} is a ${key}`)
-              .join('\n')
+              .join("\n"),
           );
 
         const theExpectedResult = toDescription(theValue);
         expect(theJust.andThen(toDescription)).toEqual(theExpectedResult);
       });
 
-      test('with multiple types in the returned `Maybe` instances', () => {
+      test("with multiple types in the returned `Maybe` instances", () => {
         class Branded<T extends string> {
           constructor(public readonly name: T) {}
         }
 
-        let theOutput = Maybe.of(new Branded('just')).andThen((_) => {
+        let theOutput = Maybe.of(new Branded("just")).andThen((_) => {
           if (Math.random() < 0.1) {
-            return maybe.just(new Branded('just-a'));
+            return maybe.just(new Branded("just-a"));
           }
 
           if (Math.random() < 0.2) {
-            return maybe.nothing<Branded<'empty'>>();
+            return maybe.nothing<Branded<"empty">>();
           }
 
           if (Math.random() < 0.3) {
-            return maybe.just(new Branded('just-b'));
+            return maybe.just(new Branded("just-b"));
           }
 
-          return maybe.nothing<Branded<'empty'>>();
+          return maybe.nothing<Branded<"empty">>();
         });
 
         expectTypeOf(theOutput).toEqualTypeOf<
-          Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
+          Maybe<Branded<"just-a"> | Branded<"just-b"> | Branded<"empty">>
         >;
       });
     });
 
-    test('`unwrap` method', () => {
-      const theValue = 'value';
+    test("`unwrap` method", () => {
+      const theValue = "value";
       const theJust = new Maybe(theValue);
       expect((theJust as Just<string>).value).toEqual(theValue);
       expect(() => (theJust as Just<string>).value).not.toThrow();
     });
 
-    test('`unwrapOr` method', () => {
+    test("`unwrapOr` method", () => {
       const theValue = [1, 2, 3];
       const theJust = new Maybe(theValue);
       const theDefaultValue: number[] = [];
@@ -987,17 +1045,17 @@ describe('`Maybe` class', () => {
       expect(theJust.unwrapOr(theDefaultValue)).toEqual(theValue);
     });
 
-    test('`unwrapOrElse` method', () => {
-      const value = 'value';
+    test("`unwrapOrElse` method", () => {
+      const value = "value";
       const theJust = new Maybe(value);
-      expect(theJust.unwrapOrElse(() => 'other value')).toEqual(value);
+      expect(theJust.unwrapOrElse(() => "other value")).toEqual(value);
     });
 
-    test('`toString` method', () => {
-      expect(maybe.of(42).toString()).toEqual('Just(42)');
+    test("`toString` method", () => {
+      expect(maybe.of(42).toString()).toEqual("Just(42)");
     });
 
-    test('`toJSON` method', () => {
+    test("`toJSON` method", () => {
       expect(maybe.of({ x: 42 }).toJSON()).toEqual({
         variant: maybe.Variant.Just,
         value: { x: 42 },
@@ -1008,58 +1066,58 @@ describe('`Maybe` class', () => {
       });
     });
 
-    test('`equals` method', () => {
-      const a = new Maybe('a');
-      const b = new Maybe('a');
-      const c = new Maybe('b');
+    test("`equals` method", () => {
+      const a = new Maybe("a");
+      const b = new Maybe("a");
+      const c = new Maybe("b");
       const d = new Maybe<string>();
       expect(a.equals(b)).toBe(true);
       expect(b.equals(c)).toBe(false);
       expect(c.equals(d)).toBe(false);
     });
 
-    test('`ap` method', () => {
+    test("`ap` method", () => {
       const toString = (a: number) => a.toString();
       const fn = new Maybe(toString);
       const val = new Maybe(3);
 
       const result = fn.ap(val);
 
-      expect(result.equals(maybe.of('3'))).toBe(true);
+      expect(result.equals(maybe.of("3"))).toBe(true);
     });
 
-    test('`get` method', () => {
+    test("`get` method", () => {
       type DeepType = {
-        something?: { with?: { deeper?: { 'key names'?: string } } };
+        something?: { with?: { deeper?: { "key names"?: string } } };
       };
 
       const allSet: DeepType = {
-        something: { with: { deeper: { 'key names': 'like this' } } },
+        something: { with: { deeper: { "key names": "like this" } } },
       };
       const deepResult = new Maybe(allSet)
-        .get('something')
-        .get('with')
-        .get('deeper')
-        .get('key names');
-      expect(deepResult).toEqual(maybe.just('like this'));
+        .get("something")
+        .get("with")
+        .get("deeper")
+        .get("key names");
+      expect(deepResult).toEqual(maybe.just("like this"));
 
       const allEmpty: DeepType = {};
       const emptyResult = new Maybe(allEmpty)
-        .get('something')
-        .get('with')
-        .get('deeper')
-        .get('key names');
+        .get("something")
+        .get("with")
+        .get("deeper")
+        .get("key names");
       expect(emptyResult).toEqual(maybe.nothing());
     });
   });
 
-  describe('`Nothing` instance', () => {
-    test('constructor', () => {
+  describe("`Nothing` instance", () => {
+    test("constructor", () => {
       const theNothing = new Maybe();
       expect(theNothing.variant).toEqual(Variant.Nothing);
     });
 
-    test('static constructor', () => {
+    test("static constructor", () => {
       const theNothing = Maybe.nothing();
       expect(theNothing.variant).toEqual(Variant.Nothing);
       // @ts-expect-error -- `value` isn't accessible without narrowing
@@ -1076,171 +1134,177 @@ describe('`Maybe` class', () => {
       expect(() => nothingFromUndefined.value).toThrow();
     });
 
-    test('`isJust` property', () => {
+    test("`isJust` property", () => {
       const theNothing = new Maybe();
       expect(theNothing.isJust).toBe(false);
     });
 
-    test('`value` property', () => {
+    test("`value` property", () => {
       const theNothing = new Maybe();
       // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => theNothing.value).toThrow();
     });
 
-    test('`isNothing` property', () => {
+    test("`isNothing` property", () => {
       const theNothing = new Maybe();
       expect(theNothing.isNothing).toBe(true);
     });
 
-    test('`map` method', () => {
+    test("`map` method", () => {
       const theNothing = new Maybe<string>();
       expect(theNothing.map(length)).toEqual(theNothing);
 
       theNothing.map(
         // @ts-expect-error
-        (_val) => null
+        (_val) => null,
       );
     });
 
-    test('`mapOr` method', () => {
+    test("`mapOr` method", () => {
       const theNothing = new Maybe<number>();
-      const theDefaultValue = 'yay';
-      expect(theNothing.mapOr(theDefaultValue, String)).toEqual(theDefaultValue);
+      const theDefaultValue = "yay";
+      expect(theNothing.mapOr(theDefaultValue, String)).toEqual(
+        theDefaultValue,
+      );
     });
 
-    test('`mapOrElse` method', () => {
-      const theDefaultValue = 'potatoes';
+    test("`mapOrElse` method", () => {
+      const theDefaultValue = "potatoes";
       const getDefaultValue = () => theDefaultValue;
       const getNeat = (x: Neat) => x.neat;
       const theNothing = new Maybe<Neat>();
-      expect(theNothing.mapOrElse(getDefaultValue, getNeat)).toBe(theDefaultValue);
+      expect(theNothing.mapOrElse(getDefaultValue, getNeat)).toBe(
+        theDefaultValue,
+      );
     });
 
-    test('`match` method', () => {
+    test("`match` method", () => {
       const nietzsche = maybe.nothing();
       const soDeepMan = [
-        'Whoever fights monsters should see to it that in the process he does not become a monster.',
-        'And if you gaze long enough into an abyss, the abyss will gaze back into you.',
-      ].join(' ');
+        "Whoever fights monsters should see to it that in the process he does not become a monster.",
+        "And if you gaze long enough into an abyss, the abyss will gaze back into you.",
+      ].join(" ");
 
       expect(
         nietzsche.match({
-          Just: (s) => s + ', yo',
+          Just: (s) => s + ", yo",
           Nothing: () => soDeepMan,
-        })
+        }),
       ).toBe(soDeepMan);
     });
 
-    test('`or` method', () => {
+    test("`or` method", () => {
       const theNothing = new Maybe<boolean>(); // the worst: optional booleans!
       const theDefaultValue = maybe.just(false);
 
       expect(theNothing.or(theDefaultValue)).toBe(theDefaultValue);
     });
 
-    describe('`orElse` method', () => {
-      test('`orElse` method', () => {
+    describe("`orElse` method", () => {
+      test("`orElse` method", () => {
         const theNothing = new Maybe<{ here: string[] }>();
-        const justTheFallback = maybe.just({ here: ['to', 'see'] });
+        const justTheFallback = maybe.just({ here: ["to", "see"] });
         const getTheFallback = () => justTheFallback;
 
         expect(theNothing.orElse(getTheFallback)).toEqual(justTheFallback);
       });
 
-      test('with multiple types in the returned `Maybe` instances', () => {
+      test("with multiple types in the returned `Maybe` instances", () => {
         class Branded<T extends string> {
           constructor(public readonly name: T) {}
         }
 
-        let theOutput = Maybe.nothing<'empty-start'>().orElse(() => {
+        let theOutput = Maybe.nothing<"empty-start">().orElse(() => {
           if (Math.random() < 0.1) {
-            return maybe.just(new Branded('just-a'));
+            return maybe.just(new Branded("just-a"));
           }
 
           if (Math.random() < 0.2) {
-            return maybe.nothing<Branded<'empty'>>();
+            return maybe.nothing<Branded<"empty">>();
           }
 
           if (Math.random() < 0.3) {
-            return maybe.just(new Branded('just-b'));
+            return maybe.just(new Branded("just-b"));
           }
 
-          return maybe.nothing<Branded<'empty'>>();
+          return maybe.nothing<Branded<"empty">>();
         });
 
         expectTypeOf(theOutput).toEqualTypeOf<
-          Maybe<Branded<'just-a'> | Branded<'just-b'> | Branded<'empty'>>
+          Maybe<Branded<"just-a"> | Branded<"just-b"> | Branded<"empty">>
         >;
       });
     });
 
-    test('`and` method', () => {
+    test("`and` method", () => {
       const theNothing = new Maybe<string[]>();
-      const theConsequentJust = new Maybe('blaster bolts');
+      const theConsequentJust = new Maybe("blaster bolts");
       const anotherNothing = new Maybe<string>();
       expect(theNothing.and(theConsequentJust)).toEqual(theNothing);
       expect(theNothing.and(anotherNothing)).toEqual(theNothing);
     });
 
-    describe('`andThen` method', () => {
-      test('basic functionality', () => {
+    describe("`andThen` method", () => {
+      test("basic functionality", () => {
         const theNothing = new Maybe();
-        const theDefaultValue = 'string';
+        const theDefaultValue = "string";
         const getDefaultValue = () => maybe.just(theDefaultValue);
 
         expect(theNothing.andThen(getDefaultValue)).toEqual(theNothing);
       });
 
-      test('with multiple types in the returned `Maybe` instances', () => {
+      test("with multiple types in the returned `Maybe` instances", () => {
         class Branded<T extends string> {
           constructor(public readonly name: T) {}
         }
 
-        let theOutput = Maybe.nothing<'empty-start'>().andThen((_) => {
+        let theOutput = Maybe.nothing<"empty-start">().andThen((_) => {
           if (Math.random() < 0.1) {
-            return maybe.just(new Branded('just-a'));
+            return maybe.just(new Branded("just-a"));
           }
 
           if (Math.random() < 0.2) {
-            return maybe.nothing<Branded<'empty'>>();
+            return maybe.nothing<Branded<"empty">>();
           }
 
           if (Math.random() < 0.3) {
-            return maybe.just(new Branded('just-b'));
+            return maybe.just(new Branded("just-b"));
           }
 
-          return maybe.nothing<Branded<'empty'>>();
+          return maybe.nothing<Branded<"empty">>();
         });
 
         expectTypeOf(theOutput).toEqualTypeOf<
-          Maybe<Branded<'just-a'> | Branded<'empty'> | Branded<'just-b'>>
+          Maybe<Branded<"just-a"> | Branded<"empty"> | Branded<"just-b">>
         >();
       });
     });
 
-    test('`value` access', () => {
+    test("`value` access", () => {
       const noStuffAtAll = new Maybe();
       // @ts-expect-error -- `value` isn't accessible without narrowing
       expect(() => noStuffAtAll.value).toThrow();
     });
 
-    test('`unwrapOr` method', () => {
+    test("`unwrapOr` method", () => {
       const theNothing = new Maybe<number[]>();
       const theDefaultValue: number[] = [];
       expect(theNothing.unwrapOr(theDefaultValue)).toEqual(theDefaultValue);
     });
 
-    test('`unwrapOrElse` method', () => {
+    test("`unwrapOrElse` method", () => {
       const theNothing = new Maybe();
-      const theDefaultValue = 'it be all fine tho';
-      expect(theNothing.unwrapOrElse(() => theDefaultValue)).toEqual(theDefaultValue);
+      const theDefaultValue = "it be all fine tho";
+      expect(theNothing.unwrapOrElse(() => theDefaultValue)).toEqual(
+        theDefaultValue,
+      );
     });
 
-    test('`toString` method', () => {
-      expect(maybe.nothing().toString()).toEqual('Nothing');
+    test("`toString` method", () => {
+      expect(maybe.nothing().toString()).toEqual("Nothing");
     });
 
-    test('`toJSON` method', () => {
+    test("`toJSON` method", () => {
       expect(maybe.nothing().toJSON()).toEqual({
         variant: maybe.Variant.Nothing,
       });
@@ -1250,33 +1314,33 @@ describe('`Maybe` class', () => {
       });
     });
 
-    test('`equals` method', () => {
-      const a = new Maybe<string>('a');
+    test("`equals` method", () => {
+      const a = new Maybe<string>("a");
       const b = new Maybe<string>();
       const c = new Maybe<string>();
       expect(a.equals(b)).toBe(false);
       expect(b.equals(c)).toBe(true);
     });
 
-    test('`ap` method', () => {
+    test("`ap` method", () => {
       const fn = new Maybe<(val: string) => number>();
-      const val = new Maybe('three');
+      const val = new Maybe("three");
 
       const result = fn.ap(val);
 
       expect(result.isNothing).toBe(true);
     });
 
-    test('`property` method', () => {
+    test("`property` method", () => {
       type DeepType = {
-        something?: { with?: { deeper?: { 'key names'?: string } } };
+        something?: { with?: { deeper?: { "key names"?: string } } };
       };
 
       const result = new Maybe<DeepType>()
-        .get('something')
-        .get('with')
-        .get('deeper')
-        .get('key names');
+        .get("something")
+        .get("with")
+        .get("deeper")
+        .get("key names");
       expect(result).toEqual(maybe.nothing());
     });
   });

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-import Result, { Ok, Variant, Err } from 'true-myth/result';
-import * as result from 'true-myth/result';
-import Unit from 'true-myth/unit';
+import Result, { Ok, Variant, Err } from "true-myth/result";
+import * as result from "true-myth/result";
+import Unit from "true-myth/unit";
 
 const length = (x: { length: number }) => x.length;
 const double = (x: number) => x * 2;
 
-describe('`Result` pure functions', () => {
-  test('`ok`', () => {
+describe("`Result` pure functions", () => {
+  test("`ok`", () => {
     const theOk = result.ok(42);
     expect(theOk).toBeInstanceOf(Result);
     switch (theOk.variant) {
@@ -35,8 +35,8 @@ describe('`Result` pure functions', () => {
     expect((withUndefined as Ok<undefined, unknown>).value).toBeUndefined();
   });
 
-  test('`err`', () => {
-    const reason = 'oh teh noes';
+  test("`err`", () => {
+    const reason = "oh teh noes";
     const theErr = result.err(reason);
     expect(theErr).toBeInstanceOf(Result);
     switch (theErr.variant) {
@@ -55,29 +55,29 @@ describe('`Result` pure functions', () => {
     expect(withUnit).toEqual(result.err(Unit));
   });
 
-  test('`tryOr`', () => {
-    const message = 'dang';
+  test("`tryOr`", () => {
+    const message = "dang";
     const goodOperation = () => 2 + 2;
 
     expect(result.tryOr(message, goodOperation)).toEqual(result.ok(4));
     expect(result.tryOr(message)(goodOperation)).toEqual(result.ok(4));
 
     const badOperation = () => {
-      throw new Error('Danger, danger, Will Robinson');
+      throw new Error("Danger, danger, Will Robinson");
     };
 
     expect(result.tryOr(message, badOperation)).toEqual(result.err(message));
     expect(result.tryOr(message)(badOperation)).toEqual(result.err(message));
   });
 
-  test('`tryOrElse`', () => {
+  test("`tryOrElse`", () => {
     function handleError<E>(e: E): E {
       return e;
     }
 
     const operation = () => 2 + 2;
     const badOperation = () => {
-      throw 'kablooey';
+      throw "kablooey";
     };
 
     const res = result.tryOrElse(handleError, operation);
@@ -89,34 +89,36 @@ describe('`Result` pure functions', () => {
     expect(res2.variant).toBe(Variant.Err);
   });
 
-  test('`map`', () => {
+  test("`map`", () => {
     const theValue = 42;
     const anOk = result.ok(theValue);
     const doubledOk = result.ok(double(theValue));
     expect(result.map(double, anOk)).toEqual(doubledOk);
 
-    const anErr: Result<number, string> = result.err('some nonsense');
+    const anErr: Result<number, string> = result.err("some nonsense");
     expect(result.map(double, anErr)).toEqual(anErr);
   });
 
-  test('`mapOr`', () => {
+  test("`mapOr`", () => {
     const theDefault = 0;
 
     const theValue = 5;
     const anOk: Result<number, string> = result.ok(theValue);
     expect(result.mapOr(theDefault, double, anOk)).toEqual(double(theValue));
 
-    const anErr: Result<number, string> = result.err('blah');
+    const anErr: Result<number, string> = result.err("blah");
     expect(result.mapOr(theDefault, double, anErr)).toEqual(theDefault);
 
-    expect(result.mapOr<number, number, string>(theDefault)(double)(anOk)).toEqual(
-      result.mapOr(theDefault, double, anOk)
+    expect(
+      result.mapOr<number, number, string>(theDefault)(double)(anOk),
+    ).toEqual(result.mapOr(theDefault, double, anOk));
+    expect(result.mapOr(theDefault, double)(anOk)).toEqual(
+      result.mapOr(theDefault, double, anOk),
     );
-    expect(result.mapOr(theDefault, double)(anOk)).toEqual(result.mapOr(theDefault, double, anOk));
   });
 
-  test('`mapOrElse`', () => {
-    const description = 'that was not good';
+  test("`mapOrElse`", () => {
+    const description = "that was not good";
     const getDefault = (reason: number) => `${description}: ${reason}`;
 
     const anOk: Result<number, number> = result.ok(5);
@@ -124,19 +126,21 @@ describe('`Result` pure functions', () => {
 
     const errValue = 10;
     const anErr = result.err(10);
-    expect(result.mapOrElse(getDefault, String, anErr)).toEqual(`${description}: ${errValue}`);
+    expect(result.mapOrElse(getDefault, String, anErr)).toEqual(
+      `${description}: ${errValue}`,
+    );
 
     expect(result.mapOrElse(getDefault)(String)(anErr)).toEqual(
-      result.mapOrElse(getDefault, String, anErr)
+      result.mapOrElse(getDefault, String, anErr),
     );
     expect(result.mapOrElse(getDefault, String)(anErr)).toEqual(
-      result.mapOrElse(getDefault, String, anErr)
+      result.mapOrElse(getDefault, String, anErr),
     );
   });
 
-  test('`match`', () => {
-    const nobody = result.ok('ok');
-    const toErrIs = result.err('human');
+  test("`match`", () => {
+    const nobody = result.ok("ok");
+    const toErrIs = result.err("human");
 
     expect(
       result.match(
@@ -144,21 +148,21 @@ describe('`Result` pure functions', () => {
           Ok: (val) => val,
           Err: (err) => err,
         },
-        nobody
-      )
-    ).toBe('ok');
+        nobody,
+      ),
+    ).toBe("ok");
     expect(
       result.match(
         {
           Ok: (val) => val,
           Err: (err) => err,
         },
-        toErrIs
-      )
-    ).toBe('human');
+        toErrIs,
+      ),
+    ).toBe("human");
   });
 
-  test('`mapErr`', () => {
+  test("`mapErr`", () => {
     const anOk: Result<number, number> = result.ok(10);
     expect(result.mapErr(double, anOk)).toEqual(anOk);
 
@@ -168,68 +172,71 @@ describe('`Result` pure functions', () => {
     expect(result.mapErr(double, anErr)).toEqual(doubledErr);
   });
 
-  test('`and`', () => {
-    const nextOk = result.ok('not a number');
-    const nextErr = result.err('not bueno');
+  test("`and`", () => {
+    const nextOk = result.ok("not a number");
+    const nextErr = result.err("not bueno");
 
     const anOk = result.ok(0);
     expect(result.and(nextOk, anOk)).toEqual(nextOk);
     expect(result.and(nextErr, anOk)).toEqual(nextErr);
 
-    const anErr = result.err('potatoes');
+    const anErr = result.err("potatoes");
     expect(result.and(nextOk, anErr)).toEqual(anErr);
     expect(result.and(nextErr, anErr)).toEqual(anErr);
   });
 
-  describe('`andThen`', () => {
-    test('basic functionality', () => {
-      const theValue = 'a string';
-      const toLengthResult = (s: string) => result.ok<number, string>(length(s));
+  describe("`andThen`", () => {
+    test("basic functionality", () => {
+      const theValue = "a string";
+      const toLengthResult = (s: string) =>
+        result.ok<number, string>(length(s));
       const expected = toLengthResult(theValue);
 
       const anOk = result.ok(theValue);
       expect(result.andThen(toLengthResult, anOk)).toEqual(expected);
 
-      const anErr: Result<string, string> = result.err('something wrong');
+      const anErr: Result<string, string> = result.err("something wrong");
       expect(result.andThen(toLengthResult, anErr)).toEqual(anErr);
     });
 
-    test('with multiple types in the `Result` returned', () => {
+    test("with multiple types in the `Result` returned", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
-      let initial = Result.ok<Branded<'ok'>, Branded<'err'>>(new Branded('ok'));
+      let initial = Result.ok<Branded<"ok">, Branded<"err">>(new Branded("ok"));
 
       let theResult = result.andThen((_) => {
         if (Math.random() < 0.1) {
-          return Result.ok(new Branded('ok-a'));
+          return Result.ok(new Branded("ok-a"));
         }
 
         if (Math.random() < 0.2) {
-          return Result.err(new Branded('err-a'));
+          return Result.err(new Branded("err-a"));
         }
 
         if (Math.random() < 0.3) {
-          return Result.ok(new Branded('ok-b'));
+          return Result.ok(new Branded("ok-b"));
         }
 
-        return Result.err(new Branded('err-b'));
+        return Result.err(new Branded("err-b"));
       }, initial);
 
       if (theResult.isOk) {
-        expectTypeOf(theResult.value).toEqualTypeOf<Branded<'ok-a'> | Branded<'ok-b'>>();
+        expectTypeOf(theResult.value).toEqualTypeOf<
+          Branded<"ok-a"> | Branded<"ok-b">
+        >();
       } else if (theResult.isErr) {
         expectTypeOf(theResult.error).toEqualTypeOf<
-          Branded<'err'> | Branded<'err-a'> | Branded<'err-b'>
+          Branded<"err"> | Branded<"err-a"> | Branded<"err-b">
         >();
       }
     });
   });
 
-  test('`or`', () => {
+  test("`or`", () => {
     const orOk: Result<number, string> = result.ok(0);
-    const orErr: Result<number, string> = result.err('something boring');
+    const orErr: Result<number, string> = result.err("something boring");
 
     type Err = { [key: string]: string };
 
@@ -237,111 +244,115 @@ describe('`Result` pure functions', () => {
     expect(result.or(orOk, anOk)).toEqual(anOk);
     expect(result.or(orErr, anOk)).toEqual(anOk);
 
-    const anErr: Result<number, Err> = result.err({ oh: 'my' });
+    const anErr: Result<number, Err> = result.err({ oh: "my" });
     expect(result.or(orOk, anErr)).toEqual(orOk);
     expect(result.or(orErr, anErr)).toEqual(orErr);
   });
 
-  describe('`orElse`', () => {
-    test('basic functionality', () => {
+  describe("`orElse`", () => {
+    test("basic functionality", () => {
       const orElseOk: Result<number, string> = result.ok(1);
       const getAnOk = () => orElseOk;
 
-      const orElseErr: Result<number, string> = result.err('oh my');
+      const orElseErr: Result<number, string> = result.err("oh my");
       const getAnErr = () => orElseErr;
 
       const anOk: Result<number, string> = result.ok(0);
       expect(result.orElse(getAnOk, anOk)).toEqual(anOk);
       expect(result.orElse(getAnErr, anOk)).toEqual(anOk);
 
-      const anErr: Result<number, string> = result.err('boom');
+      const anErr: Result<number, string> = result.err("boom");
       expect(result.orElse(getAnOk, anErr)).toEqual(orElseOk);
       expect(result.orElse(getAnErr, anErr)).toEqual(orElseErr);
     });
 
-    test('with multiple types in the `Result` returned', () => {
+    test("with multiple types in the `Result` returned", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
-      let initial = Result.err<Branded<'ok'>, Branded<'err'>>(new Branded('err'));
+      let initial = Result.err<Branded<"ok">, Branded<"err">>(
+        new Branded("err"),
+      );
 
       let theResult = result.orElse((_) => {
         if (Math.random() < 0.1) {
-          return Result.ok(new Branded('ok-a'));
+          return Result.ok(new Branded("ok-a"));
         }
 
         if (Math.random() < 0.2) {
-          return Result.err(new Branded('err-a'));
+          return Result.err(new Branded("err-a"));
         }
 
         if (Math.random() < 0.3) {
-          return Result.ok(new Branded('ok-b'));
+          return Result.ok(new Branded("ok-b"));
         }
 
-        return Result.err(new Branded('err-b'));
+        return Result.err(new Branded("err-b"));
       }, initial);
 
       if (theResult.isOk) {
         expectTypeOf(theResult.value).toEqualTypeOf<
-          Branded<'ok'> | Branded<'ok-a'> | Branded<'ok-b'>
+          Branded<"ok"> | Branded<"ok-a"> | Branded<"ok-b">
         >();
       } else if (theResult.isErr) {
-        expectTypeOf(theResult.error).toEqualTypeOf<Branded<'err-a'> | Branded<'err-b'>>();
+        expectTypeOf(theResult.error).toEqualTypeOf<
+          Branded<"err-a"> | Branded<"err-b">
+        >();
       }
     });
   });
 
-  test('`value` property', () => {
-    const theValue = 'hooray';
+  test("`value` property", () => {
+    const theValue = "hooray";
     const anOk = result.ok(theValue);
 
     if (anOk.isOk) {
       expect(() => anOk.value).not.toThrow();
       expect(anOk.value).toBe(theValue);
     } else {
-      expect.fail('Not an Ok');
+      expect.fail("Not an Ok");
     }
 
-    const theErrValue = 'oh no';
+    const theErrValue = "oh no";
     const anErr = result.err(theErrValue);
     if (anErr.isErr) {
       // @ts-expect-error
       expect(() => anErr.value).toThrow();
     } else {
-      expect.fail('Not an Err');
+      expect.fail("Not an Err");
     }
   });
 
-  test('`error` property', () => {
-    const theValue = 'hooray';
+  test("`error` property", () => {
+    const theValue = "hooray";
     const anOk = result.ok(theValue);
 
     if (anOk.isOk) {
       // @ts-expect-error
       expect(() => anOk.error).toThrow();
     } else {
-      expect.fail('Not an Ok');
+      expect.fail("Not an Ok");
     }
 
-    const theErrValue = 'oh no';
+    const theErrValue = "oh no";
     const anErr = result.err(theErrValue);
     if (anErr.isErr) {
       expect(() => anErr.error).not.toThrow();
       expect(anErr.error).toBe(theErrValue);
     } else {
-      expect.fail('Not an Err');
+      expect.fail("Not an Err");
     }
   });
 
-  test('`unwrapOr`', () => {
-    const defaultValue = 'pancakes are awesome';
+  test("`unwrapOr`", () => {
+    const defaultValue = "pancakes are awesome";
 
-    const theValue = 'waffles are tasty';
+    const theValue = "waffles are tasty";
     const anOk = result.ok(theValue);
     expect(result.unwrapOr(defaultValue, anOk)).toBe(theValue);
 
-    const anErr = result.err('pumpkins are not');
+    const anErr = result.err("pumpkins are not");
     expect(result.unwrapOr(defaultValue, anErr)).toBe(defaultValue);
     // make sure you can unwrap to a different type, like undefined
     expectTypeOf(anOk).toEqualTypeOf<Result<string, never>>();
@@ -355,16 +366,16 @@ describe('`Result` pure functions', () => {
     expect(anErrOrUndefined).toEqual(undefined);
   });
 
-  test('`unwrapOrElse`', () => {
+  test("`unwrapOrElse`", () => {
     type LocalError = { reason: string };
 
     const errToOk = (e: LocalError) => `What went wrong? ${e.reason}`;
 
-    const theValue = 'Red 5';
+    const theValue = "Red 5";
     const anOk = result.ok<string, LocalError>(theValue);
     expect(result.unwrapOrElse(errToOk, anOk)).toBe(theValue);
 
-    const theErrValue = { reason: 'bad thing' };
+    const theErrValue = { reason: "bad thing" };
     const anErr = result.err<string, LocalError>(theErrValue);
     expect(result.unwrapOrElse(errToOk, anErr)).toBe(errToOk(theErrValue));
 
@@ -380,10 +391,10 @@ describe('`Result` pure functions', () => {
     expect(anErrOrUndefined).toEqual(undefined);
   });
 
-  describe('toString', () => {
-    test('normal cases', () => {
-      const theValue = { thisIsReally: 'something' };
-      const errValue = ['oh', 'no'];
+  describe("toString", () => {
+    test("normal cases", () => {
+      const theValue = { thisIsReally: "something" };
+      const errValue = ["oh", "no"];
 
       const anOk = result.ok<typeof theValue, typeof errValue>(theValue);
       expect(result.toString(anOk)).toEqual(`Ok(${theValue.toString()})`);
@@ -392,14 +403,14 @@ describe('`Result` pure functions', () => {
       expect(result.toString(anErr)).toEqual(`Err(${errValue.toString()})`);
     });
 
-    test('custom `toString`s', () => {
+    test("custom `toString`s", () => {
       const withNotAFunction = {
-        whyThough: 'because JS bro',
-        toString: '🤨',
+        whyThough: "because JS bro",
+        toString: "🤨",
       };
 
       expect(result.toString(Result.ok(withNotAFunction))).toEqual(
-        `Ok(${JSON.stringify(withNotAFunction)})`
+        `Ok(${JSON.stringify(withNotAFunction)})`,
       );
 
       const withBadFunction = {
@@ -410,20 +421,20 @@ describe('`Result` pure functions', () => {
       };
 
       expect(result.toString(Result.err(withBadFunction))).toEqual(
-        `Err(${JSON.stringify(withBadFunction)})`
+        `Err(${JSON.stringify(withBadFunction)})`,
       );
     });
   });
 
-  test('`toJSON`', () => {
-    const theValue = { thisIsReally: 'something', b: null };
+  test("`toJSON`", () => {
+    const theValue = { thisIsReally: "something", b: null };
     const anOk = result.ok(theValue);
     expect(result.toJSON(anOk)).toEqual({
       variant: Variant.Ok,
       value: theValue,
     });
 
-    const errValue = ['oh', 'no', null];
+    const errValue = ["oh", "no", null];
     const anErr = result.err(errValue);
     expect(result.toJSON(anErr)).toEqual({
       variant: Variant.Err,
@@ -431,9 +442,11 @@ describe('`Result` pure functions', () => {
     });
   });
 
-  test('`toJSON` through serialization', () => {
+  test("`toJSON` through serialization", () => {
     const actualSerializedOk = JSON.stringify(result.ok(42));
-    const actualSerializedErr = JSON.stringify(result.err({ someInfo: 'error' }));
+    const actualSerializedErr = JSON.stringify(
+      result.err({ someInfo: "error" }),
+    );
     const actualSerializedUnitErr = JSON.stringify(result.err());
     const expectedSerializedOk = JSON.stringify({
       variant: Variant.Ok,
@@ -441,7 +454,7 @@ describe('`Result` pure functions', () => {
     });
     const expectedSerializedErr = JSON.stringify({
       variant: Variant.Err,
-      error: { someInfo: 'error' },
+      error: { someInfo: "error" },
     });
     const expectedSerializedUnitErr = JSON.stringify({
       variant: Variant.Err,
@@ -453,11 +466,11 @@ describe('`Result` pure functions', () => {
     expect(actualSerializedUnitErr).toEqual(expectedSerializedUnitErr);
   });
 
-  test('`equals`', () => {
-    const a = result.ok<string, string>('a');
-    const b = result.ok<string, string>('a');
-    const c = result.err<string, string>('error');
-    const d = result.err<string, string>('error');
+  test("`equals`", () => {
+    const a = result.ok<string, string>("a");
+    const b = result.ok<string, string>("a");
+    const c = result.err<string, string>("error");
+    const d = result.err<string, string>("error");
     expect(result.equals(b, a)).toBe(true);
     expect(result.equals(b)(a)).toBe(true);
     expect(result.equals(c, b)).toBe(false);
@@ -466,7 +479,7 @@ describe('`Result` pure functions', () => {
     expect(result.equals(d)(c)).toBe(true);
   });
 
-  test('`ap`', () => {
+  test("`ap`", () => {
     const add = (a: number) => (b: number) => a + b;
     const okAdd = result.ok<typeof add, string>(add);
 
@@ -478,56 +491,56 @@ describe('`Result` pure functions', () => {
     expect(result.ap(okAdd3, result.ok(2))).toEqual(result.ok(5));
   });
 
-  test('isInstance', () => {
-    const ok: unknown = result.ok('yay');
+  test("isInstance", () => {
+    const ok: unknown = result.ok("yay");
     expect(result.isInstance(ok)).toBe(true);
 
-    const err: unknown = result.err('oh no');
+    const err: unknown = result.err("oh no");
     expect(result.isInstance(err)).toBe(true);
 
     const nada: unknown = null;
     expect(result.isInstance(nada)).toBe(false);
 
-    const obj: unknown = { random: 'nonsense' };
+    const obj: unknown = { random: "nonsense" };
     expect(result.isInstance(obj)).toBe(false);
   });
 
-  test('`isOk` with an Ok', () => {
+  test("`isOk` with an Ok", () => {
     const testOk: Result<number, string> = result.ok(42);
 
     if (result.isOk(testOk)) {
       expect(testOk.value).toEqual(42);
     } else {
-      expect.fail('Expected an Ok');
+      expect.fail("Expected an Ok");
     }
   });
 
-  test('`isOk` with an Err', () => {
-    const testErr: Result<number, string> = result.err('');
+  test("`isOk` with an Err", () => {
+    const testErr: Result<number, string> = result.err("");
 
     expect(result.isOk(testErr)).toEqual(false);
   });
 
-  test('`isErr` with an Ok', () => {
+  test("`isErr` with an Ok", () => {
     const testOk: Result<number, string> = result.ok(42);
 
     expect(result.isErr(testOk)).toEqual(false);
   });
 
-  test('`isErr` with an Err', () => {
-    const testErr: Result<number, string> = result.err('');
+  test("`isErr` with an Err", () => {
+    const testErr: Result<number, string> = result.err("");
 
     expect(result.isErr(testErr)).toEqual(true);
   });
 
-  describe('`safe` function', () => {
-    const THE_MESSAGE = 'the error message';
+  describe("`safe` function", () => {
+    const THE_MESSAGE = "the error message";
 
     function example(
       value: number,
       { throwErr: shouldThrow = false }: { throwErr?: boolean } = {
         throwErr: false,
-      }
+      },
     ): string {
       if (shouldThrow) {
         throw new Error(THE_MESSAGE);
@@ -536,13 +549,16 @@ describe('`Result` pure functions', () => {
       return `value was ${value}`;
     }
 
-    describe('without an error handler', () => {
+    describe("without an error handler", () => {
       let safeExample = result.safe(example);
       expectTypeOf(safeExample).toEqualTypeOf<
-        (value: number, should?: { throwErr?: boolean }) => Result<string, unknown>
+        (
+          value: number,
+          should?: { throwErr?: boolean },
+        ) => Result<string, unknown>
       >();
 
-      test('when it throws', () => {
+      test("when it throws", () => {
         let theResult = safeExample(123, { throwErr: true });
         if (theResult.isErr) {
           expect(theResult.error).toBeInstanceOf(Error);
@@ -552,35 +568,40 @@ describe('`Result` pure functions', () => {
         }
       });
 
-      test('when it does not throw', () => {
+      test("when it does not throw", () => {
         let theResult = safeExample(123);
         if (theResult.isOk) {
-          expect(theResult.value).toBe('value was 123');
+          expect(theResult.value).toBe("value was 123");
         } else {
           expect.unreachable();
         }
       });
     });
 
-    describe('with an error handler', () => {
-      let safeExample = result.safe(example, (reason) => JSON.stringify(reason, null, 2));
+    describe("with an error handler", () => {
+      let safeExample = result.safe(example, (reason) =>
+        JSON.stringify(reason, null, 2),
+      );
       expectTypeOf(safeExample).toEqualTypeOf<
-        (value: number, should?: { throwErr?: boolean }) => Result<string, string>
+        (
+          value: number,
+          should?: { throwErr?: boolean },
+        ) => Result<string, string>
       >();
 
-      test('when it throws', () => {
+      test("when it throws", () => {
         let theResult = safeExample(123, { throwErr: true });
         if (theResult.isErr) {
-          expect(theResult.error).toBe('{}'); // stringify is weird
+          expect(theResult.error).toBe("{}"); // stringify is weird
         } else {
           expect.unreachable();
         }
       });
 
-      test('when it does not throw', () => {
+      test("when it does not throw", () => {
         let theResult = safeExample(123);
         if (theResult.isOk) {
-          expect(theResult.value).toBe('value was 123');
+          expect(theResult.value).toBe("value was 123");
         } else {
           expect.unreachable();
         }
@@ -592,7 +613,7 @@ describe('`Result` pure functions', () => {
 // We aren't even really concerned with the "runtime" behavior here, which we
 // know to be correct from other tests. Instead, this test just checks whether
 // the types are narrowed as they should be.
-test('narrowing', () => {
+test("narrowing", () => {
   const oneOk = result.ok();
   if (oneOk.isOk) {
     expectTypeOf(oneOk).toEqualTypeOf<Ok<Unit, never>>();
@@ -617,109 +638,109 @@ test('narrowing', () => {
     expect(anotherErr.error).toBeDefined();
   }
 
-  expect('this type checked, hooray').toBeTruthy();
+  expect("this type checked, hooray").toBeTruthy();
 });
 
-describe('`Ok` instance', () => {
-  test('constructor', () => {
+describe("`Ok` instance", () => {
+  test("constructor", () => {
     const fullyQualifiedOk = Result.ok<number, string>(42);
     expectTypeOf(fullyQualifiedOk).toMatchTypeOf<Result<number, string>>();
 
-    const unqualifiedOk = Result.ok('string');
+    const unqualifiedOk = Result.ok("string");
     expectTypeOf(unqualifiedOk).toMatchTypeOf<Result<string, unknown>>();
 
     expect(() => Result.ok(null)).not.toThrow();
     expect(() => Result.ok(undefined)).not.toThrow();
   });
 
-  test('`value` property', () => {
-    const okValue = 'yay';
+  test("`value` property", () => {
+    const okValue = "yay";
     const theOk = Result.ok(okValue);
 
     if (theOk.isOk) {
       expect(theOk.value).toEqual(okValue);
     } else {
-      expect.fail('Not an Ok');
+      expect.fail("Not an Ok");
     }
   });
 
-  test('`error` property', () => {
-    let result = Result.ok('yeat');
+  test("`error` property", () => {
+    let result = Result.ok("yeat");
 
     if (result.isErr) {
-      expectTypeOf<(typeof result)['error']>().toBeNever();
+      expectTypeOf<(typeof result)["error"]>().toBeNever();
     }
     if (result.isOk) {
       // @ts-expect-error
       expect(() => result.error).toThrow();
     } else {
-      expect('wrong branch').toEqual(true);
+      expect("wrong branch").toEqual(true);
     }
   });
 
-  test('`isOk` method', () => {
+  test("`isOk` method", () => {
     const theOk = Result.ok({});
     expect(theOk.isOk).toBe(true);
   });
 
-  test('`isErr` method', () => {
+  test("`isErr` method", () => {
     const theOk = Result.ok([]);
     expect(theOk.isErr).toBe(false);
   });
 
-  test('`map` method', () => {
+  test("`map` method", () => {
     const theValue = 10;
     const theOk = Result.ok(theValue);
     const okDoubled = Result.ok(double(theValue));
     expect(theOk.map(double)).toEqual(okDoubled);
   });
 
-  test('`mapOr` method', () => {
-    const theValue = 'neat';
+  test("`mapOr` method", () => {
+    const theValue = "neat";
     const theOk = Result.ok(theValue);
     const defaultValue = 0;
     expect(theOk.mapOr(defaultValue, length)).toEqual(length(theValue));
   });
 
-  test('`mapOrElse` method', () => {
-    const theValue = ['some', 'things'];
+  test("`mapOrElse` method", () => {
+    const theValue = ["some", "things"];
     const theOk: Result<string[], string> = Result.ok(theValue);
     const getDefault = (reason: string) => `reason being, ${reason}`;
-    const join = (strings: string[]) => strings.join(', ');
+    const join = (strings: string[]) => strings.join(", ");
     expect(theOk.mapOrElse(getDefault, join)).toEqual(join(theValue));
   });
 
-  test('`match` method', () => {
-    const theValue = 'ok';
+  test("`match` method", () => {
+    const theValue = "ok";
     const nobody = Result.ok(theValue);
 
     expect(
       nobody.match({
         Ok: (val) => val,
         Err: (err) => err,
-      })
-    ).toBe('ok');
+      }),
+    ).toBe("ok");
   });
 
-  test('`mapErr` method', () => {
-    const theOk: Result<string, string> = Result.ok('hey!');
+  test("`mapErr` method", () => {
+    const theOk: Result<string, string> = Result.ok("hey!");
     const toMoreVerboseErr = (s: string) => `Seriously, ${s} was bad.`;
     expect(theOk.mapErr(toMoreVerboseErr)).toEqual(theOk);
   });
 
-  test('`and` method', () => {
+  test("`and` method", () => {
     const theOk = Result.ok<number, string[]>(100);
 
-    const anotherOk = Result.ok({ not: 'a number' });
+    const anotherOk = Result.ok({ not: "a number" });
     expect(theOk.and(anotherOk)).toBe(anotherOk);
 
-    const anErr = Result.err(['yikes', 'bad']);
+    const anErr = Result.err(["yikes", "bad"]);
     expect(theOk.and(anErr)).toBe(anErr);
   });
 
-  describe('`andThen` method', () => {
-    test('basic functionality', () => {
-      const theValue = 'anything will do';
+  describe("`andThen` method", () => {
+    test("basic functionality", () => {
+      const theValue = "anything will do";
       const theOk = Result.ok<string, number>(theValue);
       const lengthResult = (s: string) => Result.ok(s.length);
       expect(theOk.andThen(lengthResult)).toEqual(lengthResult(theValue));
@@ -728,49 +749,53 @@ describe('`Ok` instance', () => {
       expect(theOk.andThen(convertToErr)).toEqual(convertToErr(theValue));
     });
 
-    test('with multiple types in the `Result` returned', () => {
+    test("with multiple types in the `Result` returned", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
-      let theResult = Result.ok<Branded<'ok'>, Branded<'err'>>(new Branded('ok')).andThen((_) => {
+      let theResult = Result.ok<Branded<"ok">, Branded<"err">>(
+        new Branded("ok"),
+      ).andThen((_) => {
         if (Math.random() < 0.1) {
-          return Result.ok(new Branded('ok-a'));
+          return Result.ok(new Branded("ok-a"));
         }
 
         if (Math.random() < 0.2) {
-          return Result.err(new Branded('err-a'));
+          return Result.err(new Branded("err-a"));
         }
 
         if (Math.random() < 0.3) {
-          return Result.ok(new Branded('ok-b'));
+          return Result.ok(new Branded("ok-b"));
         }
 
-        return Result.err(new Branded('err-b'));
+        return Result.err(new Branded("err-b"));
       });
 
       if (theResult.isOk) {
-        expectTypeOf(theResult.value).toEqualTypeOf<Branded<'ok-a'> | Branded<'ok-b'>>();
+        expectTypeOf(theResult.value).toEqualTypeOf<
+          Branded<"ok-a"> | Branded<"ok-b">
+        >();
       } else if (theResult.isErr) {
         expectTypeOf(theResult.error).toEqualTypeOf<
-          Branded<'err'> | Branded<'err-a'> | Branded<'err-b'>
+          Branded<"err"> | Branded<"err-a"> | Branded<"err-b">
         >();
       }
     });
   });
 
-  test('`or` method', () => {
+  test("`or` method", () => {
     const theValue = 100;
     const theOk = Result.ok<number, string>(theValue);
     const anotherOk = Result.ok(42);
     expect(theOk.or(anotherOk)).toEqual(theOk);
 
-    const anErr = Result.err<number, string>('something wrong');
+    const anErr = Result.err<number, string>("something wrong");
     expect(theOk.or(anErr)).toEqual(theOk);
   });
 
-  describe('`orElse` method', () => {
-    test('basic functionality', () => {
+  describe("`orElse` method", () => {
+    test("basic functionality", () => {
       const theValue = 1;
       const theOk = Result.ok(theValue);
       const theDefault: string[] = [];
@@ -778,38 +803,42 @@ describe('`Ok` instance', () => {
       expect(theOk.orElse(getTheDefault)).toEqual(theOk);
     });
 
-    test('with multiple types in the `Result` returned', () => {
+    test("with multiple types in the `Result` returned", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
-      let theResult = Result.err<Branded<'ok'>, Branded<'err'>>(new Branded('err')).orElse((_) => {
+      let theResult = Result.err<Branded<"ok">, Branded<"err">>(
+        new Branded("err"),
+      ).orElse((_) => {
         if (Math.random() < 0.1) {
-          return Result.ok(new Branded('ok-a'));
+          return Result.ok(new Branded("ok-a"));
         }
 
         if (Math.random() < 0.2) {
-          return Result.err(new Branded('err-a'));
+          return Result.err(new Branded("err-a"));
         }
 
         if (Math.random() < 0.3) {
-          return Result.ok(new Branded('ok-b'));
+          return Result.ok(new Branded("ok-b"));
         }
 
-        return Result.err(new Branded('err-b'));
+        return Result.err(new Branded("err-b"));
       });
 
       if (theResult.isOk) {
         expectTypeOf(theResult.value).toEqualTypeOf<
-          Branded<'ok'> | Branded<'ok-a'> | Branded<'ok-b'>
+          Branded<"ok"> | Branded<"ok-a"> | Branded<"ok-b">
         >();
       } else if (theResult.isErr) {
-        expectTypeOf(theResult.error).toEqualTypeOf<Branded<'err-a'> | Branded<'err-b'>>();
+        expectTypeOf(theResult.error).toEqualTypeOf<
+          Branded<"err-a"> | Branded<"err-b">
+        >();
       }
     });
   });
 
-  test('`value` property', () => {
+  test("`value` property", () => {
     const theValue = 42;
     const theOk = Result.ok(theValue);
 
@@ -817,22 +846,22 @@ describe('`Ok` instance', () => {
       expect(() => theOk.value).not.toThrow();
       expect(theOk.value).toEqual(theValue);
     } else {
-      expect.fail('Not an Ok');
+      expect.fail("Not an Ok");
     }
   });
 
-  test('`error` property', () => {
-    const theOk = Result.ok('anything');
+  test("`error` property", () => {
+    const theOk = Result.ok("anything");
 
     if (theOk.isOk) {
       // @ts-expect-error
       expect(() => theOk.error).toThrow();
     } else {
-      expect.fail('Not an Ok');
+      expect.fail("Not an Ok");
     }
   });
 
-  test('`unwrapOr` method', () => {
+  test("`unwrapOr` method", () => {
     const theValue = [1, 2, 3];
     const theOk = Result.ok(theValue);
     const defaultValue: typeof theValue = [];
@@ -840,7 +869,7 @@ describe('`Ok` instance', () => {
     expect(theOk.unwrapOr(defaultValue)).toBe(theValue);
   });
 
-  test('`unwrapOrElse` method', () => {
+  test("`unwrapOrElse` method", () => {
     const theValue = [1, 2, 3];
     const theOk = Result.ok(theValue);
     const defaultValue: typeof theValue = [];
@@ -849,29 +878,29 @@ describe('`Ok` instance', () => {
     expect(theOk.unwrapOrElse(getDefault)).toBe(theValue);
   });
 
-  test('`toString` method', () => {
+  test("`toString` method", () => {
     const theValue = 42;
     const theOk = Result.ok(theValue);
     expect(theOk.toString()).toEqual(`Ok(${theValue.toString()})`);
   });
 
-  test('`toJSON` method', () => {
+  test("`toJSON` method", () => {
     const theValue = 42;
     const theOk = Result.ok(theValue);
     expect(theOk.toJSON()).toEqual({ variant: Variant.Ok, value: theValue });
   });
 
-  test('`ap` method', () => {
+  test("`ap` method", () => {
     const fn = Result.ok<(val: string) => number, string>((str) => str.length);
-    const val = Result.ok<string, string>('three');
+    const val = Result.ok<string, string>("three");
 
     const result = fn.ap(val);
 
     expect(result.toString()).toEqual(`Ok(5)`);
   });
 
-  test('`cast` method', () => {
-    const val = Result.ok<string, string>('hello');
+  test("`cast` method", () => {
+    const val = Result.ok<string, string>("hello");
 
     // In the fully general `.cast()` case, we expect both sides to end up as
     // `unknown`, though in a bit of a surprising way:
@@ -897,8 +926,8 @@ describe('`Ok` instance', () => {
       return result.isOk ? Result.ok(result.value.length) : result.cast();
     }
 
-    let anOk = Result.ok<string, string>('true');
-    let anErr = Result.err<string, string>('false');
+    let anOk = Result.ok<string, string>("true");
+    let anErr = Result.err<string, string>("false");
 
     expect(castOk(anOk)).toBe(anOk);
     expect(castOk(anErr)).not.toBe(anErr);
@@ -908,12 +937,12 @@ describe('`Ok` instance', () => {
   });
 });
 
-describe('`result.Err` class', () => {
-  test('constructor', () => {
+describe("`result.Err` class", () => {
+  test("constructor", () => {
     const fullyQualifiedErr = Result.err<string, number>(42);
     expectTypeOf(fullyQualifiedErr).toMatchTypeOf<Result<string, number>>();
 
-    const unqualifiedErr = Result.err('string');
+    const unqualifiedErr = Result.err("string");
     expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<unknown, string>>();
     expectTypeOf(unqualifiedErr).toMatchTypeOf<Result<never, string>>();
 
@@ -921,65 +950,66 @@ describe('`result.Err` class', () => {
     expect(() => Result.err(undefined)).not.toThrow();
   });
 
-  test('`error` property', () => {
-    const errValue = 'boo';
+  test("`error` property", () => {
+    const errValue = "boo";
     const theErr = Result.err(errValue);
 
     if (theErr.isErr) {
       expect(theErr.error).toBe(errValue);
     } else {
-      expect.fail('Not an Err');
+      expect.fail("Not an Err");
     }
   });
 
-  test('`isOk` method', () => {
-    const theErr = Result.err('oh my!');
+  test("`isOk` method", () => {
+    const theErr = Result.err("oh my!");
     expect(theErr.isOk).toBe(false);
   });
 
-  test('`isErr` method', () => {
-    const theErr = Result.err('oh my!');
+  test("`isErr` method", () => {
+    const theErr = Result.err("oh my!");
     expect(theErr.isErr).toBe(true);
   });
 
-  test('`map` method', () => {
-    const errValue = '1 billion things wrong';
+  test("`map` method", () => {
+    const errValue = "1 billion things wrong";
     const theErr = Result.err<number, string>(errValue);
     expect(theErr.map((n) => n + 2)).toEqual(theErr);
   });
 
-  test('`mapOr` method', () => {
+  test("`mapOr` method", () => {
     const errValue: number = 42;
     const theErr: Result<number, number> = Result.err(errValue);
-    const theDefault = 'victory!';
+    const theDefault = "victory!";
     const describe = (code: number) => `The error code was ${code}`;
 
     expect(theErr.mapOr(theDefault, describe)).toEqual(theDefault);
   });
 
-  test('`mapOrElse` method', () => {
+  test("`mapOrElse` method", () => {
     const errValue: number = 42;
     const theErr: Result<number, number> = Result.err(errValue);
-    const getDefault = (valueFromErr: typeof errValue) => `whoa: ${valueFromErr}`;
+    const getDefault = (valueFromErr: typeof errValue) =>
+      `whoa: ${valueFromErr}`;
     const describe = (code: number) => `The error code was ${code}`;
 
     expect(theErr.mapOrElse(getDefault, describe)).toEqual(`whoa: ${errValue}`);
   });
 
-  test('`match` method', () => {
-    const human = 'human';
+  test("`match` method", () => {
+    const human = "human";
     const toErrIs = Result.err(human);
 
     expect(
       toErrIs.match({
         Ok: (val) => val,
         Err: (err) => err,
-      })
+      }),
     ).toBe(human);
   });
 
-  test('`mapErr` method', () => {
-    const errValue: string = 'fubar';
+  test("`mapErr` method", () => {
+    const errValue: string = "fubar";
     const theErr = Result.err(errValue);
     const elaborate = (reason: typeof errValue) => `The problem was: ${reason}`;
     const expected = Result.err(elaborate(errValue));
@@ -987,60 +1017,65 @@ describe('`result.Err` class', () => {
     expect(theErr.mapErr(elaborate)).toEqual(expected);
   });
 
-  test('`and` method', () => {
-    const theErr = Result.err('blarg');
+  test("`and` method", () => {
+    const theErr = Result.err("blarg");
 
-    const anOk = result.ok<string, string>('neat');
+    const anOk = result.ok<string, string>("neat");
     expect(theErr.and(anOk)).toEqual(theErr);
 
-    const anotherErr = result.err('oh no');
+    const anotherErr = result.err("oh no");
     expect(theErr.and(anotherErr)).toEqual(theErr);
   });
 
-  describe('`andThen` method', () => {
-    test('basic functionality', () => {
+  describe("`andThen` method", () => {
+    test("basic functionality", () => {
       const theErr = Result.err<string[], number>(42);
 
-      const getAnOk = (strings: string[]) => result.ok<number, number>(length(strings));
+      const getAnOk = (strings: string[]) =>
+        result.ok<number, number>(length(strings));
       expect(theErr.andThen(getAnOk)).toEqual(theErr);
 
       const getAnErr = (_: unknown) => result.err(0);
       expect(theErr.andThen(getAnErr)).toEqual(theErr);
     });
 
-    test('with multiple types in the `Result` returned', () => {
+    test("with multiple types in the `Result` returned", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
-      let theResult = Result.ok<Branded<'ok'>, Branded<'err'>>(new Branded('ok')).andThen((_) => {
+      let theResult = Result.ok<Branded<"ok">, Branded<"err">>(
+        new Branded("ok"),
+      ).andThen((_) => {
         if (Math.random() < 0.1) {
-          return Result.ok(new Branded('ok-a'));
+          return Result.ok(new Branded("ok-a"));
         }
 
         if (Math.random() < 0.2) {
-          return Result.err(new Branded('err-a'));
+          return Result.err(new Branded("err-a"));
         }
 
         if (Math.random() < 0.3) {
-          return Result.ok(new Branded('ok-b'));
+          return Result.ok(new Branded("ok-b"));
         }
 
-        return Result.err(new Branded('err-b'));
+        return Result.err(new Branded("err-b"));
       });
 
       if (theResult.isOk) {
-        expectTypeOf(theResult.value).toEqualTypeOf<Branded<'ok-a'> | Branded<'ok-b'>>();
+        expectTypeOf(theResult.value).toEqualTypeOf<
+          Branded<"ok-a"> | Branded<"ok-b">
+        >();
       } else if (theResult.isErr) {
         expectTypeOf(theResult.error).toEqualTypeOf<
-          Branded<'err'> | Branded<'err-a'> | Branded<'err-b'>
+          Branded<"err"> | Branded<"err-a"> | Branded<"err-b">
         >();
       }
     });
   });
 
-  test('`or` method', () => {
-    const theErr: Result<number, string> = Result.err('a shame');
+  test("`or` method", () => {
+    const theErr: Result<number, string> = Result.err("a shame");
     const anOk: Result<number, string> = result.ok(42);
     expect(theErr.or(anOk)).toBe(anOk);
 
@@ -1048,110 +1083,115 @@ describe('`result.Err` class', () => {
     expect(theErr.or(anotherErr)).toBe(anotherErr);
   });
 
-  describe('`orElse` method', () => {
-    test('basic functionality', () => {
-      const theErr = Result.err<string, string>('what sorrow');
-      const theOk = result.ok<string, string>('neat!');
+  describe("`orElse` method", () => {
+    test("basic functionality", () => {
+      const theErr = Result.err<string, string>("what sorrow");
+      const theOk = result.ok<string, string>("neat!");
       const getOk = () => theOk;
       expect(theErr.orElse(getOk)).toBe(theOk);
 
-      const anotherErr = result.err<string, string>('even worse');
+      const anotherErr = result.err<string, string>("even worse");
       const getAnotherErr = () => anotherErr;
       expect(theErr.orElse(getAnotherErr)).toBe(anotherErr);
     });
 
-    test('with multiple types in the `Result` returned', () => {
+    test("with multiple types in the `Result` returned", () => {
       class Branded<T extends string> {
         constructor(public readonly name: T) {}
       }
 
-      let theResult = Result.err<Branded<'ok'>, Branded<'err'>>(new Branded('err')).orElse((_) => {
+      let theResult = Result.err<Branded<"ok">, Branded<"err">>(
+        new Branded("err"),
+      ).orElse((_) => {
         if (Math.random() < 0.1) {
-          return Result.ok(new Branded('ok-a'));
+          return Result.ok(new Branded("ok-a"));
         }
 
         if (Math.random() < 0.2) {
-          return Result.err(new Branded('err-a'));
+          return Result.err(new Branded("err-a"));
         }
 
         if (Math.random() < 0.3) {
-          return Result.ok(new Branded('ok-b'));
+          return Result.ok(new Branded("ok-b"));
         }
 
-        return Result.err(new Branded('err-b'));
+        return Result.err(new Branded("err-b"));
       });
 
       if (theResult.isOk) {
         expectTypeOf(theResult.value).toEqualTypeOf<
-          Branded<'ok'> | Branded<'ok-a'> | Branded<'ok-b'>
+          Branded<"ok"> | Branded<"ok-a"> | Branded<"ok-b">
         >();
       } else if (theResult.isErr) {
-        expectTypeOf(theResult.error).toEqualTypeOf<Branded<'err-a'> | Branded<'err-b'>>();
+        expectTypeOf(theResult.error).toEqualTypeOf<
+          Branded<"err-a"> | Branded<"err-b">
+        >();
       }
     });
   });
 
-  test('`value` property', () => {
-    const theErr = Result.err('a pity');
+  test("`value` property", () => {
+    const theErr = Result.err("a pity");
 
     if (theErr.isErr) {
       // @ts-expect-error
       expect(() => theErr.value).toThrow();
     } else {
-      expect.fail('Not an Err');
+      expect.fail("Not an Err");
     }
   });
 
-  test('`error` property', () => {
-    const theReason = 'phooey';
+  test("`error` property", () => {
+    const theReason = "phooey";
     const theErr = Result.err(theReason);
     if (theErr.isErr) {
       expect(() => theErr.error).not.toThrow();
       expect(theErr.error).toBe(theReason);
     } else {
-      expect.fail('Not an Err');
+      expect.fail("Not an Err");
     }
   });
 
-  test('`unwrapOr` method', () => {
-    const theErr = Result.err<number, string>('whatever');
+  test("`unwrapOr` method", () => {
+    const theErr = Result.err<number, string>("whatever");
     const theDefault = 0;
     expect(theErr.unwrapOr(theDefault)).toBe(theDefault);
   });
 
-  test('`unwrapOrElse` method', () => {
-    const theReason = 'alas';
+  test("`unwrapOrElse` method", () => {
+    const theReason = "alas";
     const theErr = Result.err<number, string>(theReason);
     expect(theErr.unwrapOrElse(length)).toEqual(length(theReason));
   });
 
-  test('`toString` method', () => {
-    const theErrValue = { something: 'sad' };
+  test("`toString` method", () => {
+    const theErrValue = { something: "sad" };
     const theErr = Result.err(theErrValue);
     expect(theErr.toString()).toEqual(`Err(${theErrValue.toString()})`);
   });
 
-  test('`toJSON` method', () => {
-    const theError = 'test';
+  test("`toJSON` method", () => {
+    const theError = "test";
     const theErr = Result.err(theError);
     expect(theErr.toJSON()).toEqual({ variant: Variant.Err, error: theError });
   });
 
-  test('`equals` method', () => {
-    const a = Result.ok('a');
-    const b = Result.ok<string, string>('a');
-    const c = Result.err<string, string>('err');
-    const d = Result.err<string, string>('err');
+  test("`equals` method", () => {
+    const a = Result.ok("a");
+    const b = Result.ok<string, string>("a");
+    const c = Result.err<string, string>("err");
+    const d = Result.err<string, string>("err");
     expect(b.equals(a)).toBe(true);
     expect(b.equals(c)).toBe(false);
     expect(c.equals(d)).toBe(true);
   });
 
-  test('`ap` method', () => {
-    const fn: Result<(val: string) => number, string> = Result.err<(val: string) => number, string>(
-      'ERR_THESYSTEMISDOWN'
-    );
-    const val: Result<string, string> = Result.err('ERR_ALLURBASE');
+  test("`ap` method", () => {
+    const fn: Result<(val: string) => number, string> = Result.err<
+      (val: string) => number,
+      string
+    >("ERR_THESYSTEMISDOWN");
+    const val: Result<string, string> = Result.err("ERR_ALLURBASE");
 
     const result = fn.ap(val);
 

--- a/test/standard-schema.test.ts
+++ b/test/standard-schema.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-import Result, * as result from 'true-myth/result';
+import Result, * as result from "true-myth/result";
 import {
   type AsyncParserFor,
   asyncParserFor,
@@ -9,8 +9,8 @@ import {
   type ParseTask,
   parserFor,
   StandardSchemaV1,
-} from 'true-myth/standard-schema';
-import { unwrapErr } from 'true-myth/test-support';
+} from "true-myth/standard-schema";
+import { unwrapErr } from "true-myth/test-support";
 
 interface Person {
   name?: string | undefined;
@@ -19,14 +19,14 @@ interface Person {
 
 type CustomParser<O> = (input: unknown) => Result<O, string>;
 
-describe('Standard Schema integration', () => {
-  describe('parserFor', () => {
+describe("Standard Schema integration", () => {
+  describe("parserFor", () => {
     class CustomSchema<O> implements StandardSchemaV1<unknown, O> {
       #parse: CustomParser<O>;
 
-      get ['~standard'](): StandardSchemaV1.Props<O> {
+      get ["~standard"](): StandardSchemaV1.Props<O> {
         return {
-          vendor: 'True Myth tests',
+          vendor: "True Myth tests",
           version: 1,
           validate: (input: unknown) => {
             // Explicit match so TS doesn't ask for the return types to match.
@@ -47,36 +47,42 @@ describe('Standard Schema integration', () => {
 
     const parse = parserFor(
       new CustomSchema((data) => {
-        if (typeof data !== 'object') return result.err('data is not an object');
-        if (data === null) return result.err('data is null');
+        if (typeof data !== "object")
+          return result.err("data is not an object");
+        if (data === null) return result.err("data is null");
 
-        if (!('age' in data)) return result.err('data missing `age` field');
-        if (typeof data.age !== 'number')
-          return result.err(`'data.age' is ${typeof data.age}, should be number`);
+        if (!("age" in data)) return result.err("data missing `age` field");
+        if (typeof data.age !== "number")
+          return result.err(
+            `'data.age' is ${typeof data.age}, should be number`,
+          );
 
         let person: Person = {
           age: data.age,
         };
 
-        if ('name' in data && (data.name === undefined || typeof data.name === 'string')) {
+        if (
+          "name" in data &&
+          (data.name === undefined || typeof data.name === "string")
+        ) {
           person.name = data.name;
         }
 
         return result.ok(person);
-      })
+      }),
     );
 
     expectTypeOf(parse).toEqualTypeOf<ParserFor<Person>>();
 
-    test('with a valid user', () => {
+    test("with a valid user", () => {
       expect(parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-      const withName = parse({ age: 38, name: 'Chris' });
-      expect(withName).toEqual(result.ok({ age: 38, name: 'Chris' }));
+      const withName = parse({ age: 38, name: "Chris" });
+      expect(withName).toEqual(result.ok({ age: 38, name: "Chris" }));
       expectTypeOf(withName).toEqualTypeOf<ParseResult<Person>>();
     });
 
-    test('with an invalid user', () => {
+    test("with an invalid user", () => {
       const theResult = parse({});
       expect(theResult.isErr).toBe(true);
       const theError = unwrapErr(theResult);
@@ -84,22 +90,25 @@ describe('Standard Schema integration', () => {
     });
   });
 
-  describe('asyncParserFor', () => {
-    describe('with an asynchronous parser', () => {
+  describe("asyncParserFor", () => {
+    describe("with an asynchronous parser", () => {
       class CustomAsyncSchema<O> implements StandardSchemaV1<unknown, O> {
         #parse: CustomParser<Promise<O>>;
 
-        get ['~standard'](): StandardSchemaV1.Props<O> {
+        get ["~standard"](): StandardSchemaV1.Props<O> {
           return {
-            vendor: 'True Myth tests',
+            vendor: "True Myth tests",
             version: 1,
             validate: (input: unknown) => {
               // Explicit match so TS doesn't ask for the return types to match.
               // (Note: if we loosen `match` to return different types and produce a
               // union, this explicit match type can be dropped.)
-              return this.#parse(input).match<Promise<StandardSchemaV1.Result<O>>>({
+              return this.#parse(input).match<
+                Promise<StandardSchemaV1.Result<O>>
+              >({
                 Ok: (value) => value.then((value) => ({ value })),
-                Err: (reason) => Promise.resolve({ issues: [{ message: `Nope: ${reason}` }] }),
+                Err: (reason) =>
+                  Promise.resolve({ issues: [{ message: `Nope: ${reason}` }] }),
               });
             },
           };
@@ -112,37 +121,43 @@ describe('Standard Schema integration', () => {
 
       const parse = asyncParserFor(
         new CustomAsyncSchema((data) => {
-          if (typeof data !== 'object') return result.err('data is not an object');
-          if (data === null) return result.err('data is null');
+          if (typeof data !== "object")
+            return result.err("data is not an object");
+          if (data === null) return result.err("data is null");
 
-          if (!('age' in data)) return result.err('data missing `age` field');
-          if (typeof data.age !== 'number')
-            return result.err(`'data.age' is ${typeof data.age}, should be number`);
+          if (!("age" in data)) return result.err("data missing `age` field");
+          if (typeof data.age !== "number")
+            return result.err(
+              `'data.age' is ${typeof data.age}, should be number`,
+            );
 
           let person: Person = {
             age: data.age,
           };
 
-          if ('name' in data && (data.name === undefined || typeof data.name === 'string')) {
+          if (
+            "name" in data &&
+            (data.name === undefined || typeof data.name === "string")
+          ) {
             person.name = data.name;
           }
 
           return result.ok(Promise.resolve(person));
-        })
+        }),
       );
 
       expectTypeOf(parse).toEqualTypeOf<AsyncParserFor<Person>>();
 
-      test('with a valid user', async () => {
+      test("with a valid user", async () => {
         expect(await parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
+        const withName = parse({ age: 38, name: "Chris" });
         expectTypeOf(withName).toEqualTypeOf<ParseTask<Person>>();
         let nameResult = await withName;
-        expect(nameResult).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        expect(nameResult).toEqual(result.ok({ age: 38, name: "Chris" }));
       });
 
-      test('with an invalid user', async () => {
+      test("with an invalid user", async () => {
         const theResult = await parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -150,13 +165,13 @@ describe('Standard Schema integration', () => {
       });
     });
 
-    describe('with a synchronous parser', () => {
+    describe("with a synchronous parser", () => {
       class CustomAsyncSchema<O> implements StandardSchemaV1<unknown, O> {
         #parse: CustomParser<O>;
 
-        get ['~standard'](): StandardSchemaV1.Props<O> {
+        get ["~standard"](): StandardSchemaV1.Props<O> {
           return {
-            vendor: 'True Myth tests',
+            vendor: "True Myth tests",
             version: 1,
             validate: (input: unknown) => {
               // Explicit match so TS doesn't ask for the return types to match.
@@ -177,37 +192,43 @@ describe('Standard Schema integration', () => {
 
       const parse = asyncParserFor(
         new CustomAsyncSchema((data) => {
-          if (typeof data !== 'object') return result.err('data is not an object');
-          if (data === null) return result.err('data is null');
+          if (typeof data !== "object")
+            return result.err("data is not an object");
+          if (data === null) return result.err("data is null");
 
-          if (!('age' in data)) return result.err('data missing `age` field');
-          if (typeof data.age !== 'number')
-            return result.err(`'data.age' is ${typeof data.age}, should be number`);
+          if (!("age" in data)) return result.err("data missing `age` field");
+          if (typeof data.age !== "number")
+            return result.err(
+              `'data.age' is ${typeof data.age}, should be number`,
+            );
 
           let person: Person = {
             age: data.age,
           };
 
-          if ('name' in data && (data.name === undefined || typeof data.name === 'string')) {
+          if (
+            "name" in data &&
+            (data.name === undefined || typeof data.name === "string")
+          ) {
             person.name = data.name;
           }
 
           return result.ok(person);
-        })
+        }),
       );
 
       expectTypeOf(parse).toEqualTypeOf<AsyncParserFor<Person>>();
 
-      test('with a valid user', async () => {
+      test("with a valid user", async () => {
         expect(await parse({ age: 38 })).toEqual(result.ok({ age: 38 }));
 
-        const withName = parse({ age: 38, name: 'Chris' });
+        const withName = parse({ age: 38, name: "Chris" });
         expectTypeOf(withName).toEqualTypeOf<ParseTask<Person>>();
         let nameResult = await withName;
-        expect(nameResult).toEqual(result.ok({ age: 38, name: 'Chris' }));
+        expect(nameResult).toEqual(result.ok({ age: 38, name: "Chris" }));
       });
 
-      test('with an invalid user', async () => {
+      test("with an invalid user", async () => {
         const theResult = await parse({});
         expect(theResult.isErr).toBe(true);
         const theError = unwrapErr(theResult);
@@ -216,13 +237,13 @@ describe('Standard Schema integration', () => {
     });
   });
 
-  test('throws InvalidAsyncSchema when calling parserFor with async schema', () => {
+  test("throws InvalidAsyncSchema when calling parserFor with async schema", () => {
     class BadParser<O> implements StandardSchemaV1<unknown, O> {
       #parse: CustomParser<O>;
 
-      get ['~standard'](): StandardSchemaV1.Props<O> {
+      get ["~standard"](): StandardSchemaV1.Props<O> {
         return {
-          vendor: 'True Myth tests',
+          vendor: "True Myth tests",
           version: 1,
           validate: (input: unknown) => {
             // Explicit match so TS doesn't ask for the return types to match.
@@ -244,16 +265,18 @@ describe('Standard Schema integration', () => {
     }
 
     const BadSchema = new BadParser((val) =>
-      typeof val === 'string' ? result.ok(val) : result.err(`'${val}' is not a string`)
+      typeof val === "string"
+        ? result.ok(val)
+        : result.err(`'${val}' is not a string`),
     );
 
     let badParser = parserFor(BadSchema);
     try {
-      badParser('valid input');
-      expect(false, 'parse should throw'); // should never get here
+      badParser("valid input");
+      expect(false, "parse should throw"); // should never get here
     } catch (e) {
       expect(e instanceof Error);
-      expect((e as Error).name).toEqual('InvalidAsyncSchema');
+      expect((e as Error).name).toEqual("InvalidAsyncSchema");
     }
   });
 });

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, assert, beforeEach, describe, expect, expectTypeOf, test } from 'vitest';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+} from "vitest";
 
 import Task, {
   InvalidAccess,
@@ -39,7 +47,7 @@ import Task, {
   withRetries,
   stopRetrying,
   isRetryFailed,
-} from 'true-myth/task';
+} from "true-myth/task";
 import {
   exponential,
   fibonacci,
@@ -49,15 +57,15 @@ import {
   linear,
   none,
   type Strategy,
-} from 'true-myth/task/delay';
-import Maybe from 'true-myth/maybe';
-import Result from 'true-myth/result';
-import Unit from 'true-myth/unit';
-import { unwrap, unwrapErr } from 'true-myth/test-support';
+} from "true-myth/task/delay";
+import Maybe from "true-myth/maybe";
+import Result from "true-myth/result";
+import Unit from "true-myth/unit";
+import { unwrap, unwrapErr } from "true-myth/test-support";
 
-describe('`Task`', () => {
-  describe('constructor', () => {
-    test('resolve', async () => {
+describe("`Task`", () => {
+  describe("constructor", () => {
+    test("resolve", async () => {
       let theValue = 123;
       let theTask = new Task<number, string>((resolve) => resolve(theValue));
       let result = await theTask;
@@ -66,8 +74,8 @@ describe('`Task`', () => {
       expect(unwrap(result)).toEqual(theValue);
     });
 
-    test('reject', async () => {
-      let theReason = 'oh teh noes';
+    test("reject", async () => {
+      let theReason = "oh teh noes";
       let theTask = new Task<number, string>((_, reject) => reject(theReason));
       let result = await theTask;
       expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
@@ -75,18 +83,18 @@ describe('`Task`', () => {
       expect(unwrapErr(result)).toEqual(theReason);
     });
 
-    test('when an error is thrown', async () => {
+    test("when an error is thrown", async () => {
       // Wire up a promise to wait on this so we can make the test wait till
       // this is done before exiting. Otherwise, the promise may leak across
       // tests.
       let processPromise = new Promise((resolve) => {
-        process.on('unhandledRejection', (error) => {
+        process.on("unhandledRejection", (error) => {
           resolve(error);
         });
       });
 
       new Task<number, string>((_resolve, _reject) => {
-        throw new Error('oh teh noes');
+        throw new Error("oh teh noes");
       });
 
       let output = await processPromise;
@@ -95,77 +103,80 @@ describe('`Task`', () => {
     });
   });
 
-  test('implements the `PromiseLike` API', async () => {
-    let result = await Task.resolve<string, unknown>('hello');
+  test("implements the `PromiseLike` API", async () => {
+    let result = await Task.resolve<string, unknown>("hello");
     expectTypeOf(result).toEqualTypeOf<Result<string, unknown>>();
-    expect(unwrap(result)).toBe('hello');
+    expect(unwrap(result)).toBe("hello");
   });
-  test('assignable to `PromiseLike<Result<A, B>>`', async () => {
-    let result: PromiseLike<Result<string, unknown>> = Task.resolve<string, unknown>('hello');
-    expect(unwrap(await result)).toBe('hello');
+  test("assignable to `PromiseLike<Result<A, B>>`", async () => {
+    let result: PromiseLike<Result<string, unknown>> = Task.resolve<
+      string,
+      unknown
+    >("hello");
+    expect(unwrap(await result)).toBe("hello");
   });
-  test('assignable to `PromiseLike<unknown>`', async () => {
-    let result: PromiseLike<unknown> = Task.resolve<string, unknown>('hello');
-    expect(unwrap(await (result as Task<string, unknown>))).toBe('hello');
+  test("assignable to `PromiseLike<unknown>`", async () => {
+    let result: PromiseLike<unknown> = Task.resolve<string, unknown>("hello");
+    expect(unwrap(await (result as Task<string, unknown>))).toBe("hello");
   });
 
-  describe('static constructors', () => {
-    describe('withResolvers', () => {
-      test('supports resolving', async () => {
+  describe("static constructors", () => {
+    describe("withResolvers", () => {
+      test("supports resolving", async () => {
         let { task, resolve } = Task.withResolvers<string, never>();
         expectTypeOf(task).toEqualTypeOf<Task<string, never>>();
 
-        let theValue = 'hello';
+        let theValue = "hello";
         resolve(theValue);
         let result = await task;
         expect(unwrap(result)).toEqual(theValue);
       });
 
-      test('supports rejecting', async () => {
+      test("supports rejecting", async () => {
         let { task, reject } = Task.withResolvers<never, string>();
         expectTypeOf(task).toEqualTypeOf<Task<never, string>>();
 
-        let theReason = 'le sigh';
+        let theReason = "le sigh";
         reject(theReason);
         let result = await task;
         expect(unwrapErr(result)).toEqual(theReason);
       });
     });
 
-    describe('`resolve`', () => {
-      test('produces `Task<Unit, never>` when passed no arguments', () => {
+    describe("`resolve`", () => {
+      test("produces `Task<Unit, never>` when passed no arguments", () => {
         let theTask = Task.resolve();
         expectTypeOf(theTask).toEqualTypeOf<Task<Unit, never>>();
       });
 
-      test('produces `Task<T, never>` when passed a basic argument', () => {
-        let theValue = 'hello';
+      test("produces `Task<T, never>` when passed a basic argument", () => {
+        let theValue = "hello";
         let theTask = Task.resolve(theValue);
         expectTypeOf(theTask).toEqualTypeOf<Task<typeof theValue, never>>();
       });
 
-      test('allows explicitly setting a type for `E`', () => {
+      test("allows explicitly setting a type for `E`", () => {
         let rejectedWithUnit = Task.resolve<Unit, string>();
         expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<Unit, string>>();
 
-        let rejectedWithValue = Task.resolve<string, number>('hello');
+        let rejectedWithValue = Task.resolve<string, number>("hello");
         expectTypeOf(rejectedWithValue).toEqualTypeOf<Task<string, number>>();
       });
     });
 
-    describe('`reject`', () => {
-      test('produces `Task<never, Unit>` when passed no arguments', () => {
+    describe("`reject`", () => {
+      test("produces `Task<never, Unit>` when passed no arguments", () => {
         let theTask = Task.reject();
         expectTypeOf(theTask).toEqualTypeOf<Task<never, Unit>>();
       });
 
-      test('produces `Task<never, E>` when passed an argument', () => {
-        let theReason = 'uh oh';
+      test("produces `Task<never, E>` when passed an argument", () => {
+        let theReason = "uh oh";
         let theTask = Task.reject(theReason);
         expectTypeOf(theTask).toEqualTypeOf<Task<never, typeof theReason>>();
       });
 
-      test('allows explicitly setting a type for `T`', () => {
+      test("allows explicitly setting a type for `T`", () => {
         let rejectedWithUnit = Task.reject<string>();
         expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<string, Unit>>();
 
@@ -182,7 +193,7 @@ describe('`Task`', () => {
     // We *might* be able to “fast path” that by way of a private constructor, but
     // doing so would make it easy to accidentally touch that internal state
     // without going through the `#promise`, which would be unsafe.
-    test('`fromResult`', async () => {
+    test("`fromResult`", async () => {
       let theResult = Result.ok<number, string>(123);
       let theTask = fromResult(theResult);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -192,20 +203,24 @@ describe('`Task`', () => {
     });
   });
 
-  describe('instance methods', () => {
-    describe('`map`', () => {
-      test('for a pending promise', async () => {
+  describe("instance methods", () => {
+    describe("`map`", () => {
+      test("for a pending promise", async () => {
         let { promise, resolve } = deferred<number, string>();
-        let theTask = tryOrElse(stringify, () => promise).map((n) => n % 2 == 0);
+        let theTask = tryOrElse(stringify, () => promise).map(
+          (n) => n % 2 == 0,
+        );
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
         resolve(123);
         await theTask;
       });
 
-      test('when the promise resolves', async () => {
+      test("when the promise resolves", async () => {
         let { promise, resolve } = deferred<number, string>();
-        let theTask = tryOrElse(stringify, () => promise).map((n) => n % 2 == 0);
+        let theTask = tryOrElse(stringify, () => promise).map(
+          (n) => n % 2 == 0,
+        );
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
         resolve(123);
@@ -213,26 +228,28 @@ describe('`Task`', () => {
         expect(unwrap(result)).toBe(false);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { promise, reject } = deferred<number, string>();
-        let theTask = tryOrElse(stringify, () => promise).map((n) => n % 2 == 0);
+        let theTask = tryOrElse(stringify, () => promise).map(
+          (n) => n % 2 == 0,
+        );
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(stringify(theReason));
       });
     });
 
-    describe('`mapRejected`', () => {
-      test('for a pending promise', async () => {
+    describe("`mapRejected`", () => {
+      test("for a pending promise", async () => {
         let { promise } = deferred<number, string>();
         let theTask = fromPromise(promise).mapRejected(stringify);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
       });
 
-      test('when the promise resolves', async () => {
+      test("when the promise resolves", async () => {
         let { promise, resolve } = deferred<number, string>();
         let theTask = fromPromise(promise).mapRejected(stringify);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -242,39 +259,41 @@ describe('`Task`', () => {
         expect(unwrap(result)).toBe(123);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { promise, reject } = deferred<number, string>();
         let theTask = fromPromise(promise).mapRejected(stringify);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(stringify(theReason));
       });
     });
 
-    describe('`and`', () => {
-      describe('when the first Task resolves', () => {
-        test('when the second Task resolves', async () => {
-          let theValue = 'hello';
+    describe("`and`", () => {
+      describe("when the first Task resolves", () => {
+        test("when the second Task resolves", async () => {
+          let theValue = "hello";
           let theTask = Task.resolve(123).and(Task.resolve(theValue));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toEqual(theValue);
         });
 
-        test('when the second Task rejects', async () => {
-          let theReason = 'hello';
-          let theTask = Task.resolve<number, string>(123).and(Task.reject(theReason));
+        test("when the second Task rejects", async () => {
+          let theReason = "hello";
+          let theTask = Task.resolve<number, string>(123).and(
+            Task.reject(theReason),
+          );
           expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
       });
 
-      describe('when the first Task rejects', () => {
-        test('when the second Task resolves', async () => {
+      describe("when the first Task rejects", () => {
+        test("when the second Task resolves", async () => {
           let theReason = 123;
           let theTask = Task.reject(theReason).and(Task.resolve(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
@@ -282,7 +301,7 @@ describe('`Task`', () => {
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
 
-        test('when the second Task rejects', async () => {
+        test("when the second Task rejects", async () => {
           let theReason = 123;
           let theTask = Task.reject(theReason).and(Task.reject(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<never, number>>();
@@ -292,11 +311,11 @@ describe('`Task`', () => {
       });
 
       // Matches the text in the docs.
-      test('all combinations', async () => {
-        let resolvedA = Task.resolve('A');
-        let resolvedB = Task.resolve('B');
-        let rejectedA = Task.reject('bad');
-        let rejectedB = Task.reject('lame');
+      test("all combinations", async () => {
+        let resolvedA = Task.resolve("A");
+        let resolvedB = Task.resolve("B");
+        let rejectedA = Task.reject("bad");
+        let rejectedB = Task.reject("lame");
 
         let aAndB = resolvedA.and(resolvedB);
         await aAndB;
@@ -317,129 +336,244 @@ describe('`Task`', () => {
       });
     });
 
-    describe('`andThen`', () => {
-      test('for a pending promise', async () => {
-        let { promise, resolve } = deferred<number, string>();
-        let theTask = tryOrElse(stringify, () => promise).andThen((n) => Task.resolve(n % 2 == 0));
-        expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
-
-        resolve(123);
-        await theTask;
-      });
-
-      describe('when the first `Task` resolves', () => {
-        test('when the second is pending', async () => {
-          let theTask = Task.resolve(123).andThen((n) => {
-            return new Task<number, string>((resolve) => {
-              resolve(Math.round(n / 2));
-            });
-          });
-
-          expect(theTask.state).toBe(State.Pending);
-          let theResult = await theTask;
-          expect(theTask.state).toBe(State.Resolved);
-          expect(unwrap(theResult)).toEqual(62);
-        });
-
-        test('when the second `Task` resolves', async () => {
+    describe("`andThen`", () => {
+      describe("with a `Task`", () => {
+        test("for a pending promise", async () => {
           let { promise, resolve } = deferred<number, string>();
           let theTask = tryOrElse(stringify, () => promise).andThen((n) =>
-            Task.resolve(n % 2 == 0)
+            Task.resolve(n % 2 == 0),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
           resolve(123);
-          let result = await theTask;
-          expect(unwrap(result)).toBe(false);
+          await theTask;
         });
 
-        test('when the second `Task` rejects', async () => {
-          let { promise, resolve } = deferred<number, string>();
-          let theTask = tryOrElse(stringify, () => promise).andThen(() => Task.reject('oh no'));
-          expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
-
-          resolve(123);
-          let result = await theTask;
-          expect(unwrapErr(result)).toBe('oh no');
-        });
-      });
-
-      describe('when the first `Task` rejects', () => {
-        test('when the second is pending', async () => {
-          let theReason = 'alas!';
-          let theTask = Task.reject(theReason).andThen((n) => {
-            return new Task<number, string>((resolve) => {
-              resolve(Math.round(n / 2));
+        describe("when the first `Task` resolves", () => {
+          test("when the second is pending", async () => {
+            let theTask = Task.resolve(123).andThen((n) => {
+              return new Task<number, string>((resolve) => {
+                resolve(Math.round(n / 2));
+              });
             });
+
+            expect(theTask.state).toBe(State.Pending);
+            let theResult = await theTask;
+            expect(theTask.state).toBe(State.Resolved);
+            expect(unwrap(theResult)).toEqual(62);
           });
 
-          expect(theTask.state).toBe(State.Pending);
-          let theResult = await theTask;
-          expect(theTask.state).toBe(State.Rejected);
-          expect(unwrapErr(theResult)).toEqual(theReason);
+          test("when the second `Task` resolves", async () => {
+            let { promise, resolve } = deferred<number, string>();
+            let theTask = tryOrElse(stringify, () => promise).andThen((n) =>
+              Task.resolve(n % 2 == 0),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+            resolve(123);
+            let result = await theTask;
+            expect(unwrap(result)).toBe(false);
+          });
+
+          test("when the second `Task` rejects", async () => {
+            let { promise, resolve } = deferred<number, string>();
+            let theTask = tryOrElse(stringify, () => promise).andThen(() =>
+              Task.reject("oh no"),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
+
+            resolve(123);
+            let result = await theTask;
+            expect(unwrapErr(result)).toBe("oh no");
+          });
         });
 
-        test('when the second `Task` resolves', async () => {
-          let { promise, reject } = deferred<number, string>();
-          let theTask = fromPromise(promise).andThen((n) => Task.resolve(n % 2 == 0));
-          expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
+        describe("when the first `Task` rejects", () => {
+          test("when the second is pending", async () => {
+            let theReason = "alas!";
+            let theTask = Task.reject(theReason).andThen((n) => {
+              return new Task<number, string>((resolve) => {
+                resolve(Math.round(n / 2));
+              });
+            });
 
-          let theReason = 'nope';
-          reject(theReason);
-          let result = await theTask;
-          expect(unwrapErr(result)).toEqual(theReason);
+            expect(theTask.state).toBe(State.Pending);
+            let theResult = await theTask;
+            expect(theTask.state).toBe(State.Rejected);
+            expect(unwrapErr(theResult)).toEqual(theReason);
+          });
+
+          test("when the second `Task` resolves", async () => {
+            let { promise, reject } = deferred<number, string>();
+            let theTask = fromPromise(promise).andThen((n) =>
+              Task.resolve(n % 2 == 0),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
+
+            let theReason = "nope";
+            reject(theReason);
+            let result = await theTask;
+            expect(unwrapErr(result)).toEqual(theReason);
+          });
+
+          test("when the second `Task` rejects", async () => {
+            let theReason = "nope";
+            let theTask = Task.reject<number, string>(theReason).andThen((n) =>
+              Task.reject(n % 2 == 0 ? "yep" : "nope"),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
+
+            let result = await theTask;
+            expect(unwrapErr(result)).toEqual(theReason);
+          });
         });
 
-        test('when the second `Task` rejects', async () => {
-          let theReason = 'nope';
-          let theTask = Task.reject<number, string>(theReason).andThen((n) =>
-            Task.reject(n % 2 == 0 ? 'yep' : 'nope')
-          );
-          expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
+        test("with multiple types in the resolution and rejection", async () => {
+          class Branded<T extends string> {
+            declare readonly _name: T;
+          }
 
-          let result = await theTask;
-          expect(unwrapErr(result)).toEqual(theReason);
+          class RejA extends Branded<"rej-a"> {}
+          class RejB extends Branded<"rej-b"> {}
+
+          class ResA extends Branded<"res-a"> {}
+          class ResB extends Branded<"res-b"> {}
+
+          let theTask = new Task<Branded<"res">, Branded<"rej">>(
+            () => {},
+          ).andThen((_) => {
+            if (Math.random() < 0.1) {
+              return Task.resolve(new ResA());
+            }
+
+            if (Math.random() < 0.2) {
+              return Task.reject(new RejA());
+            }
+
+            if (Math.random() < 0.3) {
+              return Task.resolve(new ResB());
+            }
+
+            return Task.reject(new RejB());
+          });
+
+          if (theTask.isResolved) {
+            expectTypeOf(theTask.value).toEqualTypeOf<ResA | ResB>();
+          } else if (theTask.isRejected) {
+            expectTypeOf(theTask.reason).toEqualTypeOf<
+              Branded<"rej"> | RejA | RejB
+            >();
+          }
         });
       });
 
-      test('with multiple types in the resolution and rejection', async () => {
-        class Branded<T extends string> {
-          declare readonly _name: T;
-        }
+      describe("with a `Result`", () => {
+        test("for a pending promise", async () => {
+          let { promise, resolve } = deferred<number, string>();
+          let theTask = tryOrElse(stringify, () => promise).andThen((n) =>
+            Result.ok(n % 2 == 0),
+          );
+          expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
-        class RejA extends Branded<'rej-a'> {}
-        class RejB extends Branded<'rej-b'> {}
-
-        class ResA extends Branded<'res-a'> {}
-        class ResB extends Branded<'res-b'> {}
-
-        let theTask = new Task<Branded<'res'>, Branded<'rej'>>(() => {}).andThen((_) => {
-          if (Math.random() < 0.1) {
-            return Task.resolve(new ResA());
-          }
-
-          if (Math.random() < 0.2) {
-            return Task.reject(new RejA());
-          }
-
-          if (Math.random() < 0.3) {
-            return Task.resolve(new ResB());
-          }
-
-          return Task.reject(new RejB());
+          resolve(123);
+          await theTask;
         });
 
-        if (theTask.isResolved) {
-          expectTypeOf(theTask.value).toEqualTypeOf<ResA | ResB>();
-        } else if (theTask.isRejected) {
-          expectTypeOf(theTask.reason).toEqualTypeOf<Branded<'rej'> | RejA | RejB>();
-        }
+        describe("when the first `Task` resolves", () => {
+          test("when the `Result` is an `Ok`", async () => {
+            let { promise, resolve } = deferred<number, string>();
+            let theTask = tryOrElse(stringify, () => promise).andThen((n) =>
+              Result.ok(n % 2 == 0),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
+
+            resolve(123);
+            let result = await theTask;
+            expect(unwrap(result)).toBe(false);
+          });
+
+          test("when the `Result` is an `Err`", async () => {
+            let { promise, resolve } = deferred<number, string>();
+            let theTask = tryOrElse(stringify, () => promise).andThen(() =>
+              Result.err("oh no"),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
+
+            resolve(123);
+            let result = await theTask;
+            expect(unwrapErr(result)).toBe("oh no");
+          });
+        });
+
+        describe("when the `Task` rejects", () => {
+          test("when the `Result` is an `Result.Ok`", async () => {
+            let { promise, reject } = deferred<number, string>();
+            let theTask = fromPromise(promise).andThen((n) =>
+              Result.ok(n % 2 == 0),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
+
+            let theReason = "nope";
+            reject(theReason);
+            let result = await theTask;
+            expect(unwrapErr(result)).toEqual(theReason);
+          });
+
+          test("when the `Result` is an `Err`", async () => {
+            let theReason = "nope";
+            let theTask = Task.reject<number, string>(theReason).andThen((n) =>
+              Result.err(n % 2 == 0 ? "yep" : "nope"),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
+
+            let result = await theTask;
+            expect(unwrapErr(result)).toEqual(theReason);
+          });
+        });
+
+        test("with multiple types in the resolution and rejection", async () => {
+          class Branded<T extends string> {
+            declare readonly _name: T;
+          }
+
+          class RejA extends Branded<"rej-a"> {}
+          class RejB extends Branded<"rej-b"> {}
+
+          class ResA extends Branded<"res-a"> {}
+          class ResB extends Branded<"res-b"> {}
+
+          let theTask = new Task<Branded<"res">, Branded<"rej">>(
+            () => {},
+          ).andThen((_) => {
+            if (Math.random() < 0.1) {
+              return Result.ok(new ResA());
+            }
+
+            if (Math.random() < 0.2) {
+              return Result.err(new RejA());
+            }
+
+            if (Math.random() < 0.3) {
+              return Result.ok(new ResB());
+            }
+
+            return Result.err(new RejB());
+          });
+
+          if (theTask.isResolved) {
+            expectTypeOf(theTask.value).toEqualTypeOf<ResA | ResB>();
+          } else if (theTask.isRejected) {
+            expectTypeOf(theTask.reason).toEqualTypeOf<
+              Branded<"rej"> | RejA | RejB
+            >();
+          }
+        });
       });
     });
 
-    describe('`or`', () => {
-      describe('when the first Task resolves', async () => {
-        test('when the second is pending', async () => {
+    describe("`or`", () => {
+      describe("when the first Task resolves", async () => {
+        test("when the second is pending", async () => {
           let theFirst = Task.resolve(123);
           let theSecond = new Task<number, never>(noOp);
 
@@ -453,15 +587,15 @@ describe('`Task`', () => {
           expect(theChain.state).toBe(State.Resolved);
         });
 
-        test('when the second Task resolves', async () => {
+        test("when the second Task resolves", async () => {
           let theTask = Task.resolve(123).or(Task.resolve(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toEqual(123);
         });
 
-        test('when the second Task rejects', async () => {
-          let theReason = 'hello';
+        test("when the second Task rejects", async () => {
+          let theReason = "hello";
           let theTask = Task.resolve(123).or(Task.reject(theReason));
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
@@ -469,9 +603,9 @@ describe('`Task`', () => {
         });
       });
 
-      describe('when the first Task rejects', () => {
-        test('when the second is pending', async () => {
-          let theFirst = Task.reject('blergh');
+      describe("when the first Task rejects", () => {
+        test("when the second is pending", async () => {
+          let theFirst = Task.reject("blergh");
           let theSecond = new Task<number, never>(noOp);
 
           let theChain = theFirst.or(theSecond);
@@ -484,14 +618,14 @@ describe('`Task`', () => {
           expect(theChain.state).toBe(State.Pending);
         });
 
-        test('when the second Task resolves', async () => {
-          let theTask = Task.reject(123).or(Task.resolve('hello'));
+        test("when the second Task resolves", async () => {
+          let theTask = Task.reject(123).or(Task.resolve("hello"));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
-          expect(unwrap(theResult)).toBe('hello');
+          expect(unwrap(theResult)).toBe("hello");
         });
 
-        test('when the second Task rejects', async () => {
+        test("when the second Task rejects", async () => {
           let theReason = 123;
           let theTask = Task.reject(theReason).or(Task.reject(456));
           expectTypeOf(theTask).toEqualTypeOf<Task<never, number>>();
@@ -501,11 +635,11 @@ describe('`Task`', () => {
       });
 
       // Matches the text in the docs.
-      test('all combinations', async () => {
-        let resolvedA = Task.resolve('A');
-        let resolvedB = Task.resolve('B');
-        let rejectedA = Task.reject('bad');
-        let rejectedB = Task.reject('lame');
+      test("all combinations", async () => {
+        let resolvedA = Task.resolve("A");
+        let resolvedB = Task.resolve("B");
+        let rejectedA = Task.reject("bad");
+        let rejectedB = Task.reject("lame");
 
         let aOrB = resolvedA.or(resolvedB);
         await aOrB;
@@ -526,125 +660,224 @@ describe('`Task`', () => {
       });
     });
 
-    describe('`orElse`', () => {
-      test('for a pending promise', async () => {
-        let theTask = new Task<number, string>(noOp).orElse((reason) =>
-          Task.resolve(reason.length)
-        );
-        expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
-
-        expect(theTask.state).toBe(State.Pending);
-      });
-
-      describe('when the first `Task` resolves', () => {
-        test('when the second is pending', async () => {
-          let theFirst = Task.resolve(123);
-          let theSecond = new Task<number, boolean>(noOp);
-          let theChain = theFirst.orElse(() => theSecond);
-
-          expect(theFirst.state).toBe(State.Resolved);
-          expect(theSecond.state).toBe(State.Pending);
-          expect(theChain.state).toBe(State.Pending);
-          await theFirst;
-          expect(theFirst.state).toBe(State.Resolved);
-          expect(theSecond.state).toBe(State.Pending);
-          expect(theChain.state).toBe(State.Resolved);
-        });
-
-        test('when the second `Task` resolves', async () => {
-          let theTask = Task.resolve<number, string>(123).orElse((reason) =>
-            Task.resolve(reason.length)
+    describe("`orElse`", () => {
+      describe("with a `Task`", () => {
+        test("for a pending promise", async () => {
+          let theTask = new Task<number, string>(noOp).orElse((reason) =>
+            Task.resolve(reason.length),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
-          let result = await theTask;
-          expect(unwrap(result)).toBe(123);
+          expect(theTask.state).toBe(State.Pending);
         });
 
-        test('when the second `Task` rejects', async () => {
-          let theTask = Task.resolve<number, string>(123).orElse((reason) =>
-            Task.reject(reason.length)
-          );
-          expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
+        describe("when the first `Task` resolves", () => {
+          test("when the second is pending", async () => {
+            let theFirst = Task.resolve(123);
+            let theSecond = new Task<number, boolean>(noOp);
+            let theChain = theFirst.orElse(() => theSecond);
 
-          let result = await theTask;
-          expect(unwrap(result)).toBe(123);
+            expect(theFirst.state).toBe(State.Resolved);
+            expect(theSecond.state).toBe(State.Pending);
+            expect(theChain.state).toBe(State.Pending);
+            await theFirst;
+            expect(theFirst.state).toBe(State.Resolved);
+            expect(theSecond.state).toBe(State.Pending);
+            expect(theChain.state).toBe(State.Resolved);
+          });
+
+          test("when the second `Task` resolves", async () => {
+            let theTask = Task.resolve<number, string>(123).orElse((reason) =>
+              Task.resolve(reason.length),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
+
+            let result = await theTask;
+            expect(unwrap(result)).toBe(123);
+          });
+
+          test("when the second `Task` rejects", async () => {
+            let theTask = Task.resolve<number, string>(123).orElse((reason) =>
+              Task.reject(reason.length),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
+
+            let result = await theTask;
+            expect(unwrap(result)).toBe(123);
+          });
+        });
+
+        describe("when the first `Task` rejects", () => {
+          test("when the second is pending", async () => {
+            let theFirst = Task.reject<number, string>("teh sads");
+            let theSecond = new Task<number, boolean>(noOp);
+            let theChain = theFirst.orElse(() => theSecond);
+
+            expect(theFirst.state).toBe(State.Rejected);
+            expect(theSecond.state).toBe(State.Pending);
+            expect(theChain.state).toBe(State.Pending);
+            await theFirst;
+            expect(theFirst.state).toBe(State.Rejected);
+            expect(theSecond.state).toBe(State.Pending);
+            expect(theChain.state).toBe(State.Pending);
+          });
+
+          test("when the second `Task` resolves", async () => {
+            let theTask = Task.reject<number, string>("nope").orElse((reason) =>
+              Task.resolve(reason.length),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
+
+            let result = await theTask;
+            expect(unwrap(result)).toBe(4);
+          });
+
+          test("when the second `Task` rejects", async () => {
+            let theTask = Task.reject<number, string>("first error").orElse(
+              (reason) => Task.reject(reason.includes("'")),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, boolean>>();
+
+            let result = await theTask;
+            expect(unwrapErr(result)).toBe(false);
+          });
+        });
+
+        test("with multiple types in the resolution and rejection", async () => {
+          class Branded<T extends string> {
+            declare readonly _name: T;
+          }
+
+          class RejA extends Branded<"rej-a"> {}
+          class RejB extends Branded<"rej-b"> {}
+
+          class ResA extends Branded<"res-a"> {}
+          class ResB extends Branded<"res-b"> {}
+
+          let theTask = new Task<Branded<"res">, Branded<"rej">>(
+            () => {},
+          ).orElse((_) => {
+            if (Math.random() < 0.1) {
+              return Task.resolve(new ResA());
+            }
+
+            if (Math.random() < 0.2) {
+              return Task.reject(new RejA());
+            }
+
+            if (Math.random() < 0.3) {
+              return Task.resolve(new ResB());
+            }
+
+            return Task.reject(new RejB());
+          });
+
+          if (theTask.isResolved) {
+            expectTypeOf(theTask.value).toEqualTypeOf<
+              Branded<"res"> | ResA | ResB
+            >();
+          } else if (theTask.isRejected) {
+            expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
+          }
         });
       });
 
-      describe('when the first `Task` rejects', () => {
-        test('when the second is pending', async () => {
-          let theFirst = Task.reject<number, string>('teh sads');
-          let theSecond = new Task<number, boolean>(noOp);
-          let theChain = theFirst.orElse(() => theSecond);
-
-          expect(theFirst.state).toBe(State.Rejected);
-          expect(theSecond.state).toBe(State.Pending);
-          expect(theChain.state).toBe(State.Pending);
-          await theFirst;
-          expect(theFirst.state).toBe(State.Rejected);
-          expect(theSecond.state).toBe(State.Pending);
-          expect(theChain.state).toBe(State.Pending);
-        });
-
-        test('when the second `Task` resolves', async () => {
-          let theTask = Task.reject<number, string>('nope').orElse((reason) =>
-            Task.resolve(reason.length)
+      describe("with a Result", () => {
+        test("for a pending promise", async () => {
+          let theTask = new Task<number, string>(noOp).orElse((reason) =>
+            Result.ok(reason.length),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
-          let result = await theTask;
-          expect(unwrap(result)).toBe(4);
+          expect(theTask.state).toBe(State.Pending);
         });
 
-        test('when the second `Task` rejects', async () => {
-          let theTask = Task.reject<number, string>('first error').orElse((reason) =>
-            Task.reject(reason.includes("'"))
-          );
-          expectTypeOf(theTask).toEqualTypeOf<Task<number, boolean>>();
+        describe("when the `Task` resolves", () => {
+          test("when the `Result` is an `Ok`", async () => {
+            let theTask = Task.resolve<number, string>(123).orElse((reason) =>
+              Result.ok(reason.length),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
-          let result = await theTask;
-          expect(unwrapErr(result)).toBe(false);
-        });
-      });
+            let result = await theTask;
+            expect(unwrap(result)).toBe(123);
+          });
 
-      test('with multiple types in the resolution and rejection', async () => {
-        class Branded<T extends string> {
-          declare readonly _name: T;
-        }
+          test("when the `Result` is an `Err`", async () => {
+            let theTask = Task.resolve<number, string>(123).orElse((reason) =>
+              Result.err(reason.length),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
 
-        class RejA extends Branded<'rej-a'> {}
-        class RejB extends Branded<'rej-b'> {}
-
-        class ResA extends Branded<'res-a'> {}
-        class ResB extends Branded<'res-b'> {}
-
-        let theTask = new Task<Branded<'res'>, Branded<'rej'>>(() => {}).orElse((_) => {
-          if (Math.random() < 0.1) {
-            return Task.resolve(new ResA());
-          }
-
-          if (Math.random() < 0.2) {
-            return Task.reject(new RejA());
-          }
-
-          if (Math.random() < 0.3) {
-            return Task.resolve(new ResB());
-          }
-
-          return Task.reject(new RejB());
+            let result = await theTask;
+            expect(unwrap(result)).toBe(123);
+          });
         });
 
-        if (theTask.isResolved) {
-          expectTypeOf(theTask.value).toEqualTypeOf<Branded<'res'> | ResA | ResB>();
-        } else if (theTask.isRejected) {
-          expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
-        }
+        describe("when the `Task` rejects", () => {
+          test("when the `Result` is an `Ok`", async () => {
+            let theTask = Task.reject<number, string>("nope").orElse((reason) =>
+              Result.ok(reason.length),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
+
+            let result = await theTask;
+            expect(unwrap(result)).toBe(4);
+          });
+
+          test("when the `Result` is an `Err`", async () => {
+            let theTask = Task.reject<number, string>("first error").orElse(
+              (reason) => Result.err(reason.includes("'")),
+            );
+            expectTypeOf(theTask).toEqualTypeOf<Task<number, boolean>>();
+
+            let result = await theTask;
+            expect(unwrapErr(result)).toBe(false);
+          });
+        });
+
+        test("with multiple types in the resolution and rejection", async () => {
+          class Branded<T extends string> {
+            declare readonly _name: T;
+          }
+
+          class RejA extends Branded<"rej-a"> {}
+          class RejB extends Branded<"rej-b"> {}
+
+          class ResA extends Branded<"res-a"> {}
+          class ResB extends Branded<"res-b"> {}
+
+          let theTask = new Task<Branded<"res">, Branded<"rej">>(
+            () => {},
+          ).orElse((_) => {
+            if (Math.random() < 0.1) {
+              return Result.ok(new ResA());
+            }
+
+            if (Math.random() < 0.2) {
+              return Result.err(new RejA());
+            }
+
+            if (Math.random() < 0.3) {
+              return Result.ok(new ResB());
+            }
+
+            return Result.err(new RejB());
+          });
+
+          if (theTask.isResolved) {
+            expectTypeOf(theTask.value).toEqualTypeOf<
+              Branded<"res"> | ResA | ResB
+            >();
+          } else if (theTask.isRejected) {
+            expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
+          }
+        });
       });
     });
 
-    describe('`match`', () => {
-      test('with a resolved task', async () => {
+    describe("`match`", () => {
+      test("with a resolved task", async () => {
         await tryOrElse(stringify, () => Promise.resolve(123)).match({
           Resolved: (value) => expect(value).toBe(123),
           Rejected: (_reason) => expect.unreachable(),
@@ -652,7 +885,7 @@ describe('`Task`', () => {
         expect.assertions(1);
       });
 
-      test('with a rejected task', async () => {
+      test("with a rejected task", async () => {
         await tryOrElse(stringify, () => Promise.reject(123)).match({
           Resolved: (_value) => expect.unreachable(),
           Rejected: (reason) => expect(reason).toEqual(stringify(123)),
@@ -660,7 +893,7 @@ describe('`Task`', () => {
         expect.assertions(1);
       });
 
-      test('with a pending task', () => {
+      test("with a pending task", () => {
         // Will never resolve, but should be collected at the end of the test.
         // Note that this test passes when, and only when, no test assertions
         // run at all.
@@ -673,42 +906,42 @@ describe('`Task`', () => {
       });
     });
 
-    describe('toString', () => {
-      expectTypeOf(Task['toString']).toEqualTypeOf<() => string>();
+    describe("toString", () => {
+      expectTypeOf(Task["toString"]).toEqualTypeOf<() => string>();
 
-      test('pending', async () => {
+      test("pending", async () => {
         let { task, resolve } = Task.withResolvers();
-        expect(task.toString()).toEqual('Task.Pending');
+        expect(task.toString()).toEqual("Task.Pending");
 
-        resolve('');
+        resolve("");
         await task;
       });
 
-      test('resolved', async () => {
+      test("resolved", async () => {
         let theTask = new Task((resolve) => resolve(123));
         await theTask;
-        expect(theTask.toString()).toEqual('Task.Resolved(123)');
+        expect(theTask.toString()).toEqual("Task.Resolved(123)");
       });
 
-      test('rejected', async () => {
-        let theTask = new Task((_, reject) => reject('teh sads'));
+      test("rejected", async () => {
+        let theTask = new Task((_, reject) => reject("teh sads"));
         await theTask;
         expect(theTask.toString()).toEqual('Task.Rejected("teh sads")');
       });
     });
 
-    describe('`toPromise`', () => {
-      test('with a directly-constructed task', async () => {
+    describe("`toPromise`", () => {
+      test("with a directly-constructed task", async () => {
         let { task, resolve } = Task.withResolvers();
         let promise = task.toPromise();
 
-        let theValue = 'hello';
+        let theValue = "hello";
         resolve(theValue);
         let output = await promise;
         expect(unwrap(output)).toEqual(theValue);
       });
 
-      test('with a passed-in-promise', async () => {
+      test("with a passed-in-promise", async () => {
         let { promise: theInputPromise, resolve } = deferred();
         let theTask = fromPromise(theInputPromise);
 
@@ -719,9 +952,9 @@ describe('`Task`', () => {
       });
     });
 
-    describe('`timeout`', () => {
-      describe('with a number', () => {
-        test('that is shorter', async () => {
+    describe("`timeout`", () => {
+      describe("with a number", () => {
+        test("that is shorter", async () => {
           // shorter by dint of "literally any timeout is shorter than never".
           let { task } = Task.withResolvers<string, never>();
           let result = await task.timeout(1);
@@ -733,29 +966,29 @@ describe('`Task`', () => {
           }
         });
 
-        test('that is equal', async () => {
+        test("that is equal", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration)).timeout(
-            duration
-          );
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          ).timeout(duration);
           let result = await task;
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
 
-        test('that is longer', async () => {
+        test("that is longer", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration)).timeout(
-            duration * 2
-          );
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          ).timeout(duration * 2);
           let result = await task;
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
       });
 
-      describe('with another timer', () => {
-        test('that is shorter', async () => {
+      describe("with another timer", () => {
+        test("that is shorter", async () => {
           // shorter by dint of "literally any timeout is shorter than never".
           let { task } = Task.withResolvers<string, never>();
           let result = await task.timeout(timer(1));
@@ -767,21 +1000,21 @@ describe('`Task`', () => {
           }
         });
 
-        test('that is equal', async () => {
+        test("that is equal", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration)).timeout(
-            timer(duration)
-          );
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          ).timeout(timer(duration));
           let result = await task;
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
 
-        test('that is longer', async () => {
+        test("that is longer", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration)).timeout(
-            timer(duration * 2)
-          );
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          ).timeout(timer(duration * 2));
           let result = await task;
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
@@ -790,14 +1023,14 @@ describe('`Task`', () => {
     });
   });
 
-  describe('accessors', () => {
-    describe('state', () => {
-      test('is initially Pending', async () => {
+  describe("accessors", () => {
+    describe("state", () => {
+      test("is initially Pending", async () => {
         let { task } = Task.withResolvers<number, string>();
         expect(task.state).toBe(State.Pending);
       });
 
-      test('is Resolved once the promise resolves', async () => {
+      test("is Resolved once the promise resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         resolve(123);
         let result = await task;
@@ -805,10 +1038,10 @@ describe('`Task`', () => {
         expect(unwrap(result)).toBe(123);
       });
 
-      test('is Rejected if the promise rejects', async () => {
+      test("is Rejected if the promise rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
 
-        let anError = 'oh teh noes';
+        let anError = "oh teh noes";
         reject(anError);
 
         let result = await task;
@@ -817,61 +1050,61 @@ describe('`Task`', () => {
       });
     });
 
-    describe('`value`', () => {
-      test('when the task is pending', () => {
+    describe("`value`", () => {
+      test("when the task is pending", () => {
         let theTask = new Task(noOp);
 
-        expectTypeOf(theTask).not.toHaveProperty('value');
-        expectTypeOf(theTask).not.toHaveProperty('reason');
+        expectTypeOf(theTask).not.toHaveProperty("value");
+        expectTypeOf(theTask).not.toHaveProperty("reason");
 
-        expect(() => (theTask as unknown as Resolved<unknown, unknown>).value).toThrowError(
-          InvalidAccess
-        );
+        expect(
+          () => (theTask as unknown as Resolved<unknown, unknown>).value,
+        ).toThrowError(InvalidAccess);
       });
 
-      test('when the task is resolved', () => {
+      test("when the task is resolved", () => {
         let theValue = 123;
         let theTask = Task.resolve(theValue);
         if (theTask.isResolved) {
-          expectTypeOf(theTask).toHaveProperty('value');
-          expectTypeOf(theTask).not.toHaveProperty('reason');
+          expectTypeOf(theTask).toHaveProperty("value");
+          expectTypeOf(theTask).not.toHaveProperty("reason");
           expect(theTask.value).toBe(theValue);
         } else {
           expect.unreachable();
         }
       });
 
-      test('when the task is rejected', () => {
-        let theTask = Task.reject('oh teh noes');
-        expect(() => (theTask as unknown as Resolved<unknown, unknown>).value).toThrowError(
-          InvalidAccess
-        );
+      test("when the task is rejected", () => {
+        let theTask = Task.reject("oh teh noes");
+        expect(
+          () => (theTask as unknown as Resolved<unknown, unknown>).value,
+        ).toThrowError(InvalidAccess);
       });
     });
 
-    describe('`reason`', () => {
-      test('when the task is pending', () => {
+    describe("`reason`", () => {
+      test("when the task is pending", () => {
         let theTask = new Task(noOp);
-        expectTypeOf(theTask).not.toHaveProperty('value');
-        expectTypeOf(theTask).not.toHaveProperty('reason');
-        expect(() => (theTask as unknown as Rejected<unknown, unknown>).reason).toThrowError(
-          InvalidAccess
-        );
+        expectTypeOf(theTask).not.toHaveProperty("value");
+        expectTypeOf(theTask).not.toHaveProperty("reason");
+        expect(
+          () => (theTask as unknown as Rejected<unknown, unknown>).reason,
+        ).toThrowError(InvalidAccess);
       });
 
-      test('when the task is resolved', () => {
+      test("when the task is resolved", () => {
         let theTask = Task.resolve(123);
-        expect(() => (theTask as unknown as Rejected<unknown, unknown>).reason).toThrowError(
-          InvalidAccess
-        );
+        expect(
+          () => (theTask as unknown as Rejected<unknown, unknown>).reason,
+        ).toThrowError(InvalidAccess);
       });
 
-      test('when the task is rejected', () => {
-        let theReason = 'oh teh noes';
+      test("when the task is rejected", () => {
+        let theReason = "oh teh noes";
         let theTask = Task.reject(theReason);
         if (theTask.isRejected) {
-          expectTypeOf(theTask).not.toHaveProperty('value');
-          expectTypeOf(theTask).toHaveProperty('reason');
+          expectTypeOf(theTask).not.toHaveProperty("value");
+          expectTypeOf(theTask).toHaveProperty("reason");
           expect(theTask.reason).toBe(theReason);
         } else {
           expect.unreachable();
@@ -880,8 +1113,8 @@ describe('`Task`', () => {
     });
   });
 
-  describe('narrowing', () => {
-    test('pending', async () => {
+  describe("narrowing", () => {
+    test("pending", async () => {
       let { task, resolve } = Task.withResolvers<number, string>();
 
       if (task.state === State.Pending) {
@@ -894,7 +1127,7 @@ describe('`Task`', () => {
       await task;
     });
 
-    test('resolved', async () => {
+    test("resolved", async () => {
       let { task, resolve } = Task.withResolvers<number, string>();
 
       resolve(123);
@@ -908,14 +1141,14 @@ describe('`Task`', () => {
       }
     });
 
-    test('rejected', async () => {
+    test("rejected", async () => {
       let { promise, reject } = deferred<number, string>();
       let theTask = tryOrElse(
         (e) => `${e}`,
-        () => promise
+        () => promise,
       );
 
-      let theError = 'oh teh noes';
+      let theError = "oh teh noes";
       reject(theError);
       await theTask;
 
@@ -929,29 +1162,29 @@ describe('`Task`', () => {
   });
 });
 
-describe('module-scope functions', () => {
-  describe('all', () => {
-    describe('with a single task', () => {
-      test('that is still pending', () => {
+describe("module-scope functions", () => {
+  describe("all", () => {
+    describe("with a single task", () => {
+      test("that is still pending", () => {
         let { task } = Task.withResolvers<string, number>();
         let result = all([task]);
         expectTypeOf(result).toEqualTypeOf<Task<[string], number>>();
         expect(result.state).toBe(State.Pending);
       });
 
-      test('that has resolved', async () => {
-        let theTask = Task.resolve('hello');
+      test("that has resolved", async () => {
+        let theTask = Task.resolve("hello");
         let result = all([theTask]);
         expectTypeOf(result).toEqualTypeOf<Task<[string], never>>();
         await result;
         expect(result.state).toBe(State.Resolved);
         if (result.isResolved) {
-          expect(result.value).toEqual(['hello']);
+          expect(result.value).toEqual(["hello"]);
         }
       });
 
-      test('that has rejected', async () => {
-        let theReason = 'oops';
+      test("that has rejected", async () => {
+        let theReason = "oops";
         let theTask = Task.reject<string, string>(theReason);
         let result = all([theTask]);
         await result;
@@ -963,8 +1196,8 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with two tasks', () => {
-      test('types', () => {
+    describe("with two tasks", () => {
+      test("types", () => {
         let { task: task1 } = Task.withResolvers<string, number>();
         let { task: task2 } = Task.withResolvers<boolean, Error>();
         let fromTuple = all([task1, task2]);
@@ -972,126 +1205,175 @@ describe('module-scope functions', () => {
         expectTypeOf(fromTuple).toEqualTypeOf(fromArray);
       });
 
-      test('that are all still pending', () => {
+      test("that are all still pending", () => {
         let { task: task1 } = Task.withResolvers<string, number>();
         let { task: task2 } = Task.withResolvers<boolean, Error>();
         let result = all([task1, task2]);
-        expectTypeOf(result).toEqualTypeOf<Task<[string, boolean], number | Error>>();
+        expectTypeOf(result).toEqualTypeOf<
+          Task<[string, boolean], number | Error>
+        >();
         expect(result.state).toBe(State.Pending);
       });
 
-      describe('when the first resolves', () => {
-        test('while the second is pending', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
+      describe("when the first resolves", () => {
+        test("while the second is pending", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
           let { task: task2 } = Task.withResolvers<number, boolean>();
           let result = all([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<[string, number], number | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<[string, number], number | boolean>
+          >();
 
-          resolve1('first');
+          resolve1("first");
           expect(result.state).toBe(State.Pending);
         });
 
-        test('when the second has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the second has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = all([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<[number, string], string | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<[number, string], string | boolean>
+          >();
 
-          resolve2('second');
+          resolve2("second");
           resolve1(1);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
             expectTypeOf(result.value).toEqualTypeOf<[number, string]>();
-            expect(result.value).toEqual([1, 'second']);
+            expect(result.value).toEqual([1, "second"]);
           }
         });
 
-        test('when the second has rejected', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, reject: reject2 } = Task.withResolvers<boolean, string>();
+        test("when the second has rejected", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, reject: reject2 } = Task.withResolvers<
+            boolean,
+            string
+          >();
           let result = all([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<[string, boolean], number | string>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<[string, boolean], number | string>
+          >();
 
-          reject2('error');
-          resolve1('first');
+          reject2("error");
+          resolve1("first");
           await result;
           expect(result.state).toBe(State.Rejected);
           if (result.isRejected) {
-            expect(result.reason).toBe('error');
+            expect(result.reason).toBe("error");
           }
         });
       });
 
-      describe('when the second resolves', () => {
-        test('while the first is pending', async () => {
+      describe("when the second resolves", () => {
+        test("while the first is pending", async () => {
           let { task: task1 } = Task.withResolvers<number, boolean>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, Error>();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            Error
+          >();
           let result = all([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<[number, string], boolean | Error>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<[number, string], boolean | Error>
+          >();
 
-          resolve2('second');
+          resolve2("second");
           expect(result.state).toBe(State.Pending);
         });
 
-        test('when the first has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<number, boolean>();
+        test("when the first has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            number,
+            boolean
+          >();
           let result = all([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<[string, number], number | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<[string, number], number | boolean>
+          >();
 
-          resolve1('first');
+          resolve1("first");
           resolve2(2);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toEqual(['first', 2]);
+            expect(result.value).toEqual(["first", 2]);
           }
         });
 
-        test('when the first has rejected', async () => {
-          let { task: task1, reject: reject1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the first has rejected", async () => {
+          let { task: task1, reject: reject1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = all([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<[number, string], string | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<[number, string], string | boolean>
+          >();
 
-          reject1('error');
-          resolve2('second');
+          reject1("error");
+          resolve2("second");
           await result;
           expect(result.state).toBe(State.Rejected);
           if (result.isRejected) {
-            expect(result.reason).toBe('error');
+            expect(result.reason).toBe("error");
           }
         });
       });
     });
 
-    test('rejection happens immediately', async () => {
-      let { task: task1, reject: reject1 } = Task.withResolvers<number, string>();
+    test("rejection happens immediately", async () => {
+      let { task: task1, reject: reject1 } = Task.withResolvers<
+        number,
+        string
+      >();
       let { task: task2 } = Task.withResolvers<string, boolean>();
       let result = all([task1, task2]);
-      expectTypeOf(result).toEqualTypeOf<Task<[number, string], string | boolean>>();
+      expectTypeOf(result).toEqualTypeOf<
+        Task<[number, string], string | boolean>
+      >();
 
-      reject1('error');
+      reject1("error");
       await result;
       expect(result.state).toBe(State.Rejected);
       if (result.isRejected) {
-        expect(result.reason).toBe('error');
+        expect(result.reason).toBe("error");
       }
     });
 
     // Covers the early return path when a second rejection triggers.
-    test('multiple rejections', async () => {
-      let result = all([Task.reject('first'), Task.reject('second')]);
+    test("multiple rejections", async () => {
+      let result = all([Task.reject("first"), Task.reject("second")]);
       await result;
       if (result.isRejected) {
-        expect(result.reason).toBe('first');
+        expect(result.reason).toBe("first");
       } else {
         expect.unreachable();
       }
     });
 
-    test('with an empty set of tasks', async () => {
+    test("with an empty set of tasks", async () => {
       let noTasks = all([]);
       expectTypeOf(noTasks).toEqualTypeOf<Task<[], never>>();
       await noTasks;
@@ -1101,12 +1383,12 @@ describe('module-scope functions', () => {
       }
     });
 
-    test('with multiple tasks (integration)', async () => {
+    test("with multiple tasks (integration)", async () => {
       let { task: willReject, reject } = Task.withResolvers();
 
       let allTasks = all([timer(10), timer(20), willReject]);
 
-      let theReason = 'something went wrong';
+      let theReason = "something went wrong";
       reject(theReason);
       let result = await allTasks;
       expect(allTasks.state).toBe(State.Rejected);
@@ -1123,33 +1405,39 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('allSettled', () => {
-    describe('with a single task', () => {
-      test('that is still pending', () => {
+  describe("allSettled", () => {
+    describe("with a single task", () => {
+      test("that is still pending", () => {
         let { task } = Task.withResolvers<string, number>();
         let result = allSettled([task]);
-        expectTypeOf(result).toEqualTypeOf<Task<[Result<string, number>], never>>();
+        expectTypeOf(result).toEqualTypeOf<
+          Task<[Result<string, number>], never>
+        >();
         expect(result.state).toBe(State.Pending);
       });
 
-      test('that has resolved', async () => {
-        let theTask = Task.resolve('hello');
+      test("that has resolved", async () => {
+        let theTask = Task.resolve("hello");
         let result = allSettled([theTask]);
-        expectTypeOf(result).toEqualTypeOf<Task<[Result<string, never>], never>>();
+        expectTypeOf(result).toEqualTypeOf<
+          Task<[Result<string, never>], never>
+        >();
         await result;
         expect(result.state).toBe(State.Resolved);
         if (result.isResolved) {
           expect(result.value[0]!.isOk).toBe(true);
-          expect(unwrap(result.value[0]!)).toBe('hello');
+          expect(unwrap(result.value[0]!)).toBe("hello");
         }
       });
 
-      test('that has rejected', async () => {
-        let theReason = 'oops';
+      test("that has rejected", async () => {
+        let theReason = "oops";
         let theTask = Task.reject<string, string>(theReason);
         let result = allSettled([theTask]);
         await result;
-        expectTypeOf(result).toEqualTypeOf<Task<[Result<string, string>], never>>();
+        expectTypeOf(result).toEqualTypeOf<
+          Task<[Result<string, string>], never>
+        >();
         expect(result.state).toBe(State.Resolved);
         if (result.isResolved) {
           expect(result.value[0].isErr).toBe(true);
@@ -1158,8 +1446,8 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with two tasks', () => {
-      test('that are all still pending', () => {
+    describe("with two tasks", () => {
+      test("that are all still pending", () => {
         let { task: task1 } = Task.withResolvers<string, number>();
         let { task: task2 } = Task.withResolvers<boolean, Error>();
         let result = allSettled([task1, task2]);
@@ -1169,28 +1457,37 @@ describe('module-scope functions', () => {
         expect(result.state).toBe(State.Pending);
       });
 
-      describe('when the first resolves', () => {
-        test('while the second is pending', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
+      describe("when the first resolves", () => {
+        test("while the second is pending", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
           let { task: task2 } = Task.withResolvers<number, boolean>();
           let result = allSettled([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<[Result<string, number>, Result<number, boolean>], never>
           >();
 
-          resolve1('first');
+          resolve1("first");
           expect(result.state).toBe(State.Pending);
         });
 
-        test('when the second has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the second has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = allSettled([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<[Result<number, string>, Result<string, boolean>], never>
           >();
 
-          resolve2('second');
+          resolve2("second");
           resolve1(1);
           await result;
           expect(result.state).toBe(State.Resolved);
@@ -1198,89 +1495,110 @@ describe('module-scope functions', () => {
             expect(result.value[0].isOk).toBe(true);
             expect(result.value[1].isOk).toBe(true);
             expect(unwrap(result.value[0])).toBe(1);
-            expect(unwrap(result.value[1])).toBe('second');
+            expect(unwrap(result.value[1])).toBe("second");
           }
         });
 
-        test('when the second has rejected', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, reject: reject2 } = Task.withResolvers<boolean, string>();
+        test("when the second has rejected", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, reject: reject2 } = Task.withResolvers<
+            boolean,
+            string
+          >();
           let result = allSettled([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<[Result<string, number>, Result<boolean, string>], never>
           >();
 
-          reject2('error');
-          resolve1('first');
+          reject2("error");
+          resolve1("first");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
             expect(result.value[0].isOk).toBe(true);
             expect(result.value[1].isErr).toBe(true);
-            expect(unwrap(result.value[0])).toBe('first');
-            expect(unwrapErr(result.value[1])).toBe('error');
+            expect(unwrap(result.value[0])).toBe("first");
+            expect(unwrapErr(result.value[1])).toBe("error");
           }
         });
       });
 
-      describe('when the second resolves', () => {
-        test('while the first is pending', async () => {
+      describe("when the second resolves", () => {
+        test("while the first is pending", async () => {
           let { task: task1 } = Task.withResolvers<number, boolean>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, Error>();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            Error
+          >();
           let result = allSettled([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<[Result<number, boolean>, Result<string, Error>], never>
           >();
 
-          resolve2('second');
+          resolve2("second");
           expect(result.state).toBe(State.Pending);
         });
 
-        test('when the first has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<number, boolean>();
+        test("when the first has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            number,
+            boolean
+          >();
           let result = allSettled([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<[Result<string, number>, Result<number, boolean>], never>
           >();
 
-          resolve1('first');
+          resolve1("first");
           resolve2(2);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
             expect(result.value[0].isOk).toBe(true);
             expect(result.value[1].isOk).toBe(true);
-            expect(unwrap(result.value[0])).toBe('first');
+            expect(unwrap(result.value[0])).toBe("first");
             expect(unwrap(result.value[1])).toBe(2);
           }
         });
 
-        test('when the first has rejected', async () => {
-          let { task: task1, reject: reject1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the first has rejected", async () => {
+          let { task: task1, reject: reject1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = allSettled([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<[Result<number, string>, Result<string, boolean>], never>
           >();
 
-          reject1('error');
-          resolve2('second');
+          reject1("error");
+          resolve2("second");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
             expect(result.value[0].isErr).toBe(true);
             expect(result.value[1].isOk).toBe(true);
-            expect(unwrapErr(result.value[0])).toBe('error');
-            expect(unwrap(result.value[1])).toBe('second');
+            expect(unwrapErr(result.value[0])).toBe("error");
+            expect(unwrap(result.value[1])).toBe("second");
           }
         });
       });
     });
   });
 
-  describe('any', () => {
-    test('with an empty array', async () => {
+  describe("any", () => {
+    test("with an empty array", async () => {
       let result = any([]);
       expectTypeOf(result).toEqualTypeOf<Task<never, AggregateRejection<[]>>>();
       await result;
@@ -1288,103 +1606,121 @@ describe('module-scope functions', () => {
       if (result.isRejected) {
         expect(result.reason).toBeInstanceOf(AggregateRejection);
         expect(result.reason.errors.length).toBe(0);
-        expect(result.reason.toString()).toMatch('No tasks');
+        expect(result.reason.toString()).toMatch("No tasks");
       }
     });
 
-    describe('with a single task', () => {
-      test('that is still pending', () => {
+    describe("with a single task", () => {
+      test("that is still pending", () => {
         let { task } = Task.withResolvers();
         let result = any([task]);
         expect(result.state).toBe(State.Pending);
       });
 
-      test('that has resolved', async () => {
-        let theTask = Task.resolve('hello');
+      test("that has resolved", async () => {
+        let theTask = Task.resolve("hello");
         let result = any([theTask]);
         await result;
         expect(result.state).toBe(State.Resolved);
         if (result.isResolved) {
-          expect(result.value).toBe('hello');
+          expect(result.value).toBe("hello");
         }
       });
 
-      test('that has rejected', async () => {
-        let theReason = 'oops';
+      test("that has rejected", async () => {
+        let theReason = "oops";
         let theTask = Task.reject<string, string>(theReason);
         let result = any([theTask]);
         await result;
         expect(result.state).toBe(State.Rejected);
         if (result.isRejected) {
           expect(result.reason.errors[0]).toBe(theReason);
-          expect(result.reason.toString()).toMatch('[oops]');
+          expect(result.reason.toString()).toMatch("[oops]");
         }
       });
     });
 
-    describe('with two tasks', () => {
-      test('that are all still pending', () => {
+    describe("with two tasks", () => {
+      test("that are all still pending", () => {
         let { task: task1 } = Task.withResolvers();
         let { task: task2 } = Task.withResolvers();
         let result = any([task1, task2]);
         expect(result.state).toBe(State.Pending);
       });
 
-      describe('when the first resolves', () => {
-        test('while the second is pending', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
+      describe("when the first resolves", () => {
+        test("while the second is pending", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
           let { task: task2 } = Task.withResolvers<number, boolean>();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<string | number, AggregateRejection<[number, boolean]>>
           >();
 
-          resolve1('first');
+          resolve1("first");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('first');
+            expect(result.value).toBe("first");
           }
         });
 
-        test('when the second has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the second has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<number | string, AggregateRejection<[string, boolean]>>
           >();
 
-          resolve2('second');
+          resolve2("second");
           resolve1(1);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('second');
+            expect(result.value).toBe("second");
           }
         });
 
-        test('when the second has rejected', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, reject: reject2 } = Task.withResolvers<boolean, string>();
+        test("when the second has rejected", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, reject: reject2 } = Task.withResolvers<
+            boolean,
+            string
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<string | boolean, AggregateRejection<[number, string]>>
           >();
 
-          reject2('error');
-          resolve1('first');
+          reject2("error");
+          resolve1("first");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('first');
+            expect(result.value).toBe("first");
           }
         });
       });
 
-      describe('when the first rejects', () => {
-        test('while the second is pending', async () => {
-          let { task: task1, reject: reject1 } = Task.withResolvers<string, number>();
+      describe("when the first rejects", () => {
+        test("while the second is pending", async () => {
+          let { task: task1, reject: reject1 } = Task.withResolvers<
+            string,
+            number
+          >();
           let { task: task2 } = Task.withResolvers<number, boolean>();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
@@ -1395,100 +1731,130 @@ describe('module-scope functions', () => {
           expect(result.state).toBe(State.Pending);
         });
 
-        test('when the second has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the second has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<number | string, AggregateRejection<[string, boolean]>>
           >();
 
-          resolve2('second');
+          resolve2("second");
           resolve1(1);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('second');
+            expect(result.value).toBe("second");
           }
         });
 
-        test('when the second has also rejected', async () => {
-          let { task: task1, reject: reject1 } = Task.withResolvers<string, number>();
-          let { task: task2, reject: reject2 } = Task.withResolvers<boolean, string>();
+        test("when the second has also rejected", async () => {
+          let { task: task1, reject: reject1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, reject: reject2 } = Task.withResolvers<
+            boolean,
+            string
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<string | boolean, AggregateRejection<[number, string]>>
           >();
 
-          reject2('error');
+          reject2("error");
           reject1(1);
           await result;
           expect(result.state).toBe(State.Rejected);
           if (result.isRejected) {
             expect(result.reason).toBeInstanceOf(AggregateRejection);
             expect(result.reason.errors[0]!).toBe(1);
-            expect(result.reason.errors[1]!).toBe('error');
+            expect(result.reason.errors[1]!).toBe("error");
           }
         });
       });
 
-      describe('when the second resolves', () => {
-        test('while the first is pending', async () => {
+      describe("when the second resolves", () => {
+        test("while the first is pending", async () => {
           let { task: task1 } = Task.withResolvers<number, boolean>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, Error>();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            Error
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<number | string, AggregateRejection<[boolean, Error]>>
           >();
 
-          resolve2('second');
+          resolve2("second");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('second');
+            expect(result.value).toBe("second");
           }
         });
 
-        test('when the first has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<number, boolean>();
+        test("when the first has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            number,
+            boolean
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<string | number, AggregateRejection<[number, boolean]>>
           >();
 
-          resolve1('first');
+          resolve1("first");
           resolve2(2);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('first');
+            expect(result.value).toBe("first");
           }
         });
 
-        test('when the first has rejected', async () => {
-          let { task: task1, reject: reject1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the first has rejected", async () => {
+          let { task: task1, reject: reject1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = any([task1, task2]);
           expectTypeOf(result).toEqualTypeOf<
             Task<number | string, AggregateRejection<[string, boolean]>>
           >();
 
-          reject1('error');
-          resolve2('second');
+          reject1("error");
+          resolve2("second");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('second');
+            expect(result.value).toBe("second");
           }
         });
       });
     });
 
-    describe('when the second rejects', () => {
-      test('while the first is pending', async () => {
+    describe("when the second rejects", () => {
+      test("while the first is pending", async () => {
         let { task: task1 } = Task.withResolvers<number, boolean>();
-        let { task: task2, reject: reject2 } = Task.withResolvers<string, number>();
+        let { task: task2, reject: reject2 } = Task.withResolvers<
+          string,
+          number
+        >();
         let result = any([task1, task2]);
         expectTypeOf(result).toEqualTypeOf<
           Task<number | string, AggregateRejection<[boolean, number]>>
@@ -1498,78 +1864,90 @@ describe('module-scope functions', () => {
         expect(result.state).toBe(State.Pending);
       });
 
-      test('when the first has already resolved', async () => {
-        let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-        let { task: task2, reject: reject2 } = Task.withResolvers<number, boolean>();
+      test("when the first has already resolved", async () => {
+        let { task: task1, resolve: resolve1 } = Task.withResolvers<
+          string,
+          number
+        >();
+        let { task: task2, reject: reject2 } = Task.withResolvers<
+          number,
+          boolean
+        >();
         let result = any([task1, task2]);
         expectTypeOf(result).toEqualTypeOf<
           Task<string | number, AggregateRejection<[number, boolean]>>
         >();
 
-        resolve1('first');
+        resolve1("first");
         reject2(true);
         await result;
         expect(result.state).toBe(State.Resolved);
         if (result.isResolved) {
-          expect(result.value).toBe('first');
+          expect(result.value).toBe("first");
         }
       });
 
-      test('when the first has also rejected', async () => {
-        let { task: task1, reject: reject1 } = Task.withResolvers<number, string>();
-        let { task: task2, reject: reject2 } = Task.withResolvers<string, boolean>();
+      test("when the first has also rejected", async () => {
+        let { task: task1, reject: reject1 } = Task.withResolvers<
+          number,
+          string
+        >();
+        let { task: task2, reject: reject2 } = Task.withResolvers<
+          string,
+          boolean
+        >();
         let result = any([task1, task2]);
         expectTypeOf(result).toEqualTypeOf<
           Task<number | string, AggregateRejection<[string, boolean]>>
         >();
 
-        reject1('error');
+        reject1("error");
         reject2(true);
         await result;
         expect(result.state).toBe(State.Rejected);
         if (result.isRejected) {
           expect(result.reason).toBeInstanceOf(AggregateRejection);
           expect(result.reason.errors.length).toBe(2);
-          expect(result.reason.errors[0]).toBe('error');
+          expect(result.reason.errors[0]).toBe("error");
           expect(result.reason.errors[1]).toBe(true);
         }
       });
     });
   });
 
-  describe('race', () => {
-    expectTypeOf(race([Task.resolve('hello'), Task.resolve(123)])).toEqualTypeOf(
-      race([Task.resolve('hello'), Task.resolve(123)])
-    );
+  describe("race", () => {
+    expectTypeOf(
+      race([Task.resolve("hello"), Task.resolve(123)]),
+    ).toEqualTypeOf(race([Task.resolve("hello"), Task.resolve(123)]));
 
-    test('with an empty array', () => {
+    test("with an empty array", () => {
       // Note: this will *never* resolve, so do not attempt to await it!
       let result = race([]);
       expectTypeOf(result).toEqualTypeOf<Task<never, never>>();
       expect(result.state).toBe(State.Pending);
     });
 
-    describe('with a single task', () => {
-      test('that is still pending', () => {
+    describe("with a single task", () => {
+      test("that is still pending", () => {
         let { task } = Task.withResolvers<string, number>();
         let result = race([task]);
         expectTypeOf(result).toEqualTypeOf<Task<string, number>>();
         expect(result.state).toBe(State.Pending);
       });
 
-      test('that has resolved', async () => {
-        let theTask = Task.resolve('hello');
+      test("that has resolved", async () => {
+        let theTask = Task.resolve("hello");
         let result = race([theTask]);
         expectTypeOf(result).toEqualTypeOf<Task<string, never>>();
         await result;
         expect(result.state).toBe(State.Resolved);
         if (result.isResolved) {
-          expect(result.value).toBe('hello');
+          expect(result.value).toBe("hello");
         }
       });
 
-      test('that has rejected', async () => {
-        let theReason = 'oops';
+      test("that has rejected", async () => {
+        let theReason = "oops";
         let theTask = Task.reject<string, string>(theReason);
         let result = race([theTask]);
         await result;
@@ -1581,110 +1959,154 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with two tasks', () => {
-      test('that are all still pending', () => {
+    describe("with two tasks", () => {
+      test("that are all still pending", () => {
         let { task: task1 } = Task.withResolvers<string, number>();
         let { task: task2 } = Task.withResolvers<boolean, Error>();
         let result = race([task1, task2]);
-        expectTypeOf(result).toEqualTypeOf<Task<string | boolean, number | Error>>();
+        expectTypeOf(result).toEqualTypeOf<
+          Task<string | boolean, number | Error>
+        >();
         expect(result.state).toBe(State.Pending);
       });
 
-      describe('when the first resolves', () => {
-        test('while the second is pending', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
+      describe("when the first resolves", () => {
+        test("while the second is pending", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
           let { task: task2 } = Task.withResolvers<number, boolean>();
           let result = race([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<string | number, number | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<string | number, number | boolean>
+          >();
 
-          resolve1('first');
+          resolve1("first");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('first');
+            expect(result.value).toBe("first");
           }
         });
 
-        test('when the second has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the second has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = race([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<number | string, string | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<number | string, string | boolean>
+          >();
 
-          resolve2('second');
+          resolve2("second");
           resolve1(1);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('second');
+            expect(result.value).toBe("second");
           }
         });
 
-        test('when the second has rejected', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, reject: reject2 } = Task.withResolvers<boolean, string>();
+        test("when the second has rejected", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, reject: reject2 } = Task.withResolvers<
+            boolean,
+            string
+          >();
           let result = race([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<string | boolean, number | string>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<string | boolean, number | string>
+          >();
 
-          reject2('error');
-          resolve1('first');
+          reject2("error");
+          resolve1("first");
           await result;
           expect(result.state).toBe(State.Rejected);
           if (result.isRejected) {
-            expect(result.reason).toBe('error');
+            expect(result.reason).toBe("error");
           }
         });
       });
 
-      describe('when the second resolves', () => {
-        test('while the first is pending', async () => {
+      describe("when the second resolves", () => {
+        test("while the first is pending", async () => {
           let { task: task1 } = Task.withResolvers<number, boolean>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, Error>();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            Error
+          >();
           let result = race([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<number | string, boolean | Error>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<number | string, boolean | Error>
+          >();
 
-          resolve2('second');
+          resolve2("second");
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('second');
+            expect(result.value).toBe("second");
           }
         });
 
-        test('when the first has already resolved', async () => {
-          let { task: task1, resolve: resolve1 } = Task.withResolvers<string, number>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<number, boolean>();
+        test("when the first has already resolved", async () => {
+          let { task: task1, resolve: resolve1 } = Task.withResolvers<
+            string,
+            number
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            number,
+            boolean
+          >();
           let result = race([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<string | number, number | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<string | number, number | boolean>
+          >();
 
-          resolve1('first');
+          resolve1("first");
           resolve2(2);
           await result;
           expect(result.state).toBe(State.Resolved);
           if (result.isResolved) {
-            expect(result.value).toBe('first');
+            expect(result.value).toBe("first");
           }
         });
 
-        test('when the first has rejected', async () => {
-          let { task: task1, reject: reject1 } = Task.withResolvers<number, string>();
-          let { task: task2, resolve: resolve2 } = Task.withResolvers<string, boolean>();
+        test("when the first has rejected", async () => {
+          let { task: task1, reject: reject1 } = Task.withResolvers<
+            number,
+            string
+          >();
+          let { task: task2, resolve: resolve2 } = Task.withResolvers<
+            string,
+            boolean
+          >();
           let result = race([task1, task2]);
-          expectTypeOf(result).toEqualTypeOf<Task<number | string, string | boolean>>();
+          expectTypeOf(result).toEqualTypeOf<
+            Task<number | string, string | boolean>
+          >();
 
-          reject1('error');
-          resolve2('second');
+          reject1("error");
+          resolve2("second");
           await result;
           expect(result.state).toBe(State.Rejected);
           if (result.isRejected) {
-            expect(result.reason).toBe('error');
+            expect(result.reason).toBe("error");
           }
         });
       });
     });
   });
 
-  test('timer', async () => {
+  test("timer", async () => {
     let ms = 1;
     let aTimer = timer(ms);
     expectTypeOf(aTimer).toEqualTypeOf<Timer>();
@@ -1692,40 +2114,40 @@ describe('module-scope functions', () => {
     expect(unwrap(result)).toEqual(ms);
   });
 
-  describe('resolve', () => {
-    test('produces `Task<Unit, never>` when passed no arguments', () => {
+  describe("resolve", () => {
+    test("produces `Task<Unit, never>` when passed no arguments", () => {
       let theTask = resolve();
       expectTypeOf(theTask).toEqualTypeOf<Task<Unit, never>>();
     });
 
-    test('produces `Task<T, never>` when passed a basic argument', () => {
-      let theValue = 'hello';
+    test("produces `Task<T, never>` when passed a basic argument", () => {
+      let theValue = "hello";
       let theTask = resolve(theValue);
       expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
     });
 
-    test('allows explicitly setting a type for `E`', () => {
+    test("allows explicitly setting a type for `E`", () => {
       let resolvedWithUnit = resolve<Unit, string>();
       expectTypeOf(resolvedWithUnit).toEqualTypeOf<Task<Unit, string>>();
 
-      let resolvedWithValue = resolve<string, number>('hello');
+      let resolvedWithValue = resolve<string, number>("hello");
       expectTypeOf(resolvedWithValue).toEqualTypeOf<Task<string, number>>();
     });
   });
 
-  describe('reject', () => {
-    test('produces `Task<never, Unit>` when passed no arguments', () => {
+  describe("reject", () => {
+    test("produces `Task<never, Unit>` when passed no arguments", () => {
       let theTask = reject();
       expectTypeOf(theTask).toEqualTypeOf<Task<never, Unit>>();
     });
 
-    test('produces `Task<never, E>` when passed an argument', () => {
-      let theReason = 'uh oh';
+    test("produces `Task<never, E>` when passed an argument", () => {
+      let theReason = "uh oh";
       let theTask = reject(theReason);
       expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
     });
 
-    test('allows explicitly setting a type for `T`', () => {
+    test("allows explicitly setting a type for `T`", () => {
       let rejectedWithUnit = reject<string>();
       expectTypeOf(rejectedWithUnit).toEqualTypeOf<Task<string, Unit>>();
 
@@ -1734,38 +2156,38 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('withResolvers', () => {
-    test('supports resolving', async () => {
+  describe("withResolvers", () => {
+    test("supports resolving", async () => {
       let { task, resolve } = withResolvers<string, never>();
       expectTypeOf(task).toEqualTypeOf<Task<string, never>>();
 
-      let theValue = 'hello';
+      let theValue = "hello";
       resolve(theValue);
       let result = await task;
       expect(unwrap(result)).toEqual(theValue);
     });
 
-    test('supports rejecting', async () => {
+    test("supports rejecting", async () => {
       let { task, reject } = withResolvers<never, string>();
       expectTypeOf(task).toEqualTypeOf<Task<never, string>>();
 
-      let theReason = 'le sigh';
+      let theReason = "le sigh";
       reject(theReason);
       let result = await task;
       expect(unwrapErr(result)).toEqual(theReason);
     });
   });
 
-  describe('safelyTry', () => {
-    describe('with a non-throwing function', () => {
-      test('with a promise that resolves', async () => {
+  describe("safelyTry", () => {
+    describe("with a non-throwing function", () => {
+      test("with a promise that resolves", async () => {
         let theTask = safelyTry(() => Promise.resolve(123));
         expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
         let theResult = await theTask;
         expect(unwrap(theResult)).toBe(123);
       });
 
-      test('with a promise that rejects', async () => {
+      test("with a promise that rejects", async () => {
         let theTask = safelyTry(() => Promise.reject(123));
         expectTypeOf(theTask).toEqualTypeOf<Task<never, unknown>>();
         let theResult = await theTask;
@@ -1773,79 +2195,79 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with a throwing function', () => {
-      test('with a promise that resolves', async () => {
+    describe("with a throwing function", () => {
+      test("with a promise that resolves", async () => {
         let theTask = safelyTry((): Promise<number> => {
-          throw new Error('NOPE');
+          throw new Error("NOPE");
         });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
         let theResult = await theTask;
         let theError = unwrapErr(theResult);
         expect(theError).toBeInstanceOf(Error);
-        expect((theError as Error).message).toBe('NOPE');
+        expect((theError as Error).message).toBe("NOPE");
       });
 
-      test('with a promise that rejects', async () => {
+      test("with a promise that rejects", async () => {
         let theTask = safelyTry((): Promise<number> => {
-          throw new Error('NOPE');
+          throw new Error("NOPE");
         });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
         let theResult = await theTask;
         let theError = unwrapErr(theResult);
         expect(theError).toBeInstanceOf(Error);
-        expect((theError as Error).message).toBe('NOPE');
+        expect((theError as Error).message).toBe("NOPE");
       });
     });
   });
 
-  describe('tryOr', () => {
-    describe('with a non-throwing function', () => {
-      test('with a promise that resolves', async () => {
-        let theTask = tryOr('error', () => Promise.resolve(123));
+  describe("tryOr", () => {
+    describe("with a non-throwing function", () => {
+      test("with a promise that resolves", async () => {
+        let theTask = tryOr("error", () => Promise.resolve(123));
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
         expect(unwrap(theResult)).toBe(123);
       });
 
-      test('with a promise that rejects', async () => {
-        let theTask = tryOr('error', () => Promise.reject(123));
+      test("with a promise that rejects", async () => {
+        let theTask = tryOr("error", () => Promise.reject(123));
         expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
         let theResult = await theTask;
-        expect(unwrapErr(theResult)).toBe('error');
+        expect(unwrapErr(theResult)).toBe("error");
       });
     });
 
-    describe('with a throwing function', () => {
-      test('with a promise that resolves', async () => {
-        let theTask = tryOr('error', (): Promise<number> => {
-          throw new Error('NOPE');
+    describe("with a throwing function", () => {
+      test("with a promise that resolves", async () => {
+        let theTask = tryOr("error", (): Promise<number> => {
+          throw new Error("NOPE");
         });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
-        expect(unwrapErr(theResult)).toBe('error');
+        expect(unwrapErr(theResult)).toBe("error");
       });
 
-      test('with a promise that rejects', async () => {
-        let theTask = tryOr('error', (): Promise<number> => {
-          throw new Error('NOPE');
+      test("with a promise that rejects", async () => {
+        let theTask = tryOr("error", (): Promise<number> => {
+          throw new Error("NOPE");
         });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
-        expect(unwrapErr(theResult)).toBe('error');
+        expect(unwrapErr(theResult)).toBe("error");
       });
     });
   });
 
-  describe('tryOrElse', () => {
-    describe('with a non-throwing function', () => {
-      test('with a promise that resolves', async () => {
+  describe("tryOrElse", () => {
+    describe("with a non-throwing function", () => {
+      test("with a promise that resolves", async () => {
         let theTask = tryOrElse(stringify, () => Promise.resolve(123));
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
         expect(unwrap(theResult)).toBe(123);
       });
 
-      test('with a promise that rejects', async () => {
+      test("with a promise that rejects", async () => {
         let theTask = tryOrElse(stringify, () => Promise.reject(123));
         expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
         let theResult = await theTask;
@@ -1853,32 +2275,32 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with a throwing function', () => {
-      test('with a promise that resolves', async () => {
+    describe("with a throwing function", () => {
+      test("with a promise that resolves", async () => {
         let theTask = tryOrElse(stringify, (): Promise<number> => {
-          throw new Error('NOPE');
+          throw new Error("NOPE");
         });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
         let theError = unwrapErr(theResult);
-        expect(theError).toBe(stringify(new Error('NOPE')));
+        expect(theError).toBe(stringify(new Error("NOPE")));
       });
 
-      test('with a promise that rejects', async () => {
+      test("with a promise that rejects", async () => {
         let theTask = tryOrElse(stringify, (): Promise<number> => {
-          throw new Error('NOPE');
+          throw new Error("NOPE");
         });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         let theResult = await theTask;
         let theError = unwrapErr(theResult);
-        expect(theError).toBe(stringify(new Error('NOPE')));
+        expect(theError).toBe(stringify(new Error("NOPE")));
       });
     });
   });
 
-  describe('safe', () => {
-    const ERROR_MESSAGE = 'the message';
-    const REJECTION_REASON = 'ugh';
+  describe("safe", () => {
+    const ERROR_MESSAGE = "the message";
+    const REJECTION_REASON = "ugh";
 
     function example(
       value: number,
@@ -1888,21 +2310,23 @@ describe('module-scope functions', () => {
       }: { throwErr?: boolean; rejectPromise?: boolean } = {
         throwErr: false,
         rejectPromise: false,
-      }
+      },
     ): Promise<number> {
       if (throwErr) {
         throw new Error(ERROR_MESSAGE);
       }
 
-      return rejectPromise ? Promise.reject(REJECTION_REASON) : Promise.resolve(value);
+      return rejectPromise
+        ? Promise.reject(REJECTION_REASON)
+        : Promise.resolve(value);
     }
 
-    describe('without an error handler', () => {
+    describe("without an error handler", () => {
       let safeExample = safe(example);
       expectTypeOf(safeExample).toEqualTypeOf<
         (
           value: number,
-          should?: { throwErr?: boolean; rejectPromise?: boolean }
+          should?: { throwErr?: boolean; rejectPromise?: boolean },
         ) => Task<number, unknown>
       >();
 
@@ -1913,9 +2337,9 @@ describe('module-scope functions', () => {
       // @ts-expect-error: `safe` only accepts functions which return promises.
       safe(() => true);
       // @ts-expect-error: `safe` only accepts functions which return promises.
-      safe(() => 'hello');
+      safe(() => "hello");
 
-      test('when it throws', async () => {
+      test("when it throws", async () => {
         let theTask = safeExample(123, { throwErr: true });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
         await theTask;
@@ -1924,8 +2348,8 @@ describe('module-scope functions', () => {
         }
       });
 
-      describe('when it does not throw', () => {
-        test('and it resolves', async () => {
+      describe("when it does not throw", () => {
+        test("and it resolves", async () => {
           let theTask = safeExample(123);
           expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
           await theTask;
@@ -1936,7 +2360,7 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('and it rejects', async () => {
+        test("and it rejects", async () => {
           let theTask = safeExample(123, { rejectPromise: true });
           expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
           await theTask;
@@ -1949,26 +2373,26 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with an error handler', () => {
+    describe("with an error handler", () => {
       let safeExample = safe(example, stringify);
       expectTypeOf(safeExample).toEqualTypeOf<
         (
           value: number,
-          should?: { throwErr?: boolean; rejectPromise?: boolean }
+          should?: { throwErr?: boolean; rejectPromise?: boolean },
         ) => Task<number, string>
       >();
 
-      test('when it throws', async () => {
+      test("when it throws", async () => {
         let theTask = safeExample(123, { throwErr: true });
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
         await theTask;
         if (theTask.isRejected) {
-          expect(theTask.reason).toBe('{}'); // Errors stringify weirdly
+          expect(theTask.reason).toBe("{}"); // Errors stringify weirdly
         }
       });
 
-      describe('when it does not throw', () => {
-        test('and it resolves', async () => {
+      describe("when it does not throw", () => {
+        test("and it resolves", async () => {
           let theTask = safeExample(123);
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           await theTask;
@@ -1979,7 +2403,7 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('and it rejects', async () => {
+        test("and it rejects", async () => {
           let theTask = safeExample(123, { rejectPromise: true });
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           await theTask;
@@ -1993,9 +2417,9 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('safeNullable', () => {
-    const ERROR_MESSAGE = 'the message';
-    const REJECTION_REASON = 'ugh';
+  describe("safeNullable", () => {
+    const ERROR_MESSAGE = "the message";
+    const REJECTION_REASON = "ugh";
 
     function example(
       value: number,
@@ -2011,7 +2435,7 @@ describe('module-scope functions', () => {
         throwErr: false,
         rejectPromise: false,
         returnNull: false,
-      }
+      },
     ): Promise<number | null> {
       if (throwErr) {
         throw new Error(ERROR_MESSAGE);
@@ -2021,10 +2445,12 @@ describe('module-scope functions', () => {
         return Promise.resolve(null);
       }
 
-      return rejectPromise ? Promise.reject(REJECTION_REASON) : Promise.resolve(value);
+      return rejectPromise
+        ? Promise.reject(REJECTION_REASON)
+        : Promise.resolve(value);
     }
 
-    describe('without an error handler', () => {
+    describe("without an error handler", () => {
       let safeExample = safeNullable(example);
       expectTypeOf(safeExample).toEqualTypeOf<
         (
@@ -2033,11 +2459,11 @@ describe('module-scope functions', () => {
             throwErr?: boolean;
             rejectPromise?: boolean;
             returnNull?: boolean;
-          }
+          },
         ) => Task<Maybe<number>, unknown>
       >();
 
-      test('when it throws', async () => {
+      test("when it throws", async () => {
         let theTask = safeExample(123, { throwErr: true });
         expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, unknown>>();
         await theTask;
@@ -2046,8 +2472,8 @@ describe('module-scope functions', () => {
         }
       });
 
-      describe('when it does not throw', () => {
-        test('and it resolves with a value', async () => {
+      describe("when it does not throw", () => {
+        test("and it resolves with a value", async () => {
           let theTask = safeExample(123);
           expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, unknown>>();
           await theTask;
@@ -2061,7 +2487,7 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('and it resolves with null', async () => {
+        test("and it resolves with null", async () => {
           let theTask = safeExample(123, { returnNull: true });
           expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, unknown>>();
           await theTask;
@@ -2072,7 +2498,7 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('and it rejects', async () => {
+        test("and it rejects", async () => {
           let theTask = safeExample(123, { rejectPromise: true });
           expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, unknown>>();
           await theTask;
@@ -2085,7 +2511,7 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with an error handler', () => {
+    describe("with an error handler", () => {
       let safeExample = safeNullable(example, stringify);
       expectTypeOf(safeExample).toEqualTypeOf<
         (
@@ -2094,21 +2520,21 @@ describe('module-scope functions', () => {
             throwErr?: boolean;
             rejectPromise?: boolean;
             returnNull?: boolean;
-          }
+          },
         ) => Task<Maybe<number>, string>
       >();
 
-      test('when it throws', async () => {
+      test("when it throws", async () => {
         let theTask = safeExample(123, { throwErr: true });
         expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, string>>();
         await theTask;
         if (theTask.isRejected) {
-          expect(theTask.reason).toBe('{}'); // Errors stringify weirdly
+          expect(theTask.reason).toBe("{}"); // Errors stringify weirdly
         }
       });
 
-      describe('when it does not throw', () => {
-        test('and it resolves with a value', async () => {
+      describe("when it does not throw", () => {
+        test("and it resolves with a value", async () => {
           let theTask = safeExample(123);
           expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, string>>();
           await theTask;
@@ -2122,7 +2548,7 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('and it resolves with null', async () => {
+        test("and it resolves with null", async () => {
           let theTask = safeExample(123, { returnNull: true });
           expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, string>>();
           await theTask;
@@ -2133,7 +2559,7 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('and it rejects', async () => {
+        test("and it rejects", async () => {
           let theTask = safeExample(123, { rejectPromise: true });
           expectTypeOf(theTask).toEqualTypeOf<Task<Maybe<number>, string>>();
           await theTask;
@@ -2147,9 +2573,9 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('fromPromise', () => {
-    describe('`without a rejection handler`', () => {
-      test('when the promise resolves', async () => {
+  describe("fromPromise", () => {
+    describe("`without a rejection handler`", () => {
+      test("when the promise resolves", async () => {
         let { promise, resolve } = deferred<number, never>();
         let theTask = fromPromise(promise);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, unknown>>();
@@ -2160,12 +2586,12 @@ describe('module-scope functions', () => {
         expect(unwrap(theResult)).toBe(123);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { promise, reject } = deferred<never, string>();
         let theTask = fromPromise(promise);
         expectTypeOf(theTask).toEqualTypeOf<Task<never, unknown>>();
 
-        let theError = 'la';
+        let theError = "la";
         reject(theError);
         let theResult = await theTask;
         expectTypeOf(theResult).toEqualTypeOf<Result<never, unknown>>();
@@ -2173,8 +2599,8 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with a rejection handler', () => {
-      test('when the promise resolves', async () => {
+    describe("with a rejection handler", () => {
+      test("when the promise resolves", async () => {
         let { promise, resolve } = deferred<number, never>();
         let theTask = fromPromise(promise, stringify);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -2185,12 +2611,12 @@ describe('module-scope functions', () => {
         expect(unwrap(theResult)).toBe(123);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { promise, reject } = deferred<never, string>();
         let theTask = fromPromise(promise, stringify);
         expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
 
-        let theError = 'la';
+        let theError = "la";
         reject(theError);
         let theResult = await theTask;
         expectTypeOf(theResult).toEqualTypeOf<Result<never, string>>();
@@ -2199,8 +2625,8 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('fromUnsafePromise', () => {
-    test('when the promise resolves', async () => {
+  describe("fromUnsafePromise", () => {
+    test("when the promise resolves", async () => {
       let { promise, resolve } = deferred<Result<number, string>, never>();
       let theTask = fromUnsafePromise(promise);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -2212,7 +2638,7 @@ describe('module-scope functions', () => {
       expectTypeOf(theResultingResult).toEqualTypeOf(theInputResult);
     });
 
-    test('with a `Promise<Result<T, E>>`', async () => {
+    test("with a `Promise<Result<T, E>>`", async () => {
       let { promise, resolve } = deferred<Result<number, string>, never>();
       let theTask = fromUnsafePromise(promise);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -2222,9 +2648,9 @@ describe('module-scope functions', () => {
       expect(unwrap(result)).toEqual(123);
     });
 
-    test('when the promise rejects', async () => {
+    test("when the promise rejects", async () => {
       let processPromise = new Promise((resolve) => {
-        process.on('unhandledRejection', (error) => {
+        process.on("unhandledRejection", (error) => {
           resolve(error);
         });
       });
@@ -2233,7 +2659,7 @@ describe('module-scope functions', () => {
       let theTask = fromUnsafePromise(promise);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
-      let theReason = 'not good';
+      let theReason = "not good";
       try {
         reject(theReason);
         await promise;
@@ -2248,8 +2674,8 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('fromResult', () => {
-    test('from Ok', async () => {
+  describe("fromResult", () => {
+    test("from Ok", async () => {
       let theResult = Result.ok<number, string>(123);
       let theTask = fromResult(theResult);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -2258,8 +2684,8 @@ describe('module-scope functions', () => {
       expect(theTask.state).toEqual(State.Resolved);
     });
 
-    test('from Err', async () => {
-      let theResult = Result.err<number, string>('error');
+    test("from Err", async () => {
+      let theResult = Result.err<number, string>("error");
       let theTask = fromResult(theResult);
       expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
       let result = await theTask;
@@ -2268,9 +2694,9 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('map', () => {
-    describe('with both arguments', () => {
-      test('for a pending promise', async () => {
+  describe("map", () => {
+    describe("with both arguments", () => {
+      test("for a pending promise", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = map((n: number) => n % 2 == 0, task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
@@ -2279,7 +2705,7 @@ describe('module-scope functions', () => {
         await theTask;
       });
 
-      test('when the promise resolves', async () => {
+      test("when the promise resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = map((n: number) => n % 2 == 0, task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
@@ -2289,20 +2715,20 @@ describe('module-scope functions', () => {
         expect(unwrap(result)).toBe(false);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
         let theTask = map((n: number) => n % 2 == 0, task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(theReason);
       });
     });
 
-    describe('with curried form', () => {
-      test('for a pending promise', async () => {
+    describe("with curried form", () => {
+      test("for a pending promise", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = map((n: number) => n % 2 == 0)(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
@@ -2311,7 +2737,7 @@ describe('module-scope functions', () => {
         await theTask;
       });
 
-      test('when the promise resolves', async () => {
+      test("when the promise resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = map((n: number) => n % 2 == 0)(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
@@ -2321,12 +2747,12 @@ describe('module-scope functions', () => {
         expect(unwrap(result)).toBe(false);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
         let theTask = map((n: number) => n % 2 == 0)(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(theReason);
@@ -2334,15 +2760,15 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('mapRejected', () => {
-    describe('with both arguments', () => {
-      test('for a pending promise', async () => {
+  describe("mapRejected", () => {
+    describe("with both arguments", () => {
+      test("for a pending promise", async () => {
         let { task } = Task.withResolvers<number, string>();
         let theTask = mapRejected(stringify, task);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
       });
 
-      test('when the promise resolves', async () => {
+      test("when the promise resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = mapRejected(stringify, task);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
@@ -2352,26 +2778,26 @@ describe('module-scope functions', () => {
         expect(unwrap(result)).toBe(123);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
         let theTask = mapRejected(stringify, task);
         expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(stringify(theReason));
       });
     });
 
-    describe('with curried form', () => {
-      test('for a pending promise', async () => {
+    describe("with curried form", () => {
+      test("for a pending promise", async () => {
         let { task } = Task.withResolvers<number, string>();
         let theTask = mapRejected(stringify)(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<unknown, string>>();
       });
 
-      test('when the promise resolves', async () => {
+      test("when the promise resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = mapRejected(stringify)(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<unknown, string>>();
@@ -2381,12 +2807,12 @@ describe('module-scope functions', () => {
         expect(unwrap(result)).toBe(123);
       });
 
-      test('when the promise rejects', async () => {
+      test("when the promise rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
         let theTask = mapRejected(stringify)(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<unknown, string>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(stringify(theReason));
@@ -2394,22 +2820,22 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('and', () => {
-    describe('with both arguments', () => {
-      describe('when the first Task resolves', () => {
-        test('when the second Task resolves', async () => {
-          let theValue = 'hello';
+  describe("and", () => {
+    describe("with both arguments", () => {
+      describe("when the first Task resolves", () => {
+        test("when the second Task resolves", async () => {
+          let theValue = "hello";
           let theTask = and(Task.resolve(theValue), Task.resolve(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toEqual(theValue);
         });
 
-        test('when the second Task rejects', async () => {
-          let theReason = 'hello';
+        test("when the second Task rejects", async () => {
+          let theReason = "hello";
           let theTask = and(
             Task.reject<number, string>(theReason),
-            Task.resolve<number, string>(123)
+            Task.resolve<number, string>(123),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
@@ -2417,23 +2843,23 @@ describe('module-scope functions', () => {
         });
       });
 
-      describe('when the first Task rejects', () => {
-        test('when the second Task resolves', async () => {
+      describe("when the first Task rejects", () => {
+        test("when the second Task resolves", async () => {
           let theReason = 123;
           let theTask = and(
             Task.resolve<number, number>(456),
-            Task.reject<string, number>(theReason)
+            Task.reject<string, number>(theReason),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
 
-        test('when the second Task rejects', async () => {
+        test("when the second Task rejects", async () => {
           let theReason = 123;
           let theTask = and(
             Task.reject<string, number>(456),
-            Task.reject<string, number>(theReason)
+            Task.reject<string, number>(theReason),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
@@ -2442,37 +2868,43 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with curried form', () => {
-      describe('when the first Task resolves', () => {
-        test('when the second Task resolves', async () => {
-          let theValue = 'hello';
+    describe("with curried form", () => {
+      describe("when the first Task resolves", () => {
+        test("when the second Task resolves", async () => {
+          let theValue = "hello";
           let theTask = and(Task.resolve(theValue))(Task.resolve(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toEqual(theValue);
         });
 
-        test('when the second Task rejects', async () => {
-          let theReason = 'hello';
-          let theTask = and(Task.reject<number, string>(theReason))(Task.resolve(123));
+        test("when the second Task rejects", async () => {
+          let theReason = "hello";
+          let theTask = and(Task.reject<number, string>(theReason))(
+            Task.resolve(123),
+          );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
       });
 
-      describe('when the first Task rejects', () => {
-        test('when the second Task resolves', async () => {
+      describe("when the first Task rejects", () => {
+        test("when the second Task resolves", async () => {
           let theReason = 123;
-          let theTask = and(Task.resolve<number, number>(456))(Task.reject(theReason));
+          let theTask = and(Task.resolve<number, number>(456))(
+            Task.reject(theReason),
+          );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
         });
 
-        test('when the second Task rejects', async () => {
+        test("when the second Task rejects", async () => {
           let theReason = 123;
-          let theTask = and(Task.reject<string, number>(456))(Task.reject(theReason));
+          let theTask = and(Task.reject<string, number>(456))(
+            Task.reject(theReason),
+          );
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
           expect(unwrapErr(theResult)).toEqual(theReason);
@@ -2481,9 +2913,9 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('andThen', () => {
-    describe('with both arguments', () => {
-      test('for a pending task', async () => {
+  describe("andThen", () => {
+    describe("with both arguments", () => {
+      test("for a pending task", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = andThen((n) => Task.resolve(n % 2 == 0), task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
@@ -2492,7 +2924,7 @@ describe('module-scope functions', () => {
         await theTask;
       });
 
-      test('when the task resolves', async () => {
+      test("when the task resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = andThen((n) => Task.resolve(n % 2 == 0), task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, string>>();
@@ -2502,20 +2934,20 @@ describe('module-scope functions', () => {
         expect(unwrap(result)).toBe(false);
       });
 
-      test('when the task rejects', async () => {
+      test("when the task rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
-        let theTask = andThen(() => Task.reject('oh no'), task);
+        let theTask = andThen(() => Task.reject("oh no"), task);
         expectTypeOf(theTask).toEqualTypeOf<Task<never, string>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(theReason);
       });
     });
 
-    describe('with curried form', () => {
-      test('for a pending task', async () => {
+    describe("with curried form", () => {
+      test("for a pending task", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = andThen((n: number) => Task.resolve(n % 2 == 0))(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
@@ -2524,7 +2956,7 @@ describe('module-scope functions', () => {
         await theTask;
       });
 
-      test('when the task resolves', async () => {
+      test("when the task resolves", async () => {
         let { task, resolve } = Task.withResolvers<number, string>();
         let theTask = andThen((n: number) => Task.resolve(n % 2 == 0))(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<boolean, unknown>>();
@@ -2534,28 +2966,28 @@ describe('module-scope functions', () => {
         expect(unwrap(result)).toBe(false);
       });
 
-      test('when the task rejects', async () => {
+      test("when the task rejects", async () => {
         let { task, reject } = Task.withResolvers<number, string>();
-        let theTask = andThen(() => Task.reject('oh no'))(task);
+        let theTask = andThen(() => Task.reject("oh no"))(task);
         expectTypeOf(theTask).toEqualTypeOf<Task<never, unknown>>();
 
-        let theReason = 'nope';
+        let theReason = "nope";
         reject(theReason);
         let result = await theTask;
         expect(unwrapErr(result)).toEqual(theReason);
       });
     });
 
-    test('with multiple types in the resolution and rejection', async () => {
+    test("with multiple types in the resolution and rejection", async () => {
       class Branded<T extends string> {
         declare readonly _name: T;
       }
 
-      class RejA extends Branded<'rej-a'> {}
-      class RejB extends Branded<'rej-b'> {}
+      class RejA extends Branded<"rej-a"> {}
+      class RejB extends Branded<"rej-b"> {}
 
-      class ResA extends Branded<'res-a'> {}
-      class ResB extends Branded<'res-b'> {}
+      class ResA extends Branded<"res-a"> {}
+      class ResB extends Branded<"res-b"> {}
 
       let theTask = andThen(
         (_) => {
@@ -2573,7 +3005,7 @@ describe('module-scope functions', () => {
 
           return Task.reject(new RejB());
         },
-        new Task<Branded<'res'>, Branded<'rej'>>(() => {})
+        new Task<Branded<"res">, Branded<"rej">>(() => {}),
       );
 
       if (theTask.isResolved) {
@@ -2581,26 +3013,28 @@ describe('module-scope functions', () => {
         expectTypeOf(theTask.value).toEqualTypeOf<ResA | ResB>();
       } else if (theTask.isRejected) {
         // Absorbs initial type as well.
-        expectTypeOf(theTask.reason).toEqualTypeOf<Branded<'rej'> | RejA | RejB>();
+        expectTypeOf(theTask.reason).toEqualTypeOf<
+          Branded<"rej"> | RejA | RejB
+        >();
       }
     });
   });
 
-  describe('or', () => {
-    describe('with both arguments', () => {
-      describe('when the first Task resolves', () => {
-        test('when the second Task resolves', async () => {
-          let theTask = or(Task.resolve('B'), Task.resolve('A'));
+  describe("or", () => {
+    describe("with both arguments", () => {
+      describe("when the first Task resolves", () => {
+        test("when the second Task resolves", async () => {
+          let theTask = or(Task.resolve("B"), Task.resolve("A"));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
-          expect(unwrap(theResult)).toEqual('A');
+          expect(unwrap(theResult)).toEqual("A");
         });
 
-        test('when the second Task rejects', async () => {
-          let theReason = 'hello';
+        test("when the second Task rejects", async () => {
+          let theReason = "hello";
           let theTask = or(
             Task.reject<number, string>(theReason),
-            Task.resolve<number, string>(123)
+            Task.resolve<number, string>(123),
           );
           expectTypeOf(theTask).toEqualTypeOf<Task<number, string>>();
           let theResult = await theTask;
@@ -2608,15 +3042,15 @@ describe('module-scope functions', () => {
         });
       });
 
-      describe('when the first Task rejects', () => {
-        test('when the second Task resolves', async () => {
-          let theTask = or(Task.resolve('B'), Task.reject(123));
+      describe("when the first Task rejects", () => {
+        test("when the second Task resolves", async () => {
+          let theTask = or(Task.resolve("B"), Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, never>>();
           let theResult = await theTask;
-          expect(unwrap(theResult)).toBe('B');
+          expect(unwrap(theResult)).toBe("B");
         });
 
-        test('when the second Task rejects', async () => {
+        test("when the second Task rejects", async () => {
           let theTask = or(Task.reject<string, number>(456), Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<string, number>>();
           let theResult = await theTask;
@@ -2625,33 +3059,35 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with curried form', () => {
-      describe('when the first Task resolves', () => {
-        test('when the second Task resolves', async () => {
-          let theTask = or(Task.resolve('B'))(Task.resolve('A'));
+    describe("with curried form", () => {
+      describe("when the first Task resolves", () => {
+        test("when the second Task resolves", async () => {
+          let theTask = or(Task.resolve("B"))(Task.resolve("A"));
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, never>>();
           let theResult = await theTask;
-          expect(unwrap(theResult)).toEqual('A');
+          expect(unwrap(theResult)).toEqual("A");
         });
 
-        test('when the second Task rejects', async () => {
-          let theReason = 'hello';
-          let theTask = or(Task.reject<number, string>(theReason))(Task.resolve(123));
+        test("when the second Task rejects", async () => {
+          let theReason = "hello";
+          let theTask = or(Task.reject<number, string>(theReason))(
+            Task.resolve(123),
+          );
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, string>>();
           let theResult = await theTask;
           expect(unwrap(theResult)).toBe(123);
         });
       });
 
-      describe('when the first Task rejects', () => {
-        test('when the second Task resolves', async () => {
-          let theTask = or(Task.resolve('B'))(Task.reject(123));
+      describe("when the first Task rejects", () => {
+        test("when the second Task resolves", async () => {
+          let theTask = or(Task.resolve("B"))(Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, never>>();
           let theResult = await theTask;
-          expect(unwrap(theResult)).toBe('B');
+          expect(unwrap(theResult)).toBe("B");
         });
 
-        test('when the second Task rejects', async () => {
+        test("when the second Task rejects", async () => {
           let theTask = or(Task.reject<string, number>(456))(Task.reject(123));
           expectTypeOf(theTask).toEqualTypeOf<Task<unknown, number>>();
           let theResult = await theTask;
@@ -2661,18 +3097,21 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('orElse', () => {
-    test('for a pending promise', async () => {
-      let theTask = orElse((reason) => Task.resolve(reason.length), new Task<number, string>(noOp));
+  describe("orElse", () => {
+    test("for a pending promise", async () => {
+      let theTask = orElse(
+        (reason) => Task.resolve(reason.length),
+        new Task<number, string>(noOp),
+      );
       expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
       expect(theTask.state).toBe(State.Pending);
     });
 
-    test('when the promise resolves', async () => {
+    test("when the promise resolves", async () => {
       let theTask = orElse(
         (reason) => Task.resolve(reason.length),
-        Task.resolve<number, string>(123)
+        Task.resolve<number, string>(123),
       );
       expectTypeOf(theTask).toEqualTypeOf<Task<number, never>>();
 
@@ -2680,10 +3119,10 @@ describe('module-scope functions', () => {
       expect(unwrap(result)).toBe(123);
     });
 
-    test('when the promise rejects', async () => {
+    test("when the promise rejects", async () => {
       let theTask = orElse(
         (reason) => Task.reject(reason.length),
-        Task.reject<number, string>('first error')
+        Task.reject<number, string>("first error"),
       );
       expectTypeOf(theTask).toEqualTypeOf<Task<number, number>>();
 
@@ -2691,16 +3130,16 @@ describe('module-scope functions', () => {
       expect(unwrapErr(result)).toBe(11);
     });
 
-    test('with multiple types in the resolution and rejection', async () => {
+    test("with multiple types in the resolution and rejection", async () => {
       class Branded<T extends string> {
         declare readonly _name: T;
       }
 
-      class RejA extends Branded<'rej-a'> {}
-      class RejB extends Branded<'rej-b'> {}
+      class RejA extends Branded<"rej-a"> {}
+      class RejB extends Branded<"rej-b"> {}
 
-      class ResA extends Branded<'res-a'> {}
-      class ResB extends Branded<'res-b'> {}
+      class ResA extends Branded<"res-a"> {}
+      class ResB extends Branded<"res-b"> {}
 
       let theTask = orElse(
         (_) => {
@@ -2718,12 +3157,14 @@ describe('module-scope functions', () => {
 
           return Task.reject(new RejB());
         },
-        new Task<Branded<'res'>, Branded<'rej'>>(() => {})
+        new Task<Branded<"res">, Branded<"rej">>(() => {}),
       );
 
       if (theTask.isResolved) {
         // Absorbs initial type as well.
-        expectTypeOf(theTask.value).toEqualTypeOf<Branded<'res'> | ResA | ResB>();
+        expectTypeOf(theTask.value).toEqualTypeOf<
+          Branded<"res"> | ResA | ResB
+        >();
       } else if (theTask.isRejected) {
         // Does *not* absorb initial type.
         expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
@@ -2731,44 +3172,44 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('match', () => {
-    describe('with both arguments', () => {
-      test('with a resolved task', async () => {
+  describe("match", () => {
+    describe("with both arguments", () => {
+      test("with a resolved task", async () => {
         let result = await match(
           {
             Resolved: (n) => n * 2,
             Rejected: () => -1,
           },
-          Task.resolve(2)
+          Task.resolve(2),
         );
         expect(result).toBe(4);
       });
 
-      test('with a rejected task', async () => {
+      test("with a rejected task", async () => {
         let result = await match(
           {
             Resolved: (n) => n * 2,
             Rejected: () => -1,
           },
-          Task.reject('oops')
+          Task.reject("oops"),
         );
         expect(result).toBe(-1);
       });
 
-      test('with a pending task', async () => {
+      test("with a pending task", async () => {
         let result = match(
           {
             Resolved: (n: number) => n * 2,
             Rejected: () => -1,
           },
-          new Task(noOp)
+          new Task(noOp),
         );
         expectTypeOf(result).toEqualTypeOf<Promise<number>>();
       });
     });
 
-    describe('with curried form', () => {
-      test('with a resolved task', async () => {
+    describe("with curried form", () => {
+      test("with a resolved task", async () => {
         let result = await match({
           Resolved: (n: number) => n * 2,
           Rejected: () => -1,
@@ -2776,15 +3217,15 @@ describe('module-scope functions', () => {
         expect(result).toBe(4);
       });
 
-      test('with a rejected task', async () => {
+      test("with a rejected task", async () => {
         let result = await match({
           Resolved: (n: number) => n * 2,
           Rejected: () => -1,
-        })(Task.reject('oops'));
+        })(Task.reject("oops"));
         expect(result).toBe(-1);
       });
 
-      test('with a pending task', async () => {
+      test("with a pending task", async () => {
         let result = match({
           Resolved: (n: number) => n * 2,
           Rejected: () => -1,
@@ -2794,10 +3235,10 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('timeout', () => {
-    describe('with both arguments', () => {
-      describe('with a number', () => {
-        test('that is shorter', async () => {
+  describe("timeout", () => {
+    describe("with both arguments", () => {
+      describe("with a number", () => {
+        test("that is shorter", async () => {
           // shorter by dint of "literally any timeout is shorter than never".
           let { task } = Task.withResolvers<string, never>();
           let result = await timeout(1, task);
@@ -2809,25 +3250,29 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('that is equal', async () => {
+        test("that is equal", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(duration, task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
 
-        test('that is longer', async () => {
+        test("that is longer", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(duration * 2, task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
       });
 
-      describe('with another timer', () => {
-        test('that is shorter', async () => {
+      describe("with another timer", () => {
+        test("that is shorter", async () => {
           // shorter by dint of "literally any timeout is shorter than never".
           let { task } = Task.withResolvers<string, never>();
           let result = await timeout(timer(1), task);
@@ -2839,17 +3284,21 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('that is equal', async () => {
+        test("that is equal", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(timer(duration), task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
 
-        test('that is longer', async () => {
+        test("that is longer", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(timer(duration * 2), task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
@@ -2857,9 +3306,9 @@ describe('module-scope functions', () => {
       });
     });
 
-    describe('with curried form', () => {
-      describe('with a number', () => {
-        test('that is shorter', async () => {
+    describe("with curried form", () => {
+      describe("with a number", () => {
+        test("that is shorter", async () => {
           // shorter by dint of "literally any timeout is shorter than never".
           let { task } = Task.withResolvers<string, never>();
           let result = await timeout(1)(task);
@@ -2871,25 +3320,29 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('that is equal', async () => {
+        test("that is equal", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(duration)(task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
 
-        test('that is longer', async () => {
+        test("that is longer", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(duration * 2)(task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
       });
 
-      describe('with another timer', () => {
-        test('that is shorter', async () => {
+      describe("with another timer", () => {
+        test("that is shorter", async () => {
           // shorter by dint of "literally any timeout is shorter than never".
           let { task } = Task.withResolvers<string, never>();
           let result = await timeout(timer(1))(task);
@@ -2901,17 +3354,21 @@ describe('module-scope functions', () => {
           }
         });
 
-        test('that is equal', async () => {
+        test("that is equal", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(timer(duration))(task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
         });
 
-        test('that is longer', async () => {
+        test("that is longer", async () => {
           let duration = 1;
-          let task = new Task((resolve) => setTimeout(() => resolve(duration), duration));
+          let task = new Task((resolve) =>
+            setTimeout(() => resolve(duration), duration),
+          );
           let result = await timeout(timer(duration * 2))(task);
           expect(result.isOk).toBe(true);
           expect(unwrap(result)).toBe(duration);
@@ -2920,18 +3377,18 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('toPromise', () => {
-    test('with a directly-constructed task', async () => {
+  describe("toPromise", () => {
+    test("with a directly-constructed task", async () => {
       let { task, resolve } = Task.withResolvers();
       let promise = toPromise(task);
 
-      let theValue = 'hello';
+      let theValue = "hello";
       resolve(theValue);
       let output = await promise;
       expect(unwrap(output)).toEqual(theValue);
     });
 
-    test('with a passed-in-promise', async () => {
+    test("with a passed-in-promise", async () => {
       let { promise: theInputPromise, resolve } = deferred();
       let theTask = fromPromise(theInputPromise);
 
@@ -2942,33 +3399,35 @@ describe('module-scope functions', () => {
     });
   });
 
-  describe('withRetries', () => {
-    test('when the task initially rejects but later resolves', async () => {
+  describe("withRetries", () => {
+    test("when the task initially rejects but later resolves", async () => {
       let theTask = withRetries(({ count }) => {
         return count === 0
-          ? Task.reject('not the first time')
-          : Task.resolve('but the second will do!');
+          ? Task.reject("not the first time")
+          : Task.resolve("but the second will do!");
       });
 
       let theResult = await theTask;
-      expect(unwrap(theResult)).toEqual('but the second will do!');
+      expect(unwrap(theResult)).toEqual("but the second will do!");
     });
 
-    describe('when the task never resolves', () => {
-      test('not using the `status` parameter', async () => {
+    describe("when the task never resolves", () => {
+      test("not using the `status` parameter", async () => {
         let theTask = withRetries(() => {
-          return Task.reject('this test *always* rejects until the count runs out');
+          return Task.reject(
+            "this test *always* rejects until the count runs out",
+          );
         });
 
         let theError = unwrapErr(await theTask);
         assert(theError instanceof Error);
         expect(isRetryFailed(theError));
         expect(printError(theError)).toMatch(
-          /TrueMyth.Task.RetryFailed: Stopped retrying after 3 tries \(\d+ms\)/
+          /TrueMyth.Task.RetryFailed: Stopped retrying after 3 tries \(\d+ms\)/,
         );
       });
 
-      test('using the `status` parameter', async () => {
+      test("using the `status` parameter", async () => {
         let theCount = 2;
         let theMessage = `maximum count is ${theCount}`;
         let theTask = withRetries(({ count }) => {
@@ -2976,20 +3435,24 @@ describe('module-scope functions', () => {
             return stopRetrying(theMessage);
           }
 
-          return Task.reject('this test *always* rejects until the count runs out');
+          return Task.reject(
+            "this test *always* rejects until the count runs out",
+          );
         });
 
         let theError = unwrapErr(await theTask);
         assert(theError instanceof Error);
         let errorDesc = printError(theError);
         expect(errorDesc).toMatch(
-          /TrueMyth\.Task\.RetryFailed: Stopped retrying after 2 tries \(\d+ms\)/
+          /TrueMyth\.Task\.RetryFailed: Stopped retrying after 2 tries \(\d+ms\)/,
         );
-        expect(errorDesc).toMatch(`\tcaused by: TrueMyth.Task.StopRetrying: ${theMessage}`);
+        expect(errorDesc).toMatch(
+          `\tcaused by: TrueMyth.Task.StopRetrying: ${theMessage}`,
+        );
       });
 
-      test('when it rejects with `stopRetrying`', async () => {
-        let theMessage = 'any reason at all will do';
+      test("when it rejects with `stopRetrying`", async () => {
+        let theMessage = "any reason at all will do";
         let theTask = withRetries(() => {
           return Task.reject(stopRetrying(theMessage));
         });
@@ -2998,132 +3461,139 @@ describe('module-scope functions', () => {
         assert(theError instanceof Error);
         let errorDesc = printError(theError);
         expect(errorDesc).toMatch(
-          /TrueMyth\.Task\.RetryFailed: Stopped retrying after 0 tries \(\d+ms\)/
+          /TrueMyth\.Task\.RetryFailed: Stopped retrying after 0 tries \(\d+ms\)/,
         );
-        expect(errorDesc).toMatch(`\tcaused by: TrueMyth.Task.StopRetrying: ${theMessage}`);
+        expect(errorDesc).toMatch(
+          `\tcaused by: TrueMyth.Task.StopRetrying: ${theMessage}`,
+        );
       });
 
-      test('when it rejects with a non-zero duration', async () => {
-        let theResult = await withRetries(() => Task.reject('never succeeds'), take(fixed(), 5));
+      test("when it rejects with a non-zero duration", async () => {
+        let theResult = await withRetries(
+          () => Task.reject("never succeeds"),
+          take(fixed(), 5),
+        );
         let theError = unwrapErr(theResult);
         assert(theError instanceof Error);
         expect(printError(theError)).toMatch(
-          /TrueMyth\.Task\.RetryFailed: Stopped retrying after 5 tries \(\d+ms\)/
+          /TrueMyth\.Task\.RetryFailed: Stopped retrying after 5 tries \(\d+ms\)/,
         );
       });
     });
 
-    test('type checks when explicitly passed a `Strategy`', () => {
+    test("type checks when explicitly passed a `Strategy`", () => {
       let retryable = () => new Task(() => {});
       let strategy = function* (): Strategy {};
       expectTypeOf(withRetries).toBeCallableWith(retryable, strategy());
     });
   });
 
-  describe('delays', () => {
-    describe('exponential', () => {
-      test('with default factor (2)', () => {
+  describe("delays", () => {
+    describe("exponential", () => {
+      test("with default factor (2)", () => {
         let values = Array.from(take(exponential(), 5));
         expect(values).toEqual([1, 2, 4, 8, 16]);
       });
 
-      test('with custom factor', () => {
+      test("with custom factor", () => {
         let values = Array.from(take(exponential({ withFactor: 4 }), 5));
         expect(values).toEqual([1, 4, 16, 64, 256]);
       });
 
-      describe('with non-integral base', () => {
-        test('that should round down', () => {
+      describe("with non-integral base", () => {
+        test("that should round down", () => {
           let values = Array.from(take(exponential({ from: 1.1 }), 5));
           expect(values).toEqual([1, 2, 4, 8, 16]);
         });
 
-        test('that should round up', () => {
+        test("that should round up", () => {
           let values = Array.from(take(exponential({ from: 0.9 }), 5));
           expect(values).toEqual([1, 2, 4, 8, 16]);
         });
       });
     });
 
-    describe('fibonacci', () => {
-      test('with default values', () => {
+    describe("fibonacci", () => {
+      test("with default values", () => {
         let values = Array.from(take(fibonacci(), 5));
         expect(values).toEqual([1, 1, 2, 3, 5]);
       });
 
-      test('with initial value `1`', () => {
+      test("with initial value `1`", () => {
         let values = Array.from(take(fibonacci({ from: 1 }), 5));
         expect(values).toEqual([1, 1, 2, 3, 5]);
       });
 
-      test('with initial value `2`', () => {
+      test("with initial value `2`", () => {
         let values = Array.from(take(fibonacci({ from: 2 }), 5));
         expect(values).toEqual([2, 2, 4, 6, 10]);
       });
 
-      describe('with non-integral initial value', () => {
-        test('that should be rounded down', () => {
+      describe("with non-integral initial value", () => {
+        test("that should be rounded down", () => {
           let values = Array.from(take(fibonacci({ from: 1.1 }), 5));
           expect(values).toEqual([1, 1, 2, 3, 5]);
         });
 
-        test('that should be rounded up', () => {
+        test("that should be rounded up", () => {
           let values = Array.from(take(fibonacci({ from: 0.9 }), 5));
           expect(values).toEqual([1, 1, 2, 3, 5]);
         });
       });
     });
 
-    describe('fixed', () => {
-      test('with default initial value', () => {
+    describe("fixed", () => {
+      test("with default initial value", () => {
         let values = Array.from(take(fixed(), 5));
         expect(values).toEqual([1, 1, 1, 1, 1]);
       });
 
-      test('with integral value', () => {
+      test("with integral value", () => {
         let values = Array.from(take(fixed({ at: 5 }), 5));
         expect(values).toEqual([5, 5, 5, 5, 5]);
       });
 
-      test('with non-integral value', () => {
+      test("with non-integral value", () => {
         let values = Array.from(take(fixed({ at: 1.2 }), 5));
         expect(values).toEqual([1, 1, 1, 1, 1]);
       });
     });
 
-    test('immediate', () => {
+    test("immediate", () => {
       let values = Array.from(take(immediate(), 5));
       expect(values).toEqual([0, 0, 0, 0, 0]);
     });
 
-    describe('linear', () => {
-      test('with default initial value and step size', () => {
+    describe("linear", () => {
+      test("with default initial value and step size", () => {
         let values = Array.from(take(linear(), 10));
         expect(values).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
       });
 
-      test('with custom initial value', () => {
+      test("with custom initial value", () => {
         let values = Array.from(take(linear({ from: 1 }), 5));
         expect(values).toEqual([1, 2, 3, 4, 5]);
       });
 
-      test('with custom step size', () => {
+      test("with custom step size", () => {
         let values = Array.from(take(linear({ withStepSize: 2 }), 5));
         expect(values).toEqual([0, 2, 4, 6, 8]);
       });
 
-      test('with non-integral value', () => {
-        let values = Array.from(take(linear({ from: 1.1, withStepSize: 2 }), 5));
+      test("with non-integral value", () => {
+        let values = Array.from(
+          take(linear({ from: 1.1, withStepSize: 2 }), 5),
+        );
         expect(values).toEqual([1, 3, 5, 7, 9]);
       });
     });
 
-    test('none', () => {
+    test("none", () => {
       let values = Array.from(none());
       expect(values.length).toBe(0);
     });
 
-    describe('jitter', () => {
+    describe("jitter", () => {
       let originalMathRandom: typeof Math.random;
       beforeEach(() => {
         originalMathRandom = Math.random;
@@ -3133,7 +3603,7 @@ describe('module-scope functions', () => {
         Math.random = originalMathRandom;
       });
 
-      test('with random value below 0.5', () => {
+      test("with random value below 0.5", () => {
         Math.random = () => 0.25;
 
         let input = [1, 2, 3];
@@ -3145,7 +3615,7 @@ describe('module-scope functions', () => {
         }
       });
 
-      test('with random value above 0.5', () => {
+      test("with random value above 0.5", () => {
         Math.random = () => 0.75;
 
         let input = [1, 2, 3];
@@ -3160,12 +3630,13 @@ describe('module-scope functions', () => {
   });
 });
 
-describe('type utilities', () => {
-  test('results for array of tasks', () => {
-    expectTypeOf<Settled<[Task<string, number>]>>().toEqualTypeOf<[Result<string, number>]>();
-    expectTypeOf<Settled<[Task<string, number>, Task<number, string>]>>().toEqualTypeOf<
-      [Result<string, number>, Result<number, string>]
-    >;
+describe("type utilities", () => {
+  test("results for array of tasks", () => {
+    expectTypeOf<Settled<[Task<string, number>]>>().toEqualTypeOf<
+      [Result<string, number>]
+    >();
+    expectTypeOf<Settled<[Task<string, number>, Task<number, string>]>>()
+      .toEqualTypeOf<[Result<string, number>, Result<number, string>]>;
     expectTypeOf<
       Settled<
         [
@@ -3185,8 +3656,14 @@ describe('type utilities', () => {
     >();
 
     expectTypeOf<
-      Settled<Array<Task<string, number> | Task<number, string> | Task<boolean, Error>>>
-    >().toEqualTypeOf<Array<Result<string | number | boolean, number | string | Error>>>();
+      Settled<
+        Array<
+          Task<string, number> | Task<number, string> | Task<boolean, Error>
+        >
+      >
+    >().toEqualTypeOf<
+      Array<Result<string | number | boolean, number | string | Error>>
+    >();
   });
 });
 
@@ -3229,6 +3706,6 @@ function printError(e: Error): string {
   let maybeCause =
     e.cause instanceof Error ? Maybe.just(printError(e.cause)) : Maybe.of(e.cause?.toString());
 
-  let cause = maybeCause.mapOr('', (cause) => `\n\tcaused by: ${cause}`);
+  let cause = maybeCause.mapOr("", (cause) => `\n\tcaused by: ${cause}`);
   return `${e.name}: ${e.message}${cause}`;
 }

--- a/test/test-support.test.ts
+++ b/test/test-support.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-import { Result, Maybe } from 'true-myth';
-import { unwrap, unwrapErr } from 'true-myth/test-support';
+import { Result, Maybe } from "true-myth";
+import { unwrap, unwrapErr } from "true-myth/test-support";
 
-describe('`unwrap`', () => {
-  test('works on a `Just`', () => {
-    let it = Maybe.of('hello');
+describe("`unwrap`", () => {
+  test("works on a `Just`", () => {
+    let it = Maybe.of("hello");
     let unwrapped = unwrap(it);
-    expect(unwrapped).toBe('hello');
+    expect(unwrapped).toBe("hello");
     expectTypeOf(unwrapped).toBeString();
   });
 
-  test('throws on a `Nothing`', () => {
+  test("throws on a `Nothing`", () => {
     let it = Maybe.nothing<string>();
     expect(() => unwrap(it)).toThrow();
   });
 
-  test('works on an `Ok`', () => {
-    let it = Result.ok('hello');
+  test("works on an `Ok`", () => {
+    let it = Result.ok("hello");
     let unwrapped = unwrap(it);
-    expect(unwrapped).toBe('hello');
+    expect(unwrapped).toBe("hello");
     expectTypeOf(unwrapped).toBeString();
   });
 });
 
-describe('`unwrapErr`', () => {
-  test('throws on an `Ok`', () => {
-    let it = Result.ok('hello');
+describe("`unwrapErr`", () => {
+  test("throws on an `Ok`", () => {
+    let it = Result.ok("hello");
     expect(() => unwrapErr(it)).toThrow();
   });
 
-  test('unwrap throws on a Nothing', () => {
-    let it = Result.err('oh no');
+  test("unwrap throws on a Nothing", () => {
+    let it = Result.err("oh no");
     let unwrapped = unwrapErr(it);
-    expect(unwrapped).toBe('oh no');
+    expect(unwrapped).toBe("oh no");
     expectTypeOf(unwrapped).toBeString();
   });
 });

--- a/test/toolbelt.test.ts
+++ b/test/toolbelt.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, expectTypeOf, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from "vitest";
 
-import Maybe from 'true-myth/maybe';
-import Result from 'true-myth/result';
+import Maybe from "true-myth/maybe";
+import Result from "true-myth/result";
 import {
   transposeResult,
   transposeMaybe,
@@ -10,43 +10,43 @@ import {
   fromResult,
   fromMaybe,
   toMaybe,
-} from 'true-myth/toolbelt';
+} from "true-myth/toolbelt";
 
-describe('transposeResult', () => {
-  test('Ok(Just(T))', () => {
+describe("transposeResult", () => {
+  test("Ok(Just(T))", () => {
     let result = Result.ok<Maybe<number>, string>(Maybe.just(12));
     let transposed = transposeResult(result);
     expect(transposed).toStrictEqual(Maybe.just(Result.ok(12)));
     expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
   });
 
-  test('Ok(Nothing)', () => {
+  test("Ok(Nothing)", () => {
     let result = Result.ok<Maybe<number>, string>(Maybe.nothing<number>());
     let transposed = transposeResult(result);
     expect(transposed).toStrictEqual(Maybe.nothing());
     expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
   });
 
-  test('Err(E)', () => {
-    let result = Result.err<Maybe<number>, string>('hello');
+  test("Err(E)", () => {
+    let result = Result.err<Maybe<number>, string>("hello");
     let transposed = transposeResult(result);
-    expect(transposed).toStrictEqual(Maybe.just(Result.err('hello')));
+    expect(transposed).toStrictEqual(Maybe.just(Result.err("hello")));
     expectTypeOf(transposed).toEqualTypeOf<Maybe<Result<number, string>>>();
   });
 });
 
-test('`toMaybe`', () => {
-  const theValue = 'huzzah';
+test("`toMaybe`", () => {
+  const theValue = "huzzah";
   const anOk = Result.ok(theValue);
   expect(toMaybe(anOk)).toEqual(Maybe.just(theValue));
 
-  const anErr = Result.err<number, string>('uh uh');
+  const anErr = Result.err<number, string>("uh uh");
   expect(toMaybe(anErr)).toEqual(Maybe.nothing());
 });
 
-test('fromMaybe', () => {
-  const theValue = 'something';
-  const errValue = 'what happened?';
+test("fromMaybe", () => {
+  const theValue = "something";
+  const errValue = "what happened?";
 
   const aJust = Maybe.just(theValue);
   const anOk = Result.ok(theValue);
@@ -57,22 +57,22 @@ test('fromMaybe', () => {
   expect(fromMaybe(errValue, aNothing)).toEqual(anErr);
 });
 
-describe('transposeMaybe', () => {
-  test('Just(Ok(T))', () => {
+describe("transposeMaybe", () => {
+  test("Just(Ok(T))", () => {
     let maybe = Maybe.just(Result.ok<number, string>(12));
     let transposed = transposeMaybe(maybe);
     expect(transposed).toStrictEqual(Result.ok(Maybe.just(12)));
     expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
   });
 
-  test('Just(Err(E))', () => {
-    let maybe = Maybe.just(Result.err<number, string>('whoops'));
+  test("Just(Err(E))", () => {
+    let maybe = Maybe.just(Result.err<number, string>("whoops"));
     let transposed = transposeMaybe(maybe);
-    expect(transposed).toStrictEqual(Result.err('whoops'));
+    expect(transposed).toStrictEqual(Result.err("whoops"));
     expectTypeOf(transposed).toEqualTypeOf<Result<Maybe<number>, string>>();
   });
 
-  test('Nothing', () => {
+  test("Nothing", () => {
     let maybe = Maybe.nothing<Result<number, string>>();
     let transposed = transposeMaybe(maybe);
     expect(transposed).toStrictEqual(Result.ok(Maybe.nothing()));
@@ -80,38 +80,40 @@ describe('transposeMaybe', () => {
   });
 });
 
-test('`toOkOrErr`', () => {
-  const theValue = 'string';
+test("`toOkOrErr`", () => {
+  const theValue = "string";
   const theJust = Maybe.of(theValue);
-  const errValue = { reason: 'such badness' };
+  const errValue = { reason: "such badness" };
 
   expect(toOkOrErr(errValue, theJust)).toEqual(Result.ok(theValue));
   expect(toOkOrErr(errValue, Maybe.nothing())).toEqual(Result.err(errValue));
 
   expect(toOkOrErr<string, typeof errValue>(errValue)(theJust)).toEqual(
-    toOkOrErr(errValue, theJust)
+    toOkOrErr(errValue, theJust),
   );
 });
 
-test('`toOkOrElseErr`', () => {
+test("`toOkOrElseErr`", () => {
   const theJust = Maybe.of(12);
   const errValue = 24;
   const getErrValue = () => errValue;
 
   expect(toOkOrElseErr(getErrValue, theJust)).toEqual(Result.ok(12));
-  expect(toOkOrElseErr(getErrValue, Maybe.nothing())).toEqual(Result.err(errValue));
+  expect(toOkOrElseErr(getErrValue, Maybe.nothing())).toEqual(
+    Result.err(errValue),
+  );
 
   expect(toOkOrElseErr<number, number>(getErrValue)(theJust)).toEqual(
-    toOkOrElseErr(getErrValue, theJust)
+    toOkOrElseErr(getErrValue, theJust),
   );
 });
 
-test('`fromResult`', () => {
+test("`fromResult`", () => {
   const value = 1000;
   const anOk = Result.ok(value);
   expect(fromResult(anOk)).toEqual(Maybe.just(value));
 
-  const reason = 'oh teh noes';
+  const reason = "oh teh noes";
   const anErr = Result.err<number, string>(reason);
   expect(fromResult(anErr)).toEqual(Maybe.nothing());
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,8 +1,8 @@
-import { expect, expectTypeOf, test } from 'vitest';
+import { expect, expectTypeOf, test } from "vitest";
 
-import Unit, { Unit as RexportedUnit } from 'true-myth/unit';
+import Unit, { Unit as RexportedUnit } from "true-myth/unit";
 
-test('the unit type', () => {
+test("the unit type", () => {
   expectTypeOf<Unit>().not.toEqualTypeOf<{}>();
   expectTypeOf({}).not.toEqualTypeOf(Unit);
   expectTypeOf<Unit>().toEqualTypeOf<RexportedUnit>();


### PR DESCRIPTION
This makes it easier to work with a mix of asynchronous and synchronous fallible code, e.g. a safe/wrapped `fetch` call that produces a `Task` followed by a safe synchronous operation like parsing the resulting data with Zod.

This was entirely possible to accomplish previously using `fromResult` from the `task` module:

```ts
import * as task from 'true-myth/task';
// Assume `safeFetch` and `safeJson` both produce a `Task`, while the
// `parseUser` function produces a `Result<User, ParseError>`.
import { safeFetch, safeJson, parseUser } from 'somewhere';

let userResult = safeFetch('https://example.com/users/1')
  .andThen((res) => safeJson(res))
  .andThen((json) => task.fromResult(parseUser(json)));
```

That is not too bad, but it could get repetitive. More importantly, it does not align with users’ expectations from the `Promise` API, which absorbs/lifts synchronous values into the `Promise`. The above example can thus now be written like this:

```ts
import * as task from 'true-myth/task';
import { safeFetch, safeJson, parseUser } from 'somewhere';

let userResult = safeFetch('https://example.com/users/1')
  .andThen((res) => safeJson(res))
  .andThen((json) => parseUser(json));
```

Fixes #1064