### PR TITLE
Add `flatten` functions and methods to `Maybe`, `Result`, and `Task`

### DIFF
--- a/src/-private/utils.ts
+++ b/src/-private/utils.ts
@@ -34,6 +34,10 @@ export function safeToString(value: unknown): string {
   }
 }
 
+export function identity<T>(value: T): T {
+  return value;
+}
+
 /**
   This is the standard *correct* definition for a function which is a proper
   subtype of all other functions: parameters of a function subtype must be

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, test } from 'vitest';
 import Maybe, { Variant, type Nothing, type Just, type Matcher } from 'true-myth/maybe';
 import * as maybe from 'true-myth/maybe';
 import { Unit } from 'true-myth/unit';
+import { unwrap } from 'true-myth/test-support';
 
 type Neat = { neat: string };
 
@@ -747,6 +748,23 @@ describe('`Maybe` pure functions', () => {
 
     expect(maybe.isNothing(testNothing)).toEqual(true);
   });
+
+  describe('`flatten`', () => {
+    test('with `Just(Just(value))', () => {
+      let wrapped = maybe.just(maybe.just(123));
+      expect(maybe.flatten(wrapped)).toEqual(maybe.just(123));
+    });
+
+    test('with `Just(Nothing)`', () => {
+      let wrapped = maybe.just(maybe.nothing());
+      expect(maybe.flatten(wrapped)).toEqual(maybe.nothing());
+    });
+
+    test('with `Nothing<Maybe<string>>`', () => {
+      let wrapped = maybe.nothing<Maybe<string>>();
+      expect(maybe.flatten(wrapped)).toEqual(maybe.nothing());
+    });
+  });
 });
 
 // We aren't even really concerned with the "runtime" behavior here, which we
@@ -1312,6 +1330,36 @@ describe('`Maybe` class', () => {
         .get('deeper')
         .get('key names');
       expect(result).toEqual(maybe.nothing());
+    });
+  });
+
+  // Applies to *combination* of `Just` and `Nothing`.
+  describe('`flatten` method', () => {
+    test('with `Just(Just(value))', () => {
+      let wrapped = maybe.just(maybe.just(123));
+      expect(wrapped.flatten()).toEqual(maybe.just(123));
+    });
+
+    test('with `Just(Nothing)`', () => {
+      let wrapped = maybe.just(maybe.nothing());
+      expect(wrapped.flatten()).toEqual(maybe.nothing());
+    });
+
+    test('with `Nothing<Maybe<string>>`', () => {
+      let wrapped = maybe.nothing<Maybe<string>>();
+      expect(wrapped.flatten()).toEqual(maybe.nothing());
+    });
+
+    test('is not callable when the type is not nested', () => {
+      let normal = maybe.of(123);
+
+      let flattened =
+        // @ts-expect-error -- cannot call `flatten` on on-nested methods.
+        normal
+          // this comment prevents reformatting: we want the pragma to apply to
+          // the previous line only!
+          .flatten();
+      expect(unwrap(flattened)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Introduce both function and method variants to flatten nested items of each type:

```ts
import * as tm from 'true-myth';

let unnestedMaybe = tm.maybe.of(tm.maybe.of(123)).flatten();
console.log(unnestedMaybe); // Just(123)

let unnestedResult = tm.result.ok(tm.result.ok(456)).flatten();
console.log(unnestedResult); // Ok(456)

let unnestedTask = tm.task.resolve(tm.task.resolve(789)).flatten();
await unnestedTask;
console.log(unnestedTask); // Resolved(789)
```

The semantics are identical to (and the implementation is) using `andThen` with an `identity` function. Here’s what that means in practice:

| Outer             | Inner             | After `flatten`             |
| ----------------- | ----------------- | --------------------------- |
| `Just`            | `Just(inner)`     | `Just(inner)`               |
| `Just`            | `Nothing`         | `Nothing`                   |
| `Nothing`         | N/A               | `Nothing`                   |
| `Ok`              | `Ok(inner)`       | `Ok(inner)`                 |
| `Ok`              | `Err(inner)`      | `Err(inner)`                |
| `Err(outer)`      | N/A               | `Err(outer)`                |
| `Err`             | `Err(inner)`      | `Err(Err(inner))`           |
| `Resolved`        | `Resolved(inner)` | `Resolved(inner)`           |
| `Resolved`        | `Rejected(inner)` | `Rejected(inner)`           |
| `Rejected(outer)` | N/A               | `Rejected(outer)`           |
| `Rejected`        | `Rejected(inner)` | `Rejected(Rejected(inner))` |

There is no attempt to collapse the other types. We may revisit that for `Task<Result<T, E>>` or `Result<Task<T, E>>` if there is demand, but this seems a good starting point!

Fixes #1138