### PR TITLE
Docs: 1 letter code example fix

### DIFF
--- a/docs/guide/understanding/task/retries-and-delays.md
+++ b/docs/guide/understanding/task/retries-and-delays.md
@@ -326,7 +326,7 @@ import * as delay from 'true-myth/task/delay';
 
 let theTask = task.withRetries(
   () => task.fromPromise(fetch('https://example.com/')),
-  delay.exponential().map(Delay.jitter).take(5)
+  delay.exponential().map(delay.jitter).take(5)
 );
 ```
 


### PR DESCRIPTION
There is no `Delay`, to access `jitter` it should be taken from the `delay` namespace.

This just makes sure people can copy-paste the example code without having to then go and fix it themselves.

(Potentially my smallest drive-by PR ever.)