### PR TITLE
internal: simplify/modernize tsconfig.json configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,16 @@
       // `package.json`. (This way the tests can run -- and, critically, they
       // are usable in the editor! -- without having to prebuild the `src`
       // directory.)
-      "true-myth": ["./src/index.ts"],
-      "true-myth/*": ["./src/*.ts"]
+      "true-myth": [
+        "./src/index.ts"
+      ],
+      "true-myth/*": [
+        "./src/*.ts"
+      ]
     }
   },
-  "include": ["./src", "./test"]
+  "include": [
+    "src",
+    "test"
+  ]
 }


### PR DESCRIPTION
- Use `@tsconfig/strictest`.
- Set module configuration *not* to be Node-specific.
- Simplify deifnitions for `include`.