### PR TITLE
Result: fix `transposeAny` to accept readonly tuples/arrays

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -1957,7 +1957,7 @@ export function transposeAll(results: readonly AnyResult[]): Result<unknown[], u
   @template A The type of the array or tuple of tasks.
 */
 export function transposeAny(results: []): Result<[], never>;
-export function transposeAny<const A extends AnyResult[]>(
+export function transposeAny<const A extends readonly AnyResult[]>(
   results: A
 ): Result<Array<ResultTypesFor<A>['ok'][number]>, [...ResultTypesFor<A>['err']]>;
 export function transposeAny(

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -808,6 +808,12 @@ describe('`Result` pure functions', () => {
       expect(empty).toEqual(result.ok([]));
     });
 
+    test('with readonly tuple', () => {
+      const tuple = [result.ok(1)] as const;
+      const oneOk = result.all(tuple);
+      expectTypeOf(oneOk).toEqualTypeOf<Result<[number], never>>();
+    });
+
     test('with one Ok', () => {
       const oneOk = result.all([result.ok(1)]);
       expectTypeOf(oneOk).toEqualTypeOf<Result<[number], never>>();
@@ -869,6 +875,12 @@ describe('`transposeAll` function', () => {
     expect(empty).toEqual(result.ok([]));
   });
 
+  test('with readonly tuple', () => {
+    const tuple = [result.ok(1)] as const;
+    const oneOk = result.transposeAll(tuple);
+    expectTypeOf(oneOk).toEqualTypeOf<Result<[number], never[]>>();
+  });
+
   test('with one Ok', () => {
     const oneOk = result.transposeAll([result.ok(1)]);
     expectTypeOf(oneOk).toEqualTypeOf<Result<[number], never[]>>();
@@ -905,6 +917,12 @@ describe('`any` function', () => {
     const empty = result.transposeAny([]);
     expectTypeOf(empty).toEqualTypeOf<Result<[], never>>();
     expect(empty).toEqual(result.err([]));
+  });
+
+  test('with readonly tuple', () => {
+    const tuple = [result.ok(1)] as const;
+    const oneOk = result.transposeAny(tuple);
+    expectTypeOf(oneOk).toEqualTypeOf<Result<Array<number>, [never]>>();
   });
 
   test('with one Ok', () => {

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1331,6 +1331,13 @@ describe('`Task`', () => {
 
 describe('module-scope functions', () => {
   describe('all', () => {
+    test('with readonly tuple', () => {
+      let { task } = Task.withResolvers<string, number>();
+      const tuple = [task] as const;
+      let result = all(tuple);
+      expectTypeOf(result).toEqualTypeOf<Task<[string], number>>();
+    });
+
     describe('with a single task', () => {
       test('that is still pending', () => {
         let { task } = Task.withResolvers<string, number>();
@@ -1524,6 +1531,13 @@ describe('module-scope functions', () => {
   });
 
   describe('allSettled', () => {
+    test('with readonly tuple', () => {
+      let { task } = Task.withResolvers<string, number>();
+      const tuple = [task] as const;
+      let result = allSettled(tuple);
+      expectTypeOf(result).toEqualTypeOf<Task<[Result<string, number>], never>>();
+    });
+
     describe('with a single task', () => {
       test('that is still pending', () => {
         let { task } = Task.withResolvers<string, number>();
@@ -1690,6 +1704,13 @@ describe('module-scope functions', () => {
         expect(result.reason.errors.length).toBe(0);
         expect(result.reason.toString()).toMatch('No tasks');
       }
+    });
+
+    test('with readonly tuple', async () => {
+      let { task } = Task.withResolvers<string, number>();
+      const tuple = [task] as const;
+      let result = any(tuple);
+      expectTypeOf(result).toEqualTypeOf<Task<string, AggregateRejection<[number]>>>();
     });
 
     describe('with a single task', () => {


### PR DESCRIPTION
All other places correctly allow passing readonly tuples/arrays:

https://github.com/true-myth/true-myth/blob/9d7958686db00d1bec72fe76b6d6a46ba766770a/src/result.ts#L1898

Without this change,

```ts
const tuple = [result.ok(1)] as const;
const oneOk = result.transposeAny(tuple);
//                                ~~~~~
```

```
No overload matches this call.
     Overload 1 of 2, '(results: []): Result<[], never>', gave the following error.
       Argument of type 'readonly [Result<number, never>]' is not assignable to parameter of type '[]'.
         The type 'readonly [Result<number, never>]' is 'readonly' and cannot be assigned to the mutable type '[]'.
     Overload 2 of 2, '(results: AnyResult[]): Result<unknown[], unknown[]>', gave the following error.
       Argument of type 'readonly [Result<number, never>]' is not assignable to parameter of type 'AnyResult[]'.
         The type 'readonly [Result<number, never>]' is 'readonly' and cannot be assigned to the mutable type 'AnyResult[]'. [2769]
```