### PR TITLE
Result: fix `transposeAny` return type

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -1959,7 +1959,7 @@ export function transposeAll(results: readonly AnyResult[]): Result<unknown[], u
 export function transposeAny(results: []): Result<[], never>;
 export function transposeAny<const A extends AnyResult[]>(
   results: A
-): Result<Array<ResultTypesFor<A>['ok'][number]>, [...ResultTypesFor<A>['err']]>;
+): Result<ResultTypesFor<A>['ok'][number], [...ResultTypesFor<A>['err']]>;
 export function transposeAny(
   results: readonly [] | readonly AnyResult[]
 ): Result<unknown, unknown[]> {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -909,7 +909,7 @@ describe('`any` function', () => {
 
   test('with one Ok', () => {
     const oneOk = result.transposeAny([result.ok(1)]);
-    expectTypeOf(oneOk).toEqualTypeOf<Result<Array<number>, [never]>>();
+    expectTypeOf(oneOk).toEqualTypeOf<Result<number, [never]>>();
     expect(oneOk).toEqual(result.ok(1));
   });
 
@@ -921,13 +921,13 @@ describe('`any` function', () => {
 
   test('with all Ok', () => {
     const allOk = result.transposeAny([result.ok(1), result.ok(2), result.ok(3)]);
-    expectTypeOf(allOk).toEqualTypeOf<Result<Array<number>, [never, never, never]>>();
+    expectTypeOf(allOk).toEqualTypeOf<Result<number, [never, never, never]>>();
     expect(allOk).toEqual(result.ok(1));
   });
 
   test('with all Err', () => {
     const allErr = result.transposeAny([result.err('error 1'), result.err('error 2')]);
-    expectTypeOf(allErr).toEqualTypeOf<Result<Array<never>, [string, string]>>();
+    expectTypeOf(allErr).toEqualTypeOf<Result<never, [string, string]>>();
     expect(allErr).toEqual(result.err(['error 1', 'error 2']));
   });
 
@@ -937,7 +937,7 @@ describe('`any` function', () => {
       result.err('error 2'),
       result.ok(3),
     ]);
-    expectTypeOf(someErr).toEqualTypeOf<Result<Array<number>, [string, string, never]>>();
+    expectTypeOf(someErr).toEqualTypeOf<Result<number, [string, string, never]>>();
     expect(someErr).toEqual(result.ok(3));
   });
 });


### PR DESCRIPTION
https://github.com/true-myth/true-myth/pull/1189 mistakenly made it return an `Array`, but it actually returns the first resolved value, not an array.