### PR TITLE
Task: fix type inference of tasks passed to `allSettled`

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -1160,6 +1160,7 @@ export type Settled<A extends readonly AnyTask[]> = {
 
   @template A The type of the array or tuple of tasks.
  */
+export function allSettled(tasks: []): Task<[], never>;
 export function allSettled<const A extends readonly AnyTask[]>(tasks: A): Task<Settled<A>, never>;
 export function allSettled(tasks: AnyTask[]): Task<unknown, never> {
   // All task promises should resolve; none should ever reject, by definition.

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1533,8 +1533,7 @@ describe('module-scope functions', () => {
       });
 
       test('that has resolved', async () => {
-        let theTask = Task.resolve('hello');
-        let result = allSettled([theTask]);
+        let result = allSettled([Task.resolve('hello')]);
         expectTypeOf(result).toEqualTypeOf<Task<[Result<string, never>], never>>();
         await result;
         expect(result.state).toBe(State.Resolved);


### PR DESCRIPTION
All other similar functions have this signature:

https://github.com/true-myth/true-myth/blob/9d7958686db00d1bec72fe76b6d6a46ba766770a/src/task.ts#L1065

Without this signature,

```ts
const result = allSettled([Task.resolve('hello')])
//     ^? Task<[Result<string, unknown>], never>
```

Note that `Result<string, unknown>` is inferred instead of `Result<string, never>`.