### PR TITLE
Docs: remove obsolete note about AggregateRejection order & few nits

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -1039,12 +1039,14 @@ export type All<A extends readonly AnyTask[]> = Task<
   ]);
 
   let result = await allTasks;
-  console.log(result.toString()); // [Ok(10,100,1000)]
+  console.log(result.toString()); // Ok(10,100,1000)
   ```
 
   If any tasks do *not* resolve:
 
   ```ts
+  import Task, { all, timer } from 'true-myth/task';
+
   let { task: willReject, reject } = Task.withResolvers<never, string>();
 
   let allTasks = all([
@@ -1214,8 +1216,7 @@ export function allSettled(tasks: AnyTask[]): Task<unknown, never> {
   @param tasks The set of tasks to check for any resolution.
   @returns A Task which is either {@linkcode Resolved} with the value of the
     first task to resolve, or {@linkcode Rejected} with the rejection reasons
-    for all the tasks passed in in an {@linkcode AggregateRejection}. Note that
-    the order of the rejection reasons is not guaranteed.
+    for all the tasks passed in in an {@linkcode AggregateRejection}.
 
   @template A The type of the array or tuple of tasks.
 */


### PR DESCRIPTION
This commit didn't update this part of docs: https://github.com/true-myth/true-myth/commit/5fde85f1#diff-41bc16013539b5b30c19f764d2485a383a77b8825f4f53aa51f462ddbc328331L876-R881
