### PR TITLE
Fix missing test update for `transposeAny` (#1206)

### DIFF
--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -922,7 +922,7 @@ describe('`transposeAny` function', () => {
   test('with readonly tuple', () => {
     const tuple = [result.ok(1)] as const;
     const oneOk = result.transposeAny(tuple);
-    expectTypeOf(oneOk).toEqualTypeOf<Result<Array<number>, [never]>>();
+    expectTypeOf(oneOk).toEqualTypeOf<Result<number, [never]>>();
   });
 
   test('with one Ok', () => {


### PR DESCRIPTION
This was down to #1205 and #1206 not being totally independent of each other and our not requiring the branch for a PR to be fully up to date before merging. Had we required a rebase, this would have been caught in CI and fixed before merging.