### PR TITLE
docs: update distribution size info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ Size of the ESM build without tree-shaking (yes, these are in *bytes*: this is a
 
 |       file         | size (B) | terser[^terser] (B) | terser and brotli[^brotli] (B) |
 | ------------------ | -------- | ------------------- | ------------------------------ |
-| -private/utils.js  |      888 |                 321 |                            166 |
+| -private/utils.js  |      942 |                 358 |                            175 |
 | index.js           |      644 |                 352 |                            122 |
-| maybe.js           |    18872 |                3637 |                            908 |
-| result.js          |    15274 |                3927 |                            972 |
-| standard-schema.js |     5975 |                 762 |                            317 |
+| maybe.js           |    23052 |                3838 |                            943 |
+| result.js          |    21376 |                4257 |                           1034 |
+| standard-schema.js |     5984 |                 758 |                            318 |
 | task/delay.js      |     3901 |                 649 |                            259 |
-| task.js            |    54755 |                7448 |                           2025 |
+| task.js            |    59937 |                7629 |                           2036 |
 | test-support.js    |      473 |                 142 |                             89 |
-| toolbelt.js        |     3739 |                 890 |                            277 |
+| toolbelt.js        |     3739 |                 886 |                            278 |
 | unit.js            |      656 |                  58 |                             57 |
-| **total[^total]**  |   105177 |               18186 |                           5192 |
+| **total[^total]**  |   120704 |               18927 |                           5311 |
 
 
 Notes:

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "release-it": "^19.0.6",
     "rimraf": "^6.1.2",
     "shelljs": "^0.10.0",
+    "terser": "^5.46.2",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",
     "typedoc-vitepress-theme": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 25.2.0
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))
+        version: 3.2.4(vitest@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))
       arktype:
         specifier: ^2.1.27
         version: 2.2.0
@@ -56,6 +56,9 @@ importers:
       shelljs:
         specifier: ^0.10.0
         version: 0.10.0
+      terser:
+        specifier: ^5.46.2
+        version: 5.46.2
       typedoc:
         specifier: ^0.28.14
         version: 0.28.17(typescript@5.3.3)
@@ -73,13 +76,13 @@ importers:
         version: 1.3.0(typescript@5.3.3)
       vite-tsconfig-paths:
         specifier: ^6.0.1
-        version: 6.1.1(typescript@5.3.3)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))
+        version: 6.1.1(typescript@5.3.3)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))
       vitepress:
         specifier: 2.0.0-alpha.17
-        version: 2.0.0-alpha.17(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(oxc-minify@0.123.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(postcss@8.5.8)(typescript@5.3.3)(yaml@2.8.2)
+        version: 2.0.0-alpha.17(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(oxc-minify@0.123.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(postcss@8.5.8)(terser@5.46.2)(typescript@5.3.3)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+        version: 3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
       zod:
         specifier: ^4.1.13
         version: 4.3.6
@@ -304,6 +307,9 @@ packages:
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -935,6 +941,11 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1024,6 +1035,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1131,6 +1145,9 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2299,6 +2316,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -2365,6 +2385,11 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  terser@5.46.2:
+    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
@@ -2919,6 +2944,11 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
@@ -3308,13 +3338,13 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@6.0.5(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))(vue@3.5.31(typescript@5.3.3))':
+  '@vitejs/plugin-vue@6.0.5(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))(vue@3.5.31(typescript@5.3.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
       vue: 3.5.31(typescript@5.3.3)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3329,7 +3359,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vitest: 3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3341,13 +3371,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3463,6 +3493,8 @@ snapshots:
     dependencies:
       vue: 3.5.31(typescript@5.3.3)
 
+  acorn@8.16.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -3546,6 +3578,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-from@1.1.2: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -3672,6 +3706,8 @@ snapshots:
   color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@2.20.3: {}
 
   concat-map@0.0.1: {}
 
@@ -4823,7 +4859,7 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2):
+  rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.101.0
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4836,6 +4872,7 @@ snapshots:
       '@types/node': 25.2.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      terser: 5.46.2
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -4958,8 +4995,12 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1:
-    optional: true
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -5025,6 +5066,13 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  terser@5.46.2:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
 
   test-exclude@7.0.1:
     dependencies:
@@ -5152,13 +5200,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2):
+  vite-node@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -5175,17 +5223,17 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@6.1.1(typescript@5.3.3)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)):
+  vite-tsconfig-paths@6.1.1(typescript@5.3.3)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.3.3)
-      vite: 8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2):
+  vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -5197,12 +5245,13 @@ snapshots:
       '@types/node': 25.2.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      terser: 5.46.2
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitepress@2.0.0-alpha.17(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(oxc-minify@0.123.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(postcss@8.5.8)(typescript@5.3.3)(yaml@2.8.2):
+  vitepress@2.0.0-alpha.17(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(oxc-minify@0.123.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(postcss@8.5.8)(terser@5.46.2)(typescript@5.3.3)(yaml@2.8.2):
     dependencies:
       '@docsearch/css': 4.6.2
       '@docsearch/js': 4.6.2
@@ -5212,7 +5261,7 @@ snapshots:
       '@shikijs/transformers': 3.23.0
       '@shikijs/types': 3.23.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.5(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))(vue@3.5.31(typescript@5.3.3))
+      '@vitejs/plugin-vue': 6.0.5(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))(vue@3.5.31(typescript@5.3.3))
       '@vue/devtools-api': 8.1.1
       '@vue/shared': 3.5.31
       '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.3.3))
@@ -5221,7 +5270,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.23.0
-      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
       vue: 3.5.31(typescript@5.3.3)
     optionalDependencies:
       oxc-minify: 0.123.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
@@ -5253,11 +5302,11 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2):
+  vitest@3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5275,8 +5324,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
-      vite-node: 3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
+      vite-node: 3.2.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.2.0)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/scripts/measure.fish
+++ b/scripts/measure.fish
@@ -22,7 +22,7 @@ set files (fd --extension "js")
 for file in $files;
   cp "./$file" ../measure
   set minified (echo "$file" | sd '\.js' '.min.js')
-  terser "./$file" -o "./$minified" --compress --mangle
+  pnpm exec terser "./$file" -o "./$minified" --compress --mangle
 end;
 brotli -kq 11 ./**/*.min.js
 cp ./**/*.min.js ./**/*.min.js.br ../measure


### PR DESCRIPTION
- Update fish script to use `pnpm exec terser` so it works consistently and reliably in any environment.
- Update the actual measurements in the README.