### PR TITLE
Add an ESLint plugin with `must-use` and `must-await-task`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,18 @@ jobs:
       - run: pnpm add --save-dev typescript@${{ matrix.ts-version }}
       - run: pnpm type-check
 
-  tests_integration:
-    name: 'Tests: 3rd-party integrations'
+  tests_package_integration:
+    name: 'Tests: package integrations'
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+      - run: pnpm install
+      - run: pnpm test:integration:first-party
+
+  tests_third_party_integration:
+    name: 'Tests: third-party integrations'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -52,7 +62,7 @@ jobs:
       - run: pnpm install
       - run: pnpm add --save-dev typescript@latest
       - run: tsc --noEmit --project ts/test.tsconfig.json
-      - run: pnpm test --config vitest.integration.config.ts
+      - run: pnpm test:integration:third-party
 
   check_docs:
     name: 'Build docs'

--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ Size of the ESM build without tree-shaking (yes, these are in *bytes*: this is a
 Notes:
 
 - The unmodified size *includes comments*.
+
 - Thus, running through Terser gets us a much more realistic size: about 18.1KB to parse.
+
 - The total size across the wire of the whole library will be ~5.2KB.
+
 - This is all tree-shakeable to a significant degree: you should only have to “pay for” the types and functions you actually use, directly or indirectly. If your production bundle does not import or use anything from `true-myth/test-support`, you will not pay for it, for example. However, some parts of the library do depend directly on other parts: for example, `toolbelt` uses exports from `result` and `maybe`, and `Task` makes extensive use of `Result` under the hood.
 
     In detail, here are the dependencies of each module:
@@ -97,6 +100,8 @@ Notes:
     | `task/delay.js`      | None                                                         |
     | `test-support.js`    | `maybe.js`, `result.js`                                      |
     | `toolbelt.js`        | `maybe.js`, `result.js`, `-private/utils.js`                 |
+
+- This intentionally excludes the ESLint plugin contents, which should not be part of an production bundle.
 
 [^terser]: Using [terser](https://github.com/terser/terser) 5.46.2 with `--compress --mangle --mangle-props`.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -24,8 +24,8 @@ export default defineConfig({
       { text: 'Home', link: '/' },
       { text: 'Guide', link: '/guide/introduction/' },
       { text: 'API', link: '/api/' },
+      { text: 'Lint plugin', link: '/eslint-plugin/' },
       { text: 'Releases', link: 'https://github.com/true-myth/true-myth/releases' },
-      { text: 'true-myth-zod', link: 'https://github.com/true-myth/true-myth-zod' },
     ],
 
     sidebar: {

--- a/docs/eslint-plugin/index.md
+++ b/docs/eslint-plugin/index.md
@@ -1,0 +1,103 @@
+# ESLint Plugin
+
+True Myth includes an ESLint plugin at `true-myth/eslint-plugin` to support your effective use of the package.
+
+The plugin ships two rules:
+
+- [`true-myth/must-use`](./must-use.md): requires actively using `Result` and `Task` values, because forgetting to use them is usually a mistake.
+- [`true-myth/must-await-task`](./must-await-task.md): disallows floating `Task` values.
+
+## Typed Linting
+
+These rules require TypeScript parser services. Configure `@typescript-eslint/parser` with typed linting enabled:
+
+```ts
+import parser from '@typescript-eslint/parser';
+import trueMyth from 'true-myth/eslint-plugin';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'true-myth': trueMyth,
+    },
+    rules: {
+      'true-myth/must-await-task': 'error',
+      'true-myth/must-use': 'error',
+    },
+  },
+];
+```
+
+
+## Configuration
+
+You can just use the recommended (“flat”-style) config:
+
+```ts
+import trueMyth from 'true-myth/eslint-plugin';
+
+export default [trueMyth.configs.recommended];
+```
+
+You can also configure the rule options directly. For example:
+
+```ts
+import parser from '@typescript-eslint/parser';
+import trueMyth from 'true-myth/eslint-plugin';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'true-myth': trueMyth,
+    },
+    rules: {
+      'true-myth/must-use': [
+        'error',
+        {
+          additionalTypes: [
+            {
+              module: '@acme/domain',
+              export: { kind: 'named', name: 'ValidationResult' },
+            },
+          ],
+          allowVoid: [
+            {
+              module: 'true-myth/task',
+              export: { kind: 'named', name: 'Task' },
+            },
+          ],
+        },
+      ],
+      'true-myth/must-await-task': [
+        'error',
+        {
+          additionalTypes: [
+            {
+              module: '@acme/domain',
+              export: { kind: 'named', name: 'QueuedTask' },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+For detailed configuration info, see the rule docs.

--- a/docs/eslint-plugin/must-await-task.md
+++ b/docs/eslint-plugin/must-await-task.md
@@ -1,0 +1,132 @@
+# `true-myth/must-await-task`
+
+Disallow floating `Task`-producing expressions. As with native JS `Promise` instances, unhandled `Task` instances can cause memory leaks, or produce application or test instability when they live beyond the normal lifetime of a function or class hosting them.
+
+You likely want to combine this with [`true-myth/must-use`][must-use] and [`@typescript-eslint/no-floating-promises`][nfp] to handle related failure modes.
+
+[must-use]: ./must-use.md
+[nfp]: https://typescript-eslint.io/rules/no-floating-promises/
+
+## Examples
+
+Invalid:
+
+```ts
+returnsTask();
+Task.resolve(1);
+void returnsTask();
+returnsTask().map(fn);
+service.load().andThen(fn);
+cond(value) ? resolve(value) : reject("Oh no!");
+```
+
+Valid:
+
+```ts
+await returnsTask();
+const value = await returnsTask();
+void await returnsTask();
+const task = returnsTask();
+return returnsTask();
+await returnsTask().map(fn);
+await service.load().andThen(fn);
+const nextTask = returnsTask().andThen((value) => resolve(value));
+const conditionalTask = returnsTask().andThen((value) =>
+  cond(value) ? resolve(value) : reject("Oh no!")
+);
+returnsTask().match({
+  resolved: (value) => { /* ... */ },
+  rejected: (reason) => { /* ... */ },
+});
+returnsTask().toPromise();
+```
+
+## Options
+
+This rule supplies one option: `additionalTypes`. Use it to define module exports for other `Task`-like types this rule should treat as must-await.
+
+```ts
+{
+  additionalTypes?: MustUseType[];
+}
+
+type MustUseType = {
+  module: string;
+  export: { kind: 'default' } | { kind: 'named'; name: string };
+};
+```
+
+### Named exports
+
+Imagine a package named `@acme/domain` that re-exports a domain-specific `Task` alias:
+
+```ts
+export type QueuedTask<T> = Task<T, QueueError>;
+```
+
+To configure the rule to flag this `QueuedTask` as well as True Myth's native `Task` type, add it as a named export to `additionalTypes`:
+
+```ts
+{
+  additionalTypes: [
+    {
+      module: '@acme/domain',
+      export: { kind: 'named', name: 'QueuedTask' },
+    },
+  ],
+}
+```
+
+### Default exports
+
+The same basic approach works for default exports. Again, imagine that `@acme/domain/operation` has a default export derived from True Myth's `Task` type, like so:
+
+```ts
+export default interface Operation<T> extends Task<T, OperationError> {}
+```
+
+Then you would configure the lint rule by adding it to `additionalTypes` like so:
+
+```ts
+{
+  additionalTypes: [
+    {
+      module: '@acme/domain/operation',
+      export: { kind: 'default' },
+    },
+  ],
+}
+```
+
+## Configuration
+
+```ts
+import trueMyth from 'true-myth/eslint-plugin';
+
+export default [
+  {
+    plugins: {
+      'true-myth': trueMyth,
+    },
+    rules: {
+      'true-myth/must-await-task': [
+        'error',
+        {
+          additionalTypes: [
+            {
+              module: '@acme/domain',
+              export: { kind: 'named', name: 'QueuedTask' },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+The plugin also provides `trueMyth.configs.recommended`, which enables this rule.
+
+## Typed Linting
+
+This rule requires TypeScript parser services, such as those provided by `@typescript-eslint/parser` with typed linting enabled.

--- a/docs/eslint-plugin/must-use.md
+++ b/docs/eslint-plugin/must-use.md
@@ -1,0 +1,192 @@
+# `true-myth/must-use`
+
+Require callers to use values whose type should not be discarded. Most of the time, when callers return a `Result` or `Task`, it is a mistake not to handle its errors.
+
+For example, when reading from a file with an API that returns a `Result`, callers will naturally need to handle the error explicitly simply to get the data:
+
+```ts
+/** Return string if succesfully read or IoError if not */
+declare function readFile(path: string): Result<string, IoError>;
+
+let contents = readFile("some-path").unwrapOrElse((err) => {
+  console.error(err);
+  return "";
+});
+```
+
+When writing a file, though, it can be easy to overlook failure cases:
+
+```ts
+/** Return bytes written if succesful or IoError if not */
+declare function writeFile(path: string, body: string): Result<number, IoError>;
+
+writeFile("some-path", "hello!"); // what if the write fails?
+```
+
+This lint rule will provide an error indicating that the `Result` is unhandled, prompting you to make sure you account for the failure case:
+
+```ts
+writeFile("some-path").match({
+  Ok: (written) => {
+    console.log(`wrote ${written}b to "some-path"`);
+  }
+  Err: (ioError) => {
+    console.error(`failed writing to "some-path"`, ioError);
+  }
+});
+```
+
+This rule is inspired by Rust’s `#[must_use]` attribute.
+
+## Examples
+
+Invalid:
+
+```ts
+returnsResult();
+returnsTask();
+Result.ok(1);
+Task.resolve(1);
+returnsResult().map(fn);
+
+async function run() {
+  await returnsTask();
+}
+```
+
+Valid:
+
+```ts
+const result = returnsResult();
+return returnsTask();
+consume(returnsResult());
+returnsResult().unwrapOr(0);
+
+void returnsResult();
+
+async function run() {
+  void await returnsTask();
+}
+```
+
+## Options
+
+This rule provides two options: `allowVoid` and `additionalTypes`.
+
+```ts
+{
+  allowVoid?: boolean | MustUseType[];
+  additionalTypes?: MustUseType[];
+}
+
+type MustUseType = {
+  module: string;
+  export: { kind: 'default' } | { kind: 'named'; name: string };
+};
+```
+
+### `allowVoid`
+
+The `allowVoid` option allows you to explicitly discard types by using [the `void` operator][void], e.g. `void returnsResult()` and `void await returnsTask()`.
+
+[void]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void
+
+- `allowVoid` defaults to `true`, allowing explicit discards.
+- Set `allowVoid` to `false` to reject all `void` discards.
+- Set `allowVoid` to specific module exports to allow explicit discards only for those types.
+
+### `additionalTypes` 
+
+Set `additionalTypes` to module exports for any other types this rule should treat as must-use.
+
+#### Named exports
+
+Imagine a package named `@acme/domain` that re-exports a domain-specific `Result` alias:
+
+```ts
+export type ValidationResult<T> = Result<T, ValidationError>;
+```
+
+To configure the rule to flag this `ValidationResult` as well as True Myth's native `Result` and `Task` types, add it as a named export to `additionalTypes`:
+
+```ts
+{
+  additionalTypes: [
+    {
+      module: '@acme/domain',
+      export: { kind: 'named', name: 'ValidationResult' },
+    },
+  ],
+}
+```
+
+#### Default exports
+
+The same basic approach works for default exports. Again, imagine that `@acme/domain/operation` has a default export derived from True Myth’s `Task` type, like so:
+
+```ts
+export default interface Operation<T> extends Task<T, OperationError> {}
+```
+
+Then you would configure the lint rule by adding it to `additionalTypes` like so:
+
+```ts
+{
+  additionalTypes: [
+    {
+      module: '@acme/domain/operation',
+      export: { kind: 'default' },
+    },
+  ],
+}
+```
+
+To allow `void` only for selected exports, use the same shape:
+
+```ts
+{
+  allowVoid: [
+    {
+      module: 'true-myth/task',
+      export: { kind: 'named', name: 'Task' },
+    },
+  ],
+}
+```
+
+## Configuration
+
+```ts
+import trueMyth from 'true-myth/eslint-plugin';
+
+export default [
+  {
+    plugins: {
+      'true-myth': trueMyth,
+    },
+    rules: {
+      'true-myth/must-use': [
+        'error',
+        {
+          additionalTypes: [
+            {
+              module: '@acme/domain',
+              export: { kind: 'named', name: 'ValidationResult' },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+The plugin also provides `trueMyth.configs.recommended`, which enables this rule and sets `allowVoid` to `true`.
+
+## Typed Linting
+
+This rule requires TypeScript parser services, such as those provided by
+`@typescript-eslint/parser` with typed linting enabled.
+
+> [!NOTE]
+> The plugin shape is compatible with ESLint flat config and Oxlint’s JavaScript plugin loading model, but Oxlint does not currently expose the TypeScript type information this rule needs. When Oxlint provides that capability, we will add support for it.

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -8,6 +8,10 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "paths": {
+      "true-myth": ["../src/index.ts"],
+      "true-myth/eslint-plugin": ["../src/eslint-plugin/index.ts"],
+      "true-myth/task/delay": ["../src/task/delay.ts"],
+      "true-myth/*": ["../src/*.ts"],
       "*": ["./types/*"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./eslint-plugin": {
+      "types": "./dist/eslint-plugin/index.d.ts",
+      "default": "./dist/eslint-plugin/index.js"
+    },
     "./package.json": "./package.json",
     "./*": {
       "types": "./dist/*.d.ts",
@@ -50,6 +54,10 @@
     "prepublishOnly": "pnpm test && pnpm build",
     "postpublish": "pnpm clean",
     "test": "vitest run",
+    "test:all": "pnpm test && pnpm test:integration",
+    "test:integration": "pnpm test:integration:first-party && pnpm test:integration:third-party",
+    "test:integration:third-party": "vitest run --config vitest.integration.config.ts",
+    "test:integration:first-party": "vitest run --config vitest.package-integration.config.ts",
     "tdd": "vitest",
     "type-check": "tsc --noEmit --project ts/test.tsconfig.json",
     "docs": "pnpm docs:prepare && pnpm docs:build",
@@ -66,12 +74,17 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@eslint/core": "^1.2.1",
     "@release-it-plugins/lerna-changelog": "^8.0.1",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^25.0.3",
+    "@typescript-eslint/parser": "^8.59.2",
+    "@typescript-eslint/rule-tester": "^8.59.2",
+    "@typescript-eslint/utils": "^8.59.2",
     "@vitest/coverage-v8": "^4.1.5",
     "arktype": "^2.1.27",
     "effect": "^3.19.6",
+    "eslint": "^10.3.0",
     "feed": "^5.1.0",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/core':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@release-it-plugins/lerna-changelog':
         specifier: ^8.0.1
         version: 8.0.1(release-it@19.2.4(@types/node@25.9.1)(magicast@0.5.3))
@@ -20,6 +23,15 @@ importers:
       '@types/node':
         specifier: ^25.0.3
         version: 25.9.1
+      '@typescript-eslint/parser':
+        specifier: ^8.59.2
+        version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.59.2
+        version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/utils':
+        specifier: ^8.59.2
+        version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.7(vitest@4.1.7)
@@ -29,6 +41,9 @@ importers:
       effect:
         specifier: ^3.19.6
         version: 3.21.2
+      eslint:
+        specifier: ^10.3.0
+        version: 10.4.0(jiti@2.6.1)
       feed:
         specifier: ^5.1.0
         version: 5.2.1
@@ -131,11 +146,61 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@iconify-json/simple-icons@1.2.75':
     resolution: {integrity: sha512-KvcCUbvcBWb0sbqLIxHoY8z5/piXY08wcY9gfMhF+ph3AfzGMaSmZFkUY71HSXAljQngXkgs4bdKdekO0HQWvg==}
@@ -421,48 +486,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.132.0':
     resolution: {integrity: sha512-3k8ezEKmxs9Wel4N4vfF/8u764mA57j065P8nB4cU2PO/lLKloN0OA41ynfDUrSM1f5jBuF8+mLOj++aNnu4OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.132.0':
     resolution: {integrity: sha512-vM6jZIxoHoIS5rPb3K3Di0IureL4oU+wOWBy6tLSrjwW2IHqy0442CzO/Ks2U9VCuHV1q0bUGCF0H6AxCEjJHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.132.0':
     resolution: {integrity: sha512-KburrmtWpeZg58uo275QRwy5bbNOXQd1WDI2tGxkY2dJBlO7N5V9+Uthvqn6KI/6RBtjd2T5NO4dCC0fgUxGvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.132.0':
     resolution: {integrity: sha512-MnahA2MNEtEdxWdUy24JXkMUNgGPqH285GL2L22Zz7k9ixsguFD+bTbbcR88pNqdb075nazozzv3edF83+azCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.132.0':
     resolution: {integrity: sha512-VE99UPZyQO2MAG4gLGXzrBumD5PGNaiWe+EakaROGCVbT0YH/d9z2ByYqbdWAMEBiTHjthyZp6UUEFVda+LnpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.132.0':
     resolution: {integrity: sha512-FKxBkYrSAWNF4V6MacAJ/1E2SJobKKQ2CtW6Aq+pLzzEOjgk2SmxnK7I0bATlFH/O70tbTKDzWb17bySGYRcog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.132.0':
     resolution: {integrity: sha512-W8IqA2XRvg/b6l/f+2SdV45/KKmpmwTabrjiMtpg/wzJU5cmKUoHihtJXPc9NA0Ls9S/oP0wB3PMCRQoNr5J1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.132.0':
     resolution: {integrity: sha512-X1BL65pI9bfOesLdVUcErjbEAUA3qmzjXCwXPCYsFZT7ela7SsK85+sN3m2TJNxmX1mrFKNg5g8bH+d2zHresw==}
@@ -582,60 +655,70 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
     resolution: {integrity: sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
     resolution: {integrity: sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
     resolution: {integrity: sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
     resolution: {integrity: sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==}
@@ -738,11 +821,17 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -771,6 +860,57 @@ packages:
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/rule-tester@8.59.4':
+    resolution: {integrity: sha512-kEhAUFyaLGuxk3LQVyLjeFwJeIoFEgMEAco89Ma9r3CD75W+fICWLW/2NG3O0TpnMivl5/XKbi2Ok0YJcQPwKA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.4':
+    resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -914,6 +1054,11 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -934,6 +1079,9 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1143,6 +1291,9 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
@@ -1207,15 +1358,53 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.4.0:
+    resolution: {integrity: sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -1257,9 +1446,18 @@ packages:
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1277,9 +1475,24 @@ packages:
     resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
     engines: {node: '>=20', pnpm: '>=10'}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   focus-trap@8.0.1:
     resolution: {integrity: sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==}
@@ -1329,6 +1542,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -1401,6 +1618,10 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1515,10 +1736,26 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   lerna-changelog@2.2.0:
     resolution: {integrity: sha512-yjYNAHrbnw8xYFKmYWJEP52Tk4xSdlNmzpYr26+3glbSGDmpe8UMo8f9DlEntjGufL+opup421oVTXcLshwAaQ==}
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1555,24 +1792,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1592,6 +1833,10 @@ packages:
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.capitalize@4.2.1:
     resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
@@ -1843,6 +2088,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
@@ -1906,6 +2154,10 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ora@9.0.0:
     resolution: {integrity: sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==}
     engines: {node: '>=20'}
@@ -1917,6 +2169,14 @@ packages:
   oxc-minify@0.132.0:
     resolution: {integrity: sha512-7h3fOlgDwkIYxxKfGwCNejaLhH90Pvx+fttdPN7nRbWHxm6QSYcxW3IKjfxQVUeg+z1X2HZdOSY3rHkVqgxH1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
@@ -1952,6 +2212,10 @@ packages:
 
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -2004,6 +2268,10 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -2040,6 +2308,10 @@ packages:
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@6.1.0:
@@ -2335,8 +2607,18 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
@@ -2398,6 +2680,9 @@ packages:
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
@@ -2550,6 +2835,10 @@ packages:
     resolution: {integrity: sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA==}
     engines: {node: '>=18'}
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -2596,6 +2885,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
@@ -2656,6 +2949,36 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.6.1))':
+    dependencies:
+      eslint: 10.4.0(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@gar/promisify@1.1.3': {}
 
   '@gerrit0/mini-shiki@3.23.0':
@@ -2665,6 +2988,22 @@ snapshots:
       '@shikijs/themes': 3.23.0
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@iconify-json/simple-icons@1.2.75':
     dependencies:
@@ -3159,11 +3498,15 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@5.0.0': {}
 
@@ -3191,6 +3534,83 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
+
+  '@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      eslint: 10.4.0(jiti@2.6.1)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.4(typescript@5.3.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.3.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/rule-tester@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.3.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)
+      ajv: 6.15.0
+      eslint: 10.4.0(jiti@2.6.1)
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.8.0
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.3.3)':
+    dependencies:
+      typescript: 5.3.3
+
+  '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.3.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.3.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.3.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.3.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.3.3)
+      eslint: 10.4.0(jiti@2.6.1)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -3343,6 +3763,10 @@ snapshots:
     dependencies:
       vue: 3.5.31(typescript@5.3.3)
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@6.0.2:
@@ -3361,6 +3785,13 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
@@ -3569,6 +4000,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-is@0.1.4: {}
+
   default-browser-id@5.0.1: {}
 
   default-browser@5.4.0:
@@ -3620,6 +4053,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -3628,7 +4063,69 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.4.0(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
 
   estraverse@5.3.0: {}
 
@@ -3676,6 +4173,8 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3683,6 +4182,10 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fastq@1.19.1:
     dependencies:
@@ -3696,9 +4199,25 @@ snapshots:
     dependencies:
       xml-js: 1.6.11
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   focus-trap@8.0.1:
     dependencies:
@@ -3748,6 +4267,10 @@ snapshots:
       git-up: 8.1.1
 
   glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
@@ -3846,6 +4369,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore@5.3.2: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -3936,6 +4461,16 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   lerna-changelog@2.2.0:
     dependencies:
       chalk: 4.1.2
@@ -3949,6 +4484,11 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4002,6 +4542,10 @@ snapshots:
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash.capitalize@4.2.1: {}
 
@@ -4339,6 +4883,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  natural-compare@1.4.0: {}
+
   negotiator@0.6.4: {}
 
   netmask@2.0.2: {}
@@ -4400,6 +4946,15 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ora@9.0.0:
     dependencies:
       chalk: 5.6.2
@@ -4439,6 +4994,14 @@ snapshots:
       '@oxc-minify/binding-win32-arm64-msvc': 0.132.0
       '@oxc-minify/binding-win32-ia32-msvc': 0.132.0
       '@oxc-minify/binding-win32-x64-msvc': 0.132.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-map@3.0.0:
     dependencies:
@@ -4485,6 +5048,8 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  path-exists@4.0.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -4526,6 +5091,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   prettier@3.8.3: {}
 
   progress@2.0.3: {}
@@ -4557,6 +5124,8 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode.js@2.3.1: {}
+
+  punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
@@ -4874,7 +5443,15 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  ts-api-utils@2.5.0(typescript@5.3.3):
+    dependencies:
+      typescript: 5.3.3
+
   tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
 
   type-fest@2.19.0: {}
 
@@ -4935,6 +5512,10 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   universal-user-agent@7.0.3: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-join@5.0.0: {}
 
@@ -5083,6 +5664,8 @@ snapshots:
     dependencies:
       execa: 8.0.1
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5134,6 +5717,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
 

--- a/scripts/measure.fish
+++ b/scripts/measure.fish
@@ -17,7 +17,7 @@ end
 mkdir -p ./measure
 cd dist
 cleanup
-set files (fd --extension "js")
+set files (fd --extension "js" --exclude "eslint-plugin")
 
 for file in $files;
   cp "./$file" ../measure

--- a/src/eslint-plugin/index.ts
+++ b/src/eslint-plugin/index.ts
@@ -1,0 +1,82 @@
+/**
+  The True Myth ESLint plugin provides two rules:
+
+  - `mustUse`: requires explicitly handling or ignore `Result` or `Task`
+    instances, because not doing so is usually a mistake.
+  - `mustAwaitTask`: requires awaiting every `Task` to avoid unhandled async.
+
+  See [the guide](/eslint-plugin/) for details.
+
+  @module
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import type { Plugin } from '@eslint/core';
+import type { Config } from 'eslint/config';
+
+import { mustAwaitTask } from './must-await-task.js';
+import { mustUse } from './must-use.js';
+
+interface TrueMythPlugin extends Plugin {
+  configs: {
+    readonly recommended: Config;
+  };
+}
+
+const plugin: TrueMythPlugin = {
+  meta: {
+    name: 'true-myth',
+    namespace: 'true-myth',
+    version: versionFromPackageJson(),
+  },
+  rules: {
+    'must-await-task': mustAwaitTask,
+    'must-use': mustUse,
+  },
+  configs: {
+    // Uses a getter so it can be lazy and reference itself in `plugins`.
+    get recommended(): Config {
+      return {
+        name: 'true-myth/recommended',
+        plugins: {
+          'true-myth': plugin,
+        },
+        rules: {
+          'true-myth/must-await-task': 'error',
+          'true-myth/must-use': 'error',
+        },
+      };
+    },
+  },
+};
+
+export { mustAwaitTask, mustUse };
+export type { MustUseType } from './true-myth-support.js';
+export default plugin;
+
+function versionFromPackageJson(): string {
+  const pathToPackageJson = path.join('..', '..', 'package.json');
+  const packageJsonURL = new URL(pathToPackageJson, import.meta.url);
+  const packageJson: unknown = JSON.parse(readFileSync(packageJsonURL, 'utf8'));
+
+  // We don't need code coverage for the failure cases of True Myth's own
+  // `package.json` not being an object...
+  /* v8 ignore if */
+  if (!isRecord(packageJson)) {
+    throw new Error('Could not parse package.json as an object');
+  }
+
+  // ...or its not having a version string in it.
+  /* v8 ignore if */
+  if (typeof packageJson.version !== 'string') {
+    throw new Error('Expected package.json to include a string version.');
+  }
+
+  return packageJson.version;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/eslint-plugin/must-await-task.ts
+++ b/src/eslint-plugin/must-await-task.ts
@@ -1,0 +1,249 @@
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+
+import {
+  createRule,
+  Resolver,
+  TRUE_MYTH_MUST_AWAIT_TYPES,
+  getTypedParserServices,
+  mustUseTypesFrom,
+  type MustUseType,
+} from './true-myth-support.js';
+
+interface Options {
+  additionalTypes?: MustUseType[];
+}
+
+const DEFAULT_OPTIONS: Required<Options> = {
+  additionalTypes: [],
+};
+
+const MESSAGE_ID = 'unawaitedTask';
+type MESSAGE_ID = typeof MESSAGE_ID;
+
+const mustUseTypeSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    export: {
+      anyOf: [
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            kind: { enum: ['default'], type: 'string' },
+          },
+          required: ['kind'],
+        },
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            kind: { enum: ['named'], type: 'string' },
+            name: { type: 'string' },
+          },
+          required: ['kind', 'name'],
+        },
+      ],
+    },
+    module: { type: 'string' },
+  },
+  required: ['module', 'export'],
+};
+
+/**
+  Disallows floating Task-producing expressions.
+
+  @see https://true-myth.js.org/eslint-plugin/must-await-task
+ */
+export const mustAwaitTask = createRule({
+  name: 'must-await-task',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow floating Task-producing expressions.',
+    },
+    messages: {
+      [MESSAGE_ID]:
+        'Handle this `Task` by awaiting, returning, binding, or otherwise passing it along.',
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          additionalTypes: {
+            type: 'array',
+            items: {
+              ...mustUseTypeSchema,
+            },
+          },
+        },
+      },
+    ],
+  },
+
+  create(context) {
+    const services = getTypedParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const options = optionsFrom(context.options[0]);
+    const resolver = new Resolver(services.program, checker, [
+      ...TRUE_MYTH_MUST_AWAIT_TYPES,
+      ...options.additionalTypes,
+    ]);
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        checkTaskExpression(node);
+      },
+
+      NewExpression(node: TSESTree.NewExpression): void {
+        checkTaskExpression(node);
+      },
+    };
+
+    function checkTaskExpression(node: TSESTree.CallExpression | TSESTree.NewExpression): void {
+      // For `returnsTask().map(fn)`, report on the full `.map(fn)` call rather
+      // than on the `returnsTask()` receiver.
+      if (isReceiverOfMethodCall(node)) {
+        return;
+      }
+
+      // If the expression is awaited, returned, assigned, or passed onward, it
+      // is no longer floating at this location.
+      if (isHandled(node)) {
+        return;
+      }
+
+      const type = services.getTypeAtLocation(node);
+      if (resolver.obligationFor(type).isJust) {
+        context.report({
+          node,
+          messageId: MESSAGE_ID,
+        });
+      }
+    }
+  },
+});
+
+function isHandled(node: TSESTree.Expression): boolean {
+  let current = node;
+  let parent = current.parent;
+
+  while (parent) {
+    switch (parent.type) {
+      // Awaiting the expression executes and handles the Task.
+      case AST_NODE_TYPES.AwaitExpression:
+        return parent.argument === current;
+
+      // These nodes do not handle the Task; they only wrap the expression, so
+      // keep walking to find the construct that actually consumes it.
+      case AST_NODE_TYPES.ChainExpression:
+      case AST_NODE_TYPES.ConditionalExpression:
+      case AST_NODE_TYPES.TSAsExpression:
+      case AST_NODE_TYPES.TSNonNullExpression:
+      case AST_NODE_TYPES.TSTypeAssertion:
+        current = parent;
+        parent = current.parent;
+        continue;
+
+      // Expression-bodied callbacks and block returns both pass the Task to
+      // their caller, which is a handled use rather than a floating expression.
+      case AST_NODE_TYPES.ArrowFunctionExpression:
+        return parent.body === current;
+
+      // Assignments, arguments, returns, and variable initializers all transfer
+      // the Task value somewhere else for later handling.
+      case AST_NODE_TYPES.AssignmentExpression:
+        return parent.right === current;
+
+      // Passing a Task as an argument is handled by the callee; using it as the
+      // callee is not, because invoking a Task-valued expression still floats it.
+      case AST_NODE_TYPES.CallExpression:
+        return parent.callee !== current;
+
+      case AST_NODE_TYPES.ReturnStatement:
+        return parent.argument === current;
+
+      case AST_NODE_TYPES.VariableDeclarator:
+        return parent.init === current;
+
+      default:
+        return false;
+    }
+  }
+
+  // ESLint traversal supplies parent links for visited expressions; reaching
+  // this means a caller passed a detached node, so fail loudly instead of
+  // silently treating an unknown context as unhandled.
+  /* v8 ignore next */
+  throw new Error('Expected expression to have a parent node.');
+}
+
+function isReceiverOfMethodCall(node: TSESTree.Expression): boolean {
+  let current = node;
+  let parent = current.parent;
+
+  while (parent) {
+    switch (parent.type) {
+      // Syntax wrappers around the receiver should not change whether the
+      // original expression is being used as the object of a method call.
+      case AST_NODE_TYPES.ChainExpression:
+      case AST_NODE_TYPES.TSAsExpression:
+      case AST_NODE_TYPES.TSNonNullExpression:
+      case AST_NODE_TYPES.TSTypeAssertion:
+        current = parent;
+        parent = current.parent;
+        continue;
+
+      // A method call consumes the receiver Task, e.g. task.map(fn); the rule
+      // reports on the full method call expression if that call also returns a Task.
+      case AST_NODE_TYPES.MemberExpression:
+        // `task.method()` consumes `task`; `object[task]` uses the Task as a
+        // property key and should be reported as floating.
+        if (parent.object !== current) {
+          return false;
+        }
+
+        return isCalledMemberExpression(parent);
+
+      default:
+        return false;
+    }
+  }
+
+  // ESLint traversal supplies parent links for visited expressions; reaching
+  // this means a caller passed a detached node, so fail loudly instead of
+  // silently treating an unknown context as not-a-receiver.
+  /* v8 ignore next */
+  throw new Error('Expected expression to have a parent node.');
+}
+
+function isCalledMemberExpression(memberExpression: TSESTree.MemberExpression): boolean {
+  let current: TSESTree.Expression = memberExpression;
+  let parent = current.parent;
+
+  while (parent?.type === AST_NODE_TYPES.ChainExpression) {
+    current = parent;
+    parent = current.parent;
+  }
+
+  return parent?.type === AST_NODE_TYPES.CallExpression && parent.callee === current;
+}
+
+function optionsFrom(value: unknown): Required<Options> {
+  if (value === undefined) {
+    return DEFAULT_OPTIONS;
+  }
+
+  if (!isRecord(value)) {
+    throw new TypeError('Expected must-await-task options to be an object.');
+  }
+
+  return {
+    additionalTypes: mustUseTypesFrom(value.additionalTypes, 'additionalTypes'),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/eslint-plugin/must-use.ts
+++ b/src/eslint-plugin/must-use.ts
@@ -1,0 +1,261 @@
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+
+import Maybe from 'true-myth/maybe';
+
+import {
+  createRule,
+  Resolver,
+  TRUE_MYTH_MUST_AWAIT_TYPES,
+  TRUE_MYTH_MUST_USE_TYPES,
+  getTypedParserServices,
+  mustUseTypesFrom,
+  type MustUseType,
+  type Obligation,
+} from './true-myth-support.js';
+
+type AllowVoid = boolean | MustUseType[];
+
+interface Options {
+  allowVoid?: AllowVoid;
+  additionalTypes?: MustUseType[];
+}
+
+const MESSAGE_ID = 'unusedMustUseValue';
+type MESSAGE_ID = typeof MESSAGE_ID;
+
+const DEFAULT_OPTIONS: Required<Options> = {
+  additionalTypes: [],
+  allowVoid: true,
+};
+
+const mustUseTypeSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    export: {
+      anyOf: [
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            kind: { enum: ['default'], type: 'string' },
+          },
+          required: ['kind'],
+        },
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            kind: { enum: ['named'], type: 'string' },
+            name: { type: 'string' },
+          },
+          required: ['kind', 'name'],
+        },
+      ],
+    },
+    module: { type: 'string' },
+  },
+  required: ['module', 'export'],
+};
+
+/**
+  Requires callers to use True Myth `Result` and `Task` values.
+
+  @see https://true-myth.js.org/eslint-plugin/must-use
+ */
+export const mustUse = createRule({
+  name: 'must-use',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require callers to use values whose type must not be discarded.',
+    },
+    messages: {
+      [MESSAGE_ID]: '{{typeName}} values should be used or explicitly discarded with `void`.',
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          allowVoid: {
+            anyOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'array',
+                items: {
+                  ...mustUseTypeSchema,
+                },
+                uniqueItems: true,
+              },
+            ],
+          },
+          additionalTypes: {
+            type: 'array',
+            items: {
+              ...mustUseTypeSchema,
+            },
+          },
+        },
+      },
+    ],
+  },
+  create(context) {
+    const services = getTypedParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const options = optionsFrom(context.options[0]);
+    const mustAwaitTypes = [...TRUE_MYTH_MUST_AWAIT_TYPES, ...options.additionalTypes];
+    const resolver = new Resolver(services.program, checker, [
+      ...TRUE_MYTH_MUST_USE_TYPES,
+      ...options.additionalTypes,
+    ]);
+
+    return {
+      ExpressionStatement(node: TSESTree.ExpressionStatement): void {
+        const candidate = unwrapExpressionStatement(node.expression);
+        const expression = candidate.expression;
+        if (!isMustUseCandidate(expression)) {
+          return;
+        }
+
+        const obligation = obligationForExpression(expression);
+        if (obligation.isJust) {
+          if (candidate.explicitlyDiscarded && allowVoidFor(obligation.value, options.allowVoid)) {
+            return;
+          }
+
+          context.report({
+            node: expression,
+            messageId: 'unusedMustUseValue',
+            data: {
+              typeName: obligation.value.label,
+            },
+          });
+        }
+      },
+    };
+
+    function obligationForExpression(
+      expression: TSESTree.AwaitExpression | TSESTree.CallExpression | TSESTree.NewExpression
+    ): Maybe<Obligation> {
+      if (expression.type === AST_NODE_TYPES.AwaitExpression) {
+        let obligation = resolver.obligationFor(services.getTypeAtLocation(expression.argument));
+
+        if (obligation.isJust && isAwaitObligation(obligation.value, mustAwaitTypes)) {
+          return obligation;
+        }
+      }
+
+      return resolver.obligationFor(services.getTypeAtLocation(expression));
+    }
+  },
+});
+
+function unwrapExpressionStatement(expression: TSESTree.Expression): {
+  explicitlyDiscarded: boolean;
+  expression: TSESTree.Expression;
+} {
+  let current = expression;
+
+  while (true) {
+    if (current.type === AST_NODE_TYPES.UnaryExpression && current.operator === 'void') {
+      return {
+        explicitlyDiscarded: true,
+        expression: unwrapSyntax(current.argument),
+      };
+    }
+
+    let next = unwrapSyntaxOnce(current);
+    if (next === current) {
+      return {
+        explicitlyDiscarded: false,
+        expression: current,
+      };
+    }
+
+    current = next;
+  }
+}
+
+function unwrapSyntax(expression: TSESTree.Expression): TSESTree.Expression {
+  let current = expression;
+  while (true) {
+    let next = unwrapSyntaxOnce(current);
+    if (next === current) {
+      return current;
+    }
+
+    current = next;
+  }
+}
+
+function unwrapSyntaxOnce(expression: TSESTree.Expression): TSESTree.Expression {
+  switch (expression.type) {
+    case AST_NODE_TYPES.ChainExpression:
+      return expression.expression;
+    case AST_NODE_TYPES.TSAsExpression:
+    case AST_NODE_TYPES.TSNonNullExpression:
+    case AST_NODE_TYPES.TSTypeAssertion:
+      return expression.expression;
+    default:
+      return expression;
+  }
+}
+
+function isMustUseCandidate(
+  expression: TSESTree.Expression
+): expression is TSESTree.AwaitExpression | TSESTree.CallExpression | TSESTree.NewExpression {
+  return (
+    expression.type === AST_NODE_TYPES.AwaitExpression ||
+    expression.type === AST_NODE_TYPES.CallExpression ||
+    expression.type === AST_NODE_TYPES.NewExpression
+  );
+}
+
+function allowVoidFor(obligation: Obligation, allowVoid: AllowVoid): boolean {
+  return (
+    allowVoid === true ||
+    (Array.isArray(allowVoid) && allowVoid.some((allowedType) => obligation.matches(allowedType)))
+  );
+}
+
+function optionsFrom(value: unknown): Required<Options> {
+  if (value === undefined) {
+    return DEFAULT_OPTIONS;
+  }
+
+  if (!isRecord(value)) {
+    throw new TypeError('Expected must-use options to be an object.');
+  }
+
+  return {
+    additionalTypes: mustUseTypesFrom(value.additionalTypes, 'additionalTypes'),
+    allowVoid: allowVoidFrom(value.allowVoid),
+  };
+}
+
+function allowVoidFrom(value: unknown): AllowVoid {
+  if (value === undefined) {
+    return DEFAULT_OPTIONS.allowVoid;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return mustUseTypesFrom(value, 'allowVoid');
+  }
+
+  throw new TypeError('Expected allowVoid to be a boolean or an array of must-use types.');
+}
+
+function isAwaitObligation(obligation: Obligation, mustAwaitTypes: MustUseType[]): boolean {
+  return mustAwaitTypes.some((type) => obligation.matches(type));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/eslint-plugin/true-myth-support.ts
+++ b/src/eslint-plugin/true-myth-support.ts
@@ -1,0 +1,352 @@
+import { RuleContext, RuleDefinition } from '@eslint/core';
+import type { TSESTree } from '@typescript-eslint/utils';
+import ts from 'typescript';
+
+import Maybe, * as maybe from 'true-myth/maybe';
+
+interface NamedRuleDefinition extends RuleDefinition {
+  name: string;
+}
+
+export function createRule(rule: NamedRuleDefinition): RuleDefinition {
+  return {
+    meta: {
+      ...rule.meta,
+      docs: {
+        ...rule.meta?.docs,
+        url: `https://true-myth.js.org/eslint-plugin/${rule.name}`,
+      },
+    },
+    create: rule.create,
+  };
+}
+
+interface TypedParserServices {
+  esTreeNodeToTSNodeMap: {
+    get(node: TSESTree.Node): ts.Node;
+  };
+  getTypeAtLocation(node: TSESTree.Node): ts.Type;
+  program: ts.Program;
+}
+
+export function getTypedParserServices(context: RuleContext): TypedParserServices {
+  let sourceCode = context.sourceCode;
+
+  if (!('parserServices' in sourceCode) || !isTypedParserServices(sourceCode.parserServices)) {
+    throw new Error(
+      'The True Myth ESLint plugin requires typed linting from @typescript-eslint/parser.'
+    );
+  }
+
+  return sourceCode.parserServices;
+}
+
+export type Export = { kind: 'default' } | { kind: 'named'; name: string };
+
+export interface MustUseType {
+  module: string;
+  export: Export;
+}
+
+export class Obligation {
+  readonly symbol: ts.Symbol;
+  readonly type: MustUseType;
+  private readonly equivalentTypes: MustUseType[];
+
+  constructor(symbol: ts.Symbol, type: MustUseType) {
+    this.symbol = symbol;
+    this.type = type;
+    this.equivalentTypes = [type];
+  }
+
+  get label(): string {
+    switch (this.type.export.kind) {
+      case 'default':
+        return `${this.type.module} default export`;
+      case 'named':
+        return `${this.type.module} ${this.type.export.name} export`;
+      /* v8 ignore start */
+      default:
+        return unreachable(this.type.export);
+      /* v8 ignore stop */
+    }
+  }
+
+  addEquivalentType(type: MustUseType): void {
+    this.equivalentTypes.push(type);
+  }
+
+  matches(type: MustUseType): boolean {
+    return this.equivalentTypes.some((equivalentType) => sameMustUseType(equivalentType, type));
+  }
+}
+
+export function mustUseTypesFrom(value: unknown, optionName = 'must-use types'): MustUseType[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError(`Expected ${optionName} to be an array of must-use type definitions.`);
+  }
+
+  let parsed = value.reduce(
+    (result, item, index) => {
+      if (isMustUseType(item)) {
+        result.types.push(item);
+      } else {
+        result.errors.push(`${optionName}[${index}]: ${mustUseTypeErrorFor(item)}`);
+      }
+
+      return result;
+    },
+    { types: new Array<MustUseType>(), errors: new Array<string>() }
+  );
+
+  if (parsed.errors.length > 0) {
+    throw new TypeError(`Invalid ${optionName}: ${parsed.errors.join('; ')}`);
+  }
+
+  return parsed.types;
+}
+
+export function sameMustUseType(left: MustUseType, right: MustUseType): boolean {
+  if (left.module !== right.module || left.export.kind !== right.export.kind) {
+    return false;
+  }
+
+  switch (left.export.kind) {
+    case 'default':
+      return true;
+    case 'named':
+      return right.export.kind === 'named' && left.export.name === right.export.name;
+    /* v8 ignore start */
+    default:
+      return unreachable(left.export);
+    /* v8 ignore stop */
+  }
+}
+
+class SafeMap<K, V extends {}> {
+  #internal = new Map<K, V>();
+
+  set(key: K, value: V) {
+    this.#internal.set(key, value);
+  }
+
+  get(key: K): Maybe<V> {
+    return Maybe.of(this.#internal.get(key));
+  }
+}
+
+export class Resolver {
+  private readonly checker: ts.TypeChecker;
+  private readonly obligations = new SafeMap<ts.Symbol, Obligation>();
+
+  constructor(program: ts.Program, checker: ts.TypeChecker, types: MustUseType[]) {
+    this.checker = checker;
+    this.addTypes(program, types);
+  }
+
+  obligationFor(type: ts.Type, seen = new Set<ts.Type>()): Maybe<Obligation> {
+    const symbolsForType = [type.aliasSymbol, type.getSymbol(), type.symbol].filter(
+      (symbol): symbol is ts.Symbol => symbol !== undefined
+    );
+
+    for (let symbol of symbolsForType) {
+      let obligation = this.obligations.get(this.canonicalSymbol(symbol));
+      if (obligation.isJust) {
+        return obligation;
+      }
+    }
+
+    // If we see this type again, symbol lookup above already failed for it; only
+    // apparent-type recursion remains, so stop instead of cycling forever.
+    if (seen.has(type)) {
+      return maybe.nothing();
+    }
+
+    // Otherwise, mark that we have seen it precisely to avoid that cycle.
+    seen.add(type);
+
+    // Fall back to the apparent type when direct symbol lookup only sees the
+    // local type shape. For example, a value typed as `T` in
+    // `T extends Result<number, string>` can expose the configured `Result`
+    // export through its apparent type.
+    let apparent = this.checker.getApparentType(type);
+    if (apparent !== type) {
+      return this.obligationFor(apparent, seen);
+    }
+
+    return maybe.nothing();
+  }
+
+  private addTypes(program: ts.Program, types: MustUseType[]): void {
+    let host: ts.ModuleResolutionHost = {
+      directoryExists: ts.sys.directoryExists,
+      fileExists: ts.sys.fileExists,
+      getCurrentDirectory: () => program.getCurrentDirectory(),
+      readFile: ts.sys.readFile,
+      // ESLint runs this plugin in Node, where TypeScript's system host provides
+      // realpath; include it directly instead of branching for non-Node hosts.
+      realpath: ts.sys.realpath!,
+    };
+
+    for (let type of types) {
+      let symbol = maybe
+        .first(program.getSourceFiles())
+        .flatten()
+        .andThen((sourceFile) =>
+          Maybe.of(
+            ts.resolveModuleName(
+              type.module,
+              sourceFile.fileName,
+              program.getCompilerOptions(),
+              host
+            ).resolvedModule
+          )
+        )
+        .andThen((resolved) => Maybe.of(program.getSourceFile(resolved.resolvedFileName)))
+        .andThen((sourceFile) => Maybe.of(this.checker.getSymbolAtLocation(sourceFile)))
+        .andThen((moduleSymbol) =>
+          maybe.find(
+            (candidate) =>
+              candidate.getName() ===
+              (type.export.kind === 'default' ? 'default' : type.export.name),
+            this.checker.getExportsOfModule(moduleSymbol)
+          )
+        );
+
+      if (symbol.isJust) {
+        let canonical = this.canonicalSymbol(symbol.value);
+        let existing = this.obligations.get(canonical);
+        if (existing.isJust) {
+          existing.value.addEquivalentType(type);
+        } else {
+          this.obligations.set(canonical, new Obligation(symbol.value, type));
+        }
+      }
+    }
+  }
+
+  canonicalSymbol(symbol: ts.Symbol, seen = new Set<ts.Symbol>()): ts.Symbol {
+    if (seen.has(symbol) || (symbol.flags & ts.SymbolFlags.Alias) === 0) {
+      return symbol;
+    }
+
+    seen.add(symbol);
+    return this.canonicalSymbol(this.checker.getAliasedSymbol(symbol), seen);
+  }
+}
+
+const TRUE_MYTH_RESULT_TYPE: MustUseType = {
+  export: { kind: 'default' },
+  module: 'true-myth/result',
+};
+
+const TRUE_MYTH_TASK_TYPE: MustUseType = {
+  export: { kind: 'default' },
+  module: 'true-myth/task',
+};
+
+const TRUE_MYTH_NAMED_RESULT_TYPE: MustUseType = {
+  export: { kind: 'named', name: 'Result' },
+  module: 'true-myth/result',
+};
+
+const TRUE_MYTH_NAMED_TASK_TYPE: MustUseType = {
+  export: { kind: 'named', name: 'Task' },
+  module: 'true-myth/task',
+};
+
+const TRUE_MYTH_ROOT_RESULT_TYPE: MustUseType = {
+  export: { kind: 'named', name: 'Result' },
+  module: 'true-myth',
+};
+
+const TRUE_MYTH_ROOT_TASK_TYPE: MustUseType = {
+  export: { kind: 'named', name: 'Task' },
+  module: 'true-myth',
+};
+
+export const TRUE_MYTH_MUST_USE_TYPES = [
+  TRUE_MYTH_RESULT_TYPE,
+  TRUE_MYTH_NAMED_RESULT_TYPE,
+  TRUE_MYTH_TASK_TYPE,
+  TRUE_MYTH_NAMED_TASK_TYPE,
+  TRUE_MYTH_ROOT_RESULT_TYPE,
+  TRUE_MYTH_ROOT_TASK_TYPE,
+];
+
+export const TRUE_MYTH_MUST_AWAIT_TYPES = [
+  TRUE_MYTH_TASK_TYPE,
+  TRUE_MYTH_NAMED_TASK_TYPE,
+  TRUE_MYTH_ROOT_TASK_TYPE,
+];
+
+function isTypedParserServices(value: unknown): value is TypedParserServices {
+  if (!isIndexable(value)) {
+    return false;
+  }
+
+  return (
+    isMapLike(value.esTreeNodeToTSNodeMap) &&
+    hasFunction(value, 'getTypeAtLocation') &&
+    hasFunction(value.program, 'getTypeChecker')
+  );
+}
+
+function isMustUseType(value: unknown): value is MustUseType {
+  return isIndexable(value) && typeof value.module === 'string' && isExport(value.export);
+}
+
+function mustUseTypeErrorFor(value: unknown): string {
+  if (!isIndexable(value)) {
+    return 'expected an object';
+  }
+
+  let errors: string[] = [];
+
+  if (typeof value.module !== 'string') {
+    errors.push('module must be a string');
+  }
+
+  if (!isExport(value.export)) {
+    errors.push('export must be { kind: "default" } or { kind: "named", name: string }');
+  }
+
+  return errors.join(', ');
+}
+
+function isExport(value: unknown): value is Export {
+  if (!isIndexable(value)) {
+    return false;
+  }
+
+  switch (value.kind) {
+    case 'default':
+      return true;
+    case 'named':
+      return typeof value.name === 'string';
+    default:
+      return false;
+  }
+}
+
+function isMapLike(value: unknown): boolean {
+  return hasFunction(value, 'get');
+}
+
+function hasFunction(value: unknown, name: string): boolean {
+  return isIndexable(value) && typeof value[name] === 'function';
+}
+
+function isIndexable(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/* v8 ignore start */
+function unreachable(value: never): never {
+  throw new Error(`Unexpected value: ${String(value)}`);
+}
+/* v8 ignore stop */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@
   @packageDocumentation
  */
 
+/* v8 ignore start */
+
 export * as maybe from './maybe.js';
 export { default as Maybe } from './maybe.js';
 
@@ -20,3 +22,5 @@ export { default as Task } from './task.js';
 export * as toolbelt from './toolbelt.js';
 
 export { default as Unit } from './unit.js';
+
+/* v8 ignore stop */

--- a/test/eslint-plugin.test.ts
+++ b/test/eslint-plugin.test.ts
@@ -1,0 +1,1158 @@
+import parser from '@typescript-eslint/parser';
+import { RuleTester } from 'eslint';
+import { defineConfig } from 'eslint/config';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, test } from 'vitest';
+
+import Maybe from 'true-myth/maybe';
+
+import { Resolver, mustUseTypesFrom } from '../src/eslint-plugin/true-myth-support.js';
+import trueMythPlugin, { mustAwaitTask, mustUse } from 'true-myth/eslint-plugin';
+
+// RuleTester defaults to global test functions; this repo imports Vitest APIs.
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(testDirectory, '..');
+const ruleTesterFixture = 'test/fixtures/eslint-plugin-rule-tester.ts';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      projectService: true,
+      tsconfigRootDir: projectRoot,
+    },
+  },
+});
+
+const declarations = `
+import Result, { type Result as TrueMythResult } from 'true-myth/result';
+import Task, { reject, resolve, type Task as TrueMythTask } from 'true-myth/task';
+
+declare const TaskCtor: {
+  new(): TrueMythTask<number, string>;
+};
+
+declare const ResultCtor: {
+  new(): TrueMythResult<number, string>;
+};
+
+declare function returnsResult(): TrueMythResult<number, string>;
+declare function returnsTask(): TrueMythTask<number, string>;
+declare const service: {
+  check(): TrueMythResult<number, string>;
+  load(): TrueMythTask<number, string>;
+};
+declare const fn: (value: number) => number;
+declare const cond: (value: number) => boolean;
+declare function consume(value: TrueMythResult<number, string>): void;
+declare function consumeTask(value: TrueMythTask<number, string>): void;
+`;
+
+const additionalTypeDeclarations = `
+import type { MyType, MyTask, Res } from 'my-lib';
+import type DefaultMyType from 'my-lib/my-type';
+
+declare function returnsMyType(): MyType<number, string>;
+declare function returnsDefaultMyType(): DefaultMyType<number, string>;
+declare function returnsMyTask(): MyTask<number, string>;
+declare function returnsRes(): Res<number, string>;
+`;
+
+const myType = { module: 'my-lib', export: { kind: 'named', name: 'MyType' } };
+const defaultMyType = { module: 'my-lib/my-type', export: { kind: 'default' } };
+const myTask = { module: 'my-lib', export: { kind: 'named', name: 'MyTask' } };
+const resType = { module: 'my-lib', export: { kind: 'named', name: 'Res' } };
+const resultType = { module: 'true-myth/result', export: { kind: 'named', name: 'Result' } };
+const taskType = { module: 'true-myth/task', export: { kind: 'named', name: 'Task' } };
+
+function validCases(cases: Array<string | RuleTester.ValidTestCase>): RuleTester.ValidTestCase[] {
+  return cases.map((testCase) =>
+    typeof testCase === 'string'
+      ? { code: testCase, filename: ruleTesterFixture }
+      : { filename: ruleTesterFixture, ...testCase }
+  );
+}
+
+function invalidCases(cases: RuleTester.InvalidTestCase[]): RuleTester.InvalidTestCase[] {
+  return cases.map((testCase) => ({ filename: ruleTesterFixture, ...testCase }));
+}
+
+describe('ESLint plugin', () => {
+  test('recommended config is consumable by ESLint defineConfig', () => {
+    expect(defineConfig(trueMythPlugin.configs.recommended)).toHaveLength(1);
+  });
+
+  test('mustUseTypesFrom parses export-based type specs', () => {
+    expect(mustUseTypesFrom([myType, defaultMyType])).toEqual([myType, defaultMyType]);
+    expect(mustUseTypesFrom(undefined)).toEqual([]);
+  });
+
+  test('mustUseTypesFrom rejects malformed type specs', () => {
+    expect(() =>
+      mustUseTypesFrom({ module: 'my-lib', export: { kind: 'named', name: 'MyType' } })
+    ).toThrow('Expected must-use types to be an array of must-use type definitions');
+    expect(() => mustUseTypesFrom([{ lol: 'rofl' }])).toThrow(
+      'Invalid must-use types: must-use types[0]: module must be a string, export must be'
+    );
+    expect(() => mustUseTypesFrom([{ module: 'my-lib' }])).toThrow(
+      'Invalid must-use types: must-use types[0]: export must be'
+    );
+    expect(() =>
+      mustUseTypesFrom([{ module: 'my-lib', export: { kind: 'lol', name: 'rofl' } }])
+    ).toThrow('Invalid must-use types: must-use types[0]: export must be');
+    expect(() =>
+      mustUseTypesFrom([{ lol: 'rofl' }, { module: 'my-lib', export: { kind: 'lol' } }])
+    ).toThrow('must-use types[0]: module must be a string');
+    expect(() =>
+      mustUseTypesFrom([{ lol: 'rofl' }, { module: 'my-lib', export: { kind: 'lol' } }])
+    ).toThrow('must-use types[1]: export must be');
+    expect(() => mustUseTypesFrom([{ module: 123, export: { kind: 'default' } }])).toThrow(
+      'must-use types[0]: module must be a string'
+    );
+    expect(() => mustUseTypesFrom([null])).toThrow('must-use types[0]: expected an object');
+  });
+
+  test('Resolver stops on apparent type cycles after checking symbols', () => {
+    const firstType = {
+      getSymbol() {
+        return undefined;
+      },
+    };
+    const secondType = {
+      getSymbol() {
+        return undefined;
+      },
+    };
+    const resolver = Object.create(Resolver.prototype) as Resolver;
+    Object.assign(resolver, {
+      checker: {
+        getApparentType(type: unknown) {
+          return type === firstType ? secondType : firstType;
+        },
+      },
+      obligations: {
+        get() {
+          return Maybe.nothing();
+        },
+      },
+    });
+
+    expect(resolver.obligationFor(firstType as never).isNothing).toBe(true);
+  });
+
+  test('rules are exported', () => {
+    expect(
+      trueMythPlugin.rules?.['must-use'],
+      'the `must-use` rule is exported'
+    ).not.toBeUndefined();
+    expect(
+      trueMythPlugin.rules?.['must-await-task'],
+      'the `must-await-task` rule is exported'
+    ).not.toBeUndefined();
+  });
+
+  test('rules require typed parser services', () => {
+    const sourceCode = {
+      ast: {},
+      getLoc() {
+        return {
+          end: { column: 0, line: 1 },
+          start: { column: 0, line: 1 },
+        };
+      },
+      getRange() {
+        return [0, 0] satisfies [number, number];
+      },
+      parserServices: null,
+      text: '',
+      traverse() {
+        return [][Symbol.iterator]();
+      },
+    };
+
+    const context: Parameters<typeof mustUse.create>[0] = {
+      cwd: projectRoot,
+      filename: ruleTesterFixture,
+      id: 'true-myth/must-use',
+      languageOptions: {},
+      options: [],
+      physicalFilename: ruleTesterFixture,
+      report() {},
+      settings: {},
+      sourceCode,
+    };
+
+    expect(() => {
+      mustUse.create(context);
+    }).toThrow('requires typed linting');
+  });
+
+  test('rules reject malformed options when called directly', () => {
+    const sourceCode = {
+      ast: {},
+      getLoc() {
+        return {
+          end: { column: 0, line: 1 },
+          start: { column: 0, line: 1 },
+        };
+      },
+      getRange() {
+        return [0, 0] satisfies [number, number];
+      },
+      parserServices: {
+        esTreeNodeToTSNodeMap: new Map(),
+        getTypeAtLocation() {
+          throw new Error('not needed');
+        },
+        program: {
+          getTypeChecker() {
+            return {};
+          },
+        },
+      },
+      text: '',
+      traverse() {
+        return [][Symbol.iterator]();
+      },
+    };
+
+    expect(() => {
+      mustUse.create({
+        cwd: projectRoot,
+        filename: ruleTesterFixture,
+        id: 'true-myth/must-use',
+        languageOptions: {},
+        options: [{ allowVoid: 'nope' }],
+        physicalFilename: ruleTesterFixture,
+        report() {},
+        settings: {},
+        sourceCode,
+      });
+    }).toThrow('Expected allowVoid to be a boolean or an array of must-use types.');
+
+    expect(() => {
+      mustUse.create({
+        cwd: projectRoot,
+        filename: ruleTesterFixture,
+        id: 'true-myth/must-use',
+        languageOptions: {},
+        options: [{ allowVoid: [{ lol: 'rofl' }] }],
+        physicalFilename: ruleTesterFixture,
+        report() {},
+        settings: {},
+        sourceCode,
+      });
+    }).toThrow('Invalid allowVoid: allowVoid[0]: module must be a string, export must be');
+
+    expect(() => {
+      mustUse.create({
+        cwd: projectRoot,
+        filename: ruleTesterFixture,
+        id: 'true-myth/must-use',
+        languageOptions: {},
+        options: [123],
+        physicalFilename: ruleTesterFixture,
+        report() {},
+        settings: {},
+        sourceCode,
+      });
+    }).toThrow('Expected must-use options to be an object.');
+
+    expect(() => {
+      mustAwaitTask.create({
+        cwd: projectRoot,
+        filename: ruleTesterFixture,
+        id: 'true-myth/must-await-task',
+        languageOptions: {},
+        options: [123],
+        physicalFilename: ruleTesterFixture,
+        report() {},
+        settings: {},
+        sourceCode,
+      });
+    }).toThrow('Expected must-await-task options to be an object.');
+  });
+});
+
+ruleTester.run('must-use', mustUse, {
+  valid: validCases([
+    {
+      name: 'uses Result via assignment',
+      code: `${declarations}
+const value = returnsResult();
+`,
+    },
+    {
+      name: 'uses Task via assignment',
+      code: `${declarations}
+const value = returnsTask();
+`,
+    },
+    {
+      name: 'uses Result via return',
+      code: `${declarations}
+function getValue() {
+  return returnsResult();
+}
+`,
+    },
+    {
+      name: 'uses Task via return',
+      code: `${declarations}
+function getValue() {
+  return returnsTask();
+}
+`,
+    },
+    {
+      name: 'uses Result as an argument',
+      code: `${declarations}
+consume(returnsResult());
+`,
+    },
+    {
+      name: 'uses Task as an argument',
+      code: `${declarations}
+declare function consumeTask(value: TrueMythTask<number, string>): void;
+consumeTask(returnsTask());
+`,
+    },
+    {
+      name: 'uses re-exported Result via assignment',
+      code: `
+import type { Result as ReexportedResult } from './true-myth-reexport.js';
+
+declare function returnsResult(): ReexportedResult<number, string>;
+
+const value = returnsResult();
+`,
+    },
+    {
+      name: 'uses re-exported Task via assignment',
+      code: `
+import type { Task as ReexportedTask } from './true-myth-reexport.js';
+
+declare function returnsTask(): ReexportedTask<number, string>;
+
+const value = returnsTask();
+`,
+    },
+    {
+      name: 'uses namespace Result via assignment',
+      code: `
+import * as trueMyth from 'true-myth';
+
+declare function returnsResult(): trueMyth.Result<number, string>;
+
+const value = returnsResult();
+`,
+    },
+    {
+      name: 'uses namespace Task via assignment',
+      code: `
+import * as trueMyth from 'true-myth';
+
+declare function returnsTask(): trueMyth.Task<number, string>;
+
+const value = returnsTask();
+`,
+    },
+    {
+      name: 'uses Result through unwrapping',
+      code: `${declarations}
+returnsResult().unwrapOr(0);
+`,
+    },
+    {
+      name: 'explicitly discards Result with void',
+      code: `${declarations}
+void returnsResult();
+`,
+    },
+    {
+      name: 'explicitly discards Task with void',
+      code: `${declarations}
+void returnsTask();
+`,
+    },
+    {
+      name: 'explicitly executes and discards Task with void await',
+      code: `${declarations}
+async function run() {
+  void await returnsTask();
+}
+`,
+    },
+    {
+      name: 'allows void discard for Result only',
+      code: `${declarations}
+void returnsResult();
+`,
+      options: [{ allowVoid: [resultType] }],
+    },
+    {
+      name: 'allows void discard for Task only',
+      code: `${declarations}
+void returnsTask();
+`,
+      options: [{ allowVoid: [taskType] }],
+    },
+    {
+      name: 'allows void await discard for Task only',
+      code: `${declarations}
+async function run() {
+  void await returnsTask();
+}
+`,
+      options: [{ allowVoid: [taskType] }],
+    },
+    {
+      name: 'allows void discard for Result and Task',
+      code: `${declarations}
+void returnsResult();
+void returnsTask();
+`,
+      options: [{ allowVoid: [resultType, taskType] }],
+    },
+    {
+      name: 'uses default void handling for empty options',
+      code: `${declarations}
+void returnsTask();
+`,
+      options: [{}],
+    },
+    {
+      name: 'allows non-must-use return type',
+      code: `${declarations}
+declare function returnsNumber(): number;
+returnsNumber();
+`,
+    },
+    {
+      name: 'allows non-call expression statement',
+      code: `${declarations}
+1;
+`,
+    },
+    {
+      name: 'allows asserted void discard',
+      code: `${declarations}
+void (returnsTask() as TrueMythTask<number, string>);
+`,
+    },
+    {
+      name: 'ignores local Result with the same name',
+      code: `
+type Result<T, E> = { value: T; error?: E };
+declare function returnsResult(): Result<number, string>;
+returnsResult();
+`,
+    },
+    {
+      name: 'does not require custom type without option',
+      code: `
+type Outcome<T, E> = { value: T };
+declare function returnsOutcome(): Outcome<number, string>;
+returnsOutcome();
+`,
+    },
+    {
+      name: 'allows void discard for additional named export',
+      code: `${additionalTypeDeclarations}
+void returnsMyType();
+`,
+      options: [
+        {
+          additionalTypes: [myType],
+          allowVoid: [myType],
+        },
+      ],
+    },
+    {
+      name: 'allows void discard for additional default export',
+      code: `${additionalTypeDeclarations}
+void returnsDefaultMyType();
+`,
+      options: [
+        {
+          additionalTypes: [defaultMyType],
+          allowVoid: [defaultMyType],
+        },
+      ],
+    },
+    {
+      name: 'skips unresolvable additional type',
+      code: `
+interface MissingResult<T, E> {
+  readonly value: T;
+  readonly error?: E;
+}
+
+declare function returnsMissingType(): MissingResult<number, string>;
+returnsMissingType();
+`,
+      options: [
+        {
+          additionalTypes: [
+            { module: 'missing-lib', export: { kind: 'named', name: 'MissingResult' } },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'does not require unrelated Result type',
+      code: `
+type Result<T, E> = { value: T; error?: E };
+declare function returnsLocalResult(): Result<number, string>;
+returnsLocalResult();
+`,
+    },
+    {
+      name: 'does not require unrelated Task type',
+      code: `
+type Task<T, E> = { value: T; error?: E };
+declare function returnsLocalTask(): Task<number, string>;
+returnsLocalTask();
+`,
+    },
+  ]),
+  invalid: invalidCases([
+    {
+      name: 'rejects bare Result-returning call',
+      code: `${declarations}
+returnsResult();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Task-returning call',
+      code: `${declarations}
+returnsTask();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Result-returning method call',
+      code: `${declarations}
+service.check();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Task-returning method call',
+      code: `${declarations}
+service.load();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare re-exported Result-returning call',
+      code: `
+import type { Result as ReexportedResult } from './true-myth-reexport.js';
+
+declare function returnsResult(): ReexportedResult<number, string>;
+
+returnsResult();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare re-exported Task-returning call',
+      code: `
+import type { Task as ReexportedTask } from './true-myth-reexport.js';
+
+declare function returnsTask(): ReexportedTask<number, string>;
+
+returnsTask();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare namespace Result-returning call',
+      code: `
+import * as trueMyth from 'true-myth';
+
+declare function returnsResult(): trueMyth.Result<number, string>;
+
+returnsResult();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare namespace Task-returning call',
+      code: `
+import * as trueMyth from 'true-myth';
+
+declare function returnsTask(): trueMyth.Task<number, string>;
+
+returnsTask();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Result constructor function',
+      code: `${declarations}
+Result.ok(1);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Task constructor function',
+      code: `${declarations}
+Task.resolve(1);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare new expression returning Result',
+      code: `${declarations}
+new ResultCtor();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare new expression returning Task',
+      code: `${declarations}
+new TaskCtor();
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Result-returning chain',
+      code: `${declarations}
+returnsResult().map(fn);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare Task-returning chain',
+      code: `${declarations}
+returnsTask().map(fn);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects optional Result-returning chain',
+      code: `${declarations}
+returnsResult()?.map(fn);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects optional Task-returning chain',
+      code: `${declarations}
+returnsTask()?.map(fn);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects asserted Result-returning call',
+      code: `${declarations}
+(returnsResult() as TrueMythResult<number, string>);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects asserted Task-returning call',
+      code: `${declarations}
+(returnsTask() as TrueMythTask<number, string>);
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects type-asserted Result-returning call',
+      code: `${declarations}
+(<TrueMythResult<number, string>>returnsResult());
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects type-asserted Task-returning call',
+      code: `${declarations}
+(<TrueMythTask<number, string>>returnsTask());
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects non-null asserted Result-returning call',
+      code: `${declarations}
+returnsResult()!;
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects non-null asserted Task-returning call',
+      code: `${declarations}
+returnsTask()!;
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects awaited Task result without use',
+      code: `${declarations}
+async function run() {
+  await returnsTask();
+}
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects awaited Result without use',
+      code: `${declarations}
+async function run() {
+  await returnsResult();
+}
+`,
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects awaited additional await-like type without use',
+      code: `${additionalTypeDeclarations}
+async function run() {
+  await returnsMyTask();
+}
+`,
+      options: [{ additionalTypes: [myTask] }],
+      errors: [{ messageId: 'unusedMustUseValue', data: { typeName: 'my-lib MyTask export' } }],
+    },
+    {
+      name: 'rejects void discard when disabled',
+      code: `${declarations}
+void returnsResult();
+`,
+      options: [{ allowVoid: false }],
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects Task void discard when disabled',
+      code: `${declarations}
+void returnsTask();
+`,
+      options: [{ allowVoid: false }],
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects Result void discard when only Task is allowed',
+      code: `${declarations}
+void returnsResult();
+`,
+      options: [{ allowVoid: [taskType] }],
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects Task void discard when only Result is allowed',
+      code: `${declarations}
+void returnsTask();
+`,
+      options: [{ allowVoid: [resultType] }],
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects void await Task discard when only Result is allowed',
+      code: `${declarations}
+async function run() {
+  void await returnsTask();
+}
+`,
+      options: [{ allowVoid: [resultType] }],
+      errors: [{ messageId: 'unusedMustUseValue' }],
+    },
+    {
+      name: 'rejects bare additional type',
+      code: `${additionalTypeDeclarations}
+returnsMyType();
+`,
+      options: [{ additionalTypes: [myType] }],
+      errors: [{ messageId: 'unusedMustUseValue', data: { typeName: 'my-lib MyType export' } }],
+    },
+    {
+      name: 'rejects bare additional default export',
+      code: `${additionalTypeDeclarations}
+returnsDefaultMyType();
+`,
+      options: [{ additionalTypes: [defaultMyType] }],
+      errors: [
+        { messageId: 'unusedMustUseValue', data: { typeName: 'my-lib/my-type default export' } },
+      ],
+    },
+    {
+      name: 'rejects additional namespace type',
+      code: `
+import * as myLib from 'my-lib';
+
+declare function returnsMyType(): myLib.MyType<number, string>;
+
+returnsMyType();
+`,
+      options: [{ additionalTypes: [myType] }],
+      errors: [{ messageId: 'unusedMustUseValue', data: { typeName: 'my-lib MyType export' } }],
+    },
+    {
+      name: 'rejects void discard when allowVoid export does not match',
+      code: `${additionalTypeDeclarations}
+void returnsRes();
+`,
+      options: [{ additionalTypes: [resType], allowVoid: [myType] }],
+      errors: [{ messageId: 'unusedMustUseValue', data: { typeName: 'my-lib Res export' } }],
+    },
+  ]),
+});
+
+ruleTester.run('must-await-task', mustAwaitTask, {
+  valid: validCases([
+    {
+      name: 'awaits Task-returning call',
+      code: `${declarations}
+async function run() {
+  await returnsTask();
+}
+`,
+    },
+    {
+      name: 'explicitly awaits and discards Task-returning call',
+      code: `${declarations}
+async function run() {
+  void await returnsTask();
+}
+`,
+    },
+    {
+      name: 'awaits chained Task-returning call',
+      code: `${declarations}
+async function run() {
+  await returnsTask().map(fn);
+}
+`,
+    },
+    {
+      name: 'awaits chained Task-returning method call',
+      code: `${declarations}
+async function run() {
+  await service.load().map(fn);
+}
+`,
+    },
+    {
+      name: 'awaits optional chained Task-returning call',
+      code: `${declarations}
+async function run() {
+  await returnsTask()?.map(fn);
+}
+`,
+    },
+    {
+      name: 'awaits parenthesized optional chained Task-returning call',
+      code: `${declarations}
+async function run() {
+  await (returnsTask()?.map)(fn);
+}
+`,
+    },
+    {
+      name: 'awaits asserted Task-returning call',
+      code: `${declarations}
+async function run() {
+  await (returnsTask() as TrueMythTask<number, string>);
+}
+`,
+    },
+    {
+      name: 'awaits asserted chained Task-returning call',
+      code: `${declarations}
+async function run() {
+  await (returnsTask() as TrueMythTask<number, string>).map(fn);
+}
+`,
+    },
+    {
+      name: 'awaits non-null asserted chained Task-returning call',
+      code: `${declarations}
+async function run() {
+  await returnsTask()!.map(fn);
+}
+`,
+    },
+    {
+      name: 'awaits Task constructor function',
+      code: `${declarations}
+async function run() {
+  await Task.resolve(1);
+}
+`,
+    },
+    {
+      name: 'awaits optional Task-returning call',
+      code: `${declarations}
+async function run() {
+  await returnsTask?.();
+}
+`,
+    },
+    {
+      name: 'awaits new expression returning Task',
+      code: `${declarations}
+async function run() {
+  await new TaskCtor();
+}
+`,
+    },
+    {
+      name: 'binds Task-returning call for later handling',
+      code: `${declarations}
+const value = returnsTask();
+`,
+    },
+    {
+      name: 'binds Task constructor helpers for later handling',
+      code: `${declarations}
+let resolvedTask = resolve("Hello");
+let rejectedTask = reject("Oh no!");
+`,
+    },
+    {
+      name: 'assigns Task-returning call for later handling',
+      code: `${declarations}
+let value: TrueMythTask<number, string>;
+value = returnsTask();
+`,
+    },
+    {
+      name: 'returns Task-returning call for later handling',
+      code: `${declarations}
+function getValue() {
+  return returnsTask();
+}
+`,
+    },
+    {
+      name: 'passes Task-returning call for later handling',
+      code: `${declarations}
+consumeTask(returnsTask());
+`,
+    },
+    {
+      name: 'returns Task constructor helpers from combinator callback',
+      code: `${declarations}
+const nextTask = returnsTask().andThen((value) => {
+  if (cond(value)) {
+    return resolve(value);
+  }
+
+  return reject("Oh no!");
+});
+`,
+    },
+    {
+      name: 'returns Task constructor helper from expression-bodied callback',
+      code: `${declarations}
+const nextTask = returnsTask().andThen((value) => resolve(value));
+`,
+    },
+    {
+      name: 'returns Task constructor helpers from conditional callback',
+      code: `${declarations}
+const nextTask = returnsTask().andThen((value) =>
+  cond(value) ? resolve(value) : reject("Oh no!")
+);
+`,
+    },
+    {
+      name: 'ignores Result-returning call',
+      code: `${declarations}
+const value = returnsResult();
+`,
+    },
+    {
+      name: 'ignores unrelated Task type',
+      code: `
+type Task<T, E> = { value: T; error?: E };
+declare function returnsLocalTask(): Task<number, string>;
+const value = returnsLocalTask();
+`,
+    },
+    {
+      name: 'uses default additional types for empty options',
+      code: `${declarations}
+const value = returnsTask();
+`,
+      options: [{}],
+    },
+    {
+      name: 'awaits additional must-await type',
+      code: `${additionalTypeDeclarations}
+async function run() {
+  await returnsMyTask();
+}
+`,
+      options: [{ additionalTypes: [myTask] }],
+    },
+    {
+      name: 'ignores additional type when module is unresolvable',
+      code: `
+interface MissingTask<T, E> {
+  readonly value: T;
+  readonly error?: E;
+}
+
+declare function returnsMissingTask(): MissingTask<number, string>;
+returnsMissingTask();
+`,
+      options: [
+        {
+          additionalTypes: [
+            { module: 'missing-lib', export: { kind: 'named', name: 'MissingTask' } },
+          ],
+        },
+      ],
+    },
+  ]),
+  invalid: invalidCases([
+    {
+      name: 'rejects bare Task-returning call',
+      code: `${declarations}
+returnsTask();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects bare Task-returning method call',
+      code: `${declarations}
+service.load();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited Task-returning chain',
+      code: `${declarations}
+returnsTask().map(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited Task-returning method chain',
+      code: `${declarations}
+service.load().map(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited optional Task-returning chain',
+      code: `${declarations}
+returnsTask()?.map(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited optional Task-returning method call',
+      code: `${declarations}
+returnsTask().map?.(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects Task-returning call used as member key',
+      code: `${declarations}
+declare const keyedService: Record<string, number>;
+keyedService[returnsTask()];
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited asserted Task-returning chain',
+      code: `${declarations}
+(returnsTask() as TrueMythTask<number, string>).map(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited non-null asserted Task-returning chain',
+      code: `${declarations}
+returnsTask()!.map(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects unawaited nested Task-returning chain',
+      code: `${declarations}
+returnsTask().map(fn).map(fn);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects void Task-returning call',
+      code: `${declarations}
+void returnsTask();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects bare Task constructor function',
+      code: `${declarations}
+Task.resolve(1);
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects floating standalone Task constructor helper',
+      code: `${declarations}
+resolve("Hello");
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects floating conditional Task constructor helpers',
+      code: `${declarations}
+cond(1) ? resolve("Hello") : reject("Oh no!");
+`,
+      errors: [{ messageId: 'unawaitedTask' }, { messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects optional bare Task-returning call',
+      code: `${declarations}
+returnsTask?.();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects bare new expression returning Task',
+      code: `${declarations}
+new TaskCtor();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects bare re-exported Task-returning call',
+      code: `
+import type { Task as ReexportedTask } from './true-myth-reexport.js';
+
+declare function returnsTask(): ReexportedTask<number, string>;
+
+returnsTask();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects bare namespace Task-returning call',
+      code: `
+import * as trueMyth from 'true-myth';
+
+declare function returnsTask(): trueMyth.Task<number, string>;
+
+returnsTask();
+`,
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+    {
+      name: 'rejects bare additional must-await type',
+      code: `${additionalTypeDeclarations}
+returnsMyTask();
+`,
+      options: [{ additionalTypes: [myTask] }],
+      errors: [{ messageId: 'unawaitedTask' }],
+    },
+  ]),
+});

--- a/test/fixtures/eslint-plugin-rule-tester.ts
+++ b/test/fixtures/eslint-plugin-rule-tester.ts
@@ -1,0 +1,2 @@
+// Anchor file for typed @typescript-eslint/rule-tester snippets.
+export {};

--- a/test/fixtures/my-lib.ts
+++ b/test/fixtures/my-lib.ts
@@ -1,0 +1,14 @@
+export interface MyType<T, E> {
+  readonly value: T;
+  readonly error?: E;
+}
+
+export interface MyTask<T, E> {
+  readonly value: T;
+  readonly error?: E;
+}
+
+export interface Res<T, E> {
+  readonly value: T;
+  readonly error?: E;
+}

--- a/test/fixtures/my-type.ts
+++ b/test/fixtures/my-type.ts
@@ -1,0 +1,4 @@
+export default interface MyType<T, E> {
+  readonly value: T;
+  readonly error?: E;
+}

--- a/test/fixtures/true-myth-reexport.ts
+++ b/test/fixtures/true-myth-reexport.ts
@@ -1,0 +1,2 @@
+export type { Result } from 'true-myth/result';
+export type { Task } from 'true-myth/task';

--- a/test/fixtures/tsconfig.json
+++ b/test/fixtures/tsconfig.json
@@ -1,0 +1,22 @@
+// Narrow tsconfig for the ESLint rule-tester fixture. Keeping the include
+// list small means @typescript-eslint/project-service initialises quickly.
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../ts/base.tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "true-myth": ["src/index.ts"],
+      "true-myth/eslint-plugin": ["src/eslint-plugin/index.ts"],
+      "true-myth/*": ["src/*.ts"],
+      "my-lib": ["test/fixtures/my-lib.ts"],
+      "my-lib/my-type": ["test/fixtures/my-type.ts"]
+    }
+  },
+  "include": [
+    "./eslint-plugin-rule-tester.ts",
+    "./my-lib.ts",
+    "./my-type.ts",
+    "./true-myth-reexport.ts"
+  ]
+}

--- a/test/integration/eslint-plugin-package.test.ts
+++ b/test/integration/eslint-plugin-package.test.ts
@@ -1,0 +1,157 @@
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as url from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+const testDirectory = path.dirname(url.fileURLToPath(import.meta.url));
+const projectRoot = path.join(testDirectory, '..', '..');
+
+describe('published ESLint plugin package', () => {
+  test('imports emitted JavaScript and declarations through package exports', () => {
+    childProcess.execFileSync('pnpm', ['build'], { cwd: projectRoot });
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'true-myth-package-'));
+    const packageDirectory = path.join(tmpDir, 'node_modules', 'true-myth');
+
+    fs.mkdirSync(packageDirectory, { recursive: true });
+    fs.cpSync(path.join(projectRoot, 'dist'), path.join(packageDirectory, 'dist'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(packageDirectory, 'package.json'),
+      fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')
+    );
+
+    linkDependency(tmpDir, 'typescript');
+    linkDependency(tmpDir, 'eslint');
+    linkDependency(tmpDir, '@eslint');
+    linkDependency(tmpDir, '@types');
+    linkDependency(tmpDir, '@typescript-eslint');
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ type: 'module' }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'package-consumer.mjs'),
+      `
+        import { Maybe, Result, Task, Unit, maybe, result, standardSchema, task, toolbelt } from 'true-myth';
+        import trueMythPlugin from 'true-myth/eslint-plugin';
+        import MaybeDefault, { just } from 'true-myth/maybe';
+        import ResultDefault, { ok } from 'true-myth/result';
+        import { parserFor } from 'true-myth/standard-schema';
+        import TaskDefault, { resolve } from 'true-myth/task';
+        import { unwrap } from 'true-myth/test-support';
+        import { fromMaybe } from 'true-myth/toolbelt';
+        import UnitDefault from 'true-myth/unit';
+
+        if (!trueMythPlugin.rules?.['must-use']) {
+          throw new Error('Expected the packed plugin to expose must-use.');
+        }
+
+        if (
+          Maybe !== MaybeDefault ||
+          Result !== ResultDefault ||
+          Task !== TaskDefault ||
+          Unit !== UnitDefault ||
+          just(1).unwrapOr(0) !== 1 ||
+          ok(1).unwrapOr(0) !== 1 ||
+          unwrap(just(1)) !== 1 ||
+          fromMaybe('missing', just(1)).unwrapOr(0) !== 1 ||
+          maybe.just(1).unwrapOr(0) !== 1 ||
+          result.ok(1).unwrapOr(0) !== 1 ||
+          toolbelt.fromMaybe('missing', just(1)).unwrapOr(0) !== 1 ||
+          standardSchema.parserFor !== parserFor ||
+          task.resolve !== resolve
+        ) {
+          throw new Error('Expected public true-myth exports to resolve from the packed package.');
+        }
+
+        await resolve(1);
+        parserFor({ '~standard': { version: 1, vendor: 'test', validate: (value) => ({ value }) } });
+      `
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'package-consumer.ts'),
+      `
+        import { Maybe, Result, Task, Unit, maybe, result, standardSchema, task, toolbelt } from 'true-myth';
+        import trueMythPlugin from 'true-myth/eslint-plugin';
+        import MaybeDefault, { just } from 'true-myth/maybe';
+        import ResultDefault, { ok } from 'true-myth/result';
+        import { parserFor } from 'true-myth/standard-schema';
+        import TaskDefault, { resolve } from 'true-myth/task';
+        import { unwrap } from 'true-myth/test-support';
+        import { fromMaybe } from 'true-myth/toolbelt';
+        import UnitDefault from 'true-myth/unit';
+
+        const mustUse = trueMythPlugin.rules?.['must-use'];
+        const value: number = just(1).unwrapOr(0) + ok(1).unwrapOr(0);
+        const constructors: [typeof MaybeDefault, typeof ResultDefault, typeof TaskDefault, typeof UnitDefault] = [
+          Maybe,
+          Result,
+          Task,
+          Unit,
+        ];
+        const namespaces = [
+          maybe.just(1),
+          result.ok(1),
+          task.resolve(1),
+          toolbelt.fromMaybe('missing', just(1)),
+          standardSchema.parserFor,
+        ];
+        const helpers = [
+          unwrap(just(1)),
+          fromMaybe('missing', just(1)).unwrapOr(0),
+          parserFor,
+          resolve,
+        ];
+
+        if (!mustUse || value !== 2 || constructors.length !== 4 || namespaces.length !== 5 || helpers.length !== 4) {
+          throw new Error('unreachable');
+        }
+      `
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            exactOptionalPropertyTypes: true,
+            lib: ['es2022'],
+            module: 'Node16',
+            moduleResolution: 'Node16',
+            noEmit: true,
+            strict: true,
+            target: 'es2022',
+            types: ['node'],
+          },
+          include: ['package-consumer.ts'],
+        },
+        null,
+        2
+      )
+    );
+
+    childProcess.execFileSync('node', ['package-consumer.mjs'], { cwd: tmpDir });
+    childProcess.execFileSync(
+      'node',
+      [path.join(projectRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', '.'],
+      {
+        cwd: tmpDir,
+      }
+    );
+
+    expect(true).toBe(true);
+  }, 30_000);
+});
+
+function linkDependency(tmpDir: string, depName: string): void {
+  fs.symlinkSync(
+    path.join(projectRoot, 'node_modules', depName),
+    path.join(tmpDir, 'node_modules', depName),
+    'dir'
+  );
+}

--- a/ts/publish.tsconfig.json
+++ b/ts/publish.tsconfig.json
@@ -7,6 +7,13 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "../dist"
+    "outDir": "../dist",
+    "rootDir": "../src",
+    "types": ["node"],
+    "paths": {
+      "true-myth": ["../src/index.ts"],
+      "true-myth/eslint-plugin": ["../src/eslint-plugin/index.ts"],
+      "true-myth/*": ["../src/*.ts"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,17 @@
       "true-myth": [
         "./src/index.ts"
       ],
+      "true-myth/eslint-plugin": [
+        "./src/eslint-plugin/index.ts"
+      ],
       "true-myth/*": [
         "./src/*.ts"
       ]
-    }
+    },
+    // For tests.
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,10 @@ export const BaseConfig = defineConfig({
         replacement: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
       },
       {
+        find: /^true-myth\/eslint-plugin$/,
+        replacement: fileURLToPath(new URL('./src/eslint-plugin/index.ts', import.meta.url)),
+      },
+      {
         find: /^true-myth\/(.+)$/,
         replacement: fileURLToPath(new URL('./src/$1.ts', import.meta.url)),
       },

--- a/vitest.package-integration.config.ts
+++ b/vitest.package-integration.config.ts
@@ -2,12 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 import { BaseConfig } from './vitest.config.js';
 
-const ThirdPartyIntegrationTest = defineConfig({
+const PackageIntegrationTest = defineConfig({
   ...BaseConfig,
   test: {
-    include: ['test/integration/standard-schema.test.ts'],
+    include: ['test/integration/eslint-plugin-package.test.ts'],
     exclude: [],
   },
 });
 
-export default ThirdPartyIntegrationTest;
+export default PackageIntegrationTest;


### PR DESCRIPTION
Inspired by Rust’s `#[must_use]` and `@typescript-eslint/no-floating-promises`. I’m testing this out in a consuming repo and making sure to cover *alllll* the edge cases before we publish it, hopefully in a 9.4 release sometime soon.