### PR TITLE
Configure Buildkite and Cloudflare for deploying docs to true-myth.dev 

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Install mise on BuildKite-hosted agents where it is not pre-installed.
+if ! command -v mise &>/dev/null; then
+  curl -fsSL https://mise.run | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Install the Node.js and pnpm versions pinned in mise.toml.
+mise install
+
+# Expose mise-managed tool shims so that pnpm/node are available directly
+# in step commands, both on hosted agents and self-hosted agents without
+# mise activate in their shell profile.
+export PATH="$HOME/.local/share/mise/shims:$PATH"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,23 @@
+agents:
+  queue: "default"
+
+steps:
+  - label: ":books: Build docs"
+    key: "check-docs"
+    command: |
+      pnpm install
+      pnpm add --save-dev typescript@latest
+      pnpm run docs
+
+  - label: ":cloudflare: Deploy docs"
+    key: "deploy-docs"
+    depends_on: "check-docs"
+    branches: "main"
+    command: |
+      git fetch --unshallow 2>/dev/null || true
+      pnpm install
+      pnpm add --save-dev typescript@latest
+      pnpm run docs
+      npx wrangler pages deploy docs/.vitepress/dist \
+        --project-name=true-myth-docs \
+        --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,3 @@ jsconfig.json
 
 # Nova config
 .nova
-.codanna/index
-.fastembed_cache

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ docs-dist
 docs/.vitepress/cache
 docs/api/
 
+# Or wrangler output.
+.wrangler
+
 # Exclude auto-created jsconfig.json
 jsconfig.json
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "valibot": "^1.2.0",
     "vitepress": "2.0.0-alpha.17",
     "vitest": "^4.1.5",
+    "wrangler": "^4.97.0",
     "zod": "^4.1.13"
   },
   "engines": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+allowBuilds:
+  esbuild: true
+  sharp: false
+  workerd: true
 overrides:
   vite: npm:rolldown-vite@latest

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+"$schema" = "./node_modules/wrangler/config-schema.json"
+name = "true-myth"
+compatibility_date = "2026-06-03"
+
+[assets]
+directory = "./docs/.vitepress/dist"


### PR DESCRIPTION
- Add `wrangler` dependency and set up a basic `wrangler.toml` that just points a static site at the output from Vitepress
- Add a basic Buildkite pipeline