### PR TITLE
Add `CLOUDFLARE_API_TOKEN` secret to Buildkite config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 agents:
   queue: "default"
 
+secrets:
+  - CLOUDFLARE_API_TOKEN
+
 steps:
   - label: ":books: Build docs"
     key: "check-docs"


### PR DESCRIPTION
Docs: [Buildkite Secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets).