### PR TITLE
Set Dependabot cooldown to 1 day to match pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    cooldown:
+      default-days: 1


### PR DESCRIPTION
Combined with [the pnpm `minimumReleaseAge` setting][pnpm], which defaults to 1440 minutes since pnpm v11, _i.e._, 1 day, this should meaningfully decrease the likelihood of a zero-day vulnerability hitting us via Dependabot (see docs [here][dependabot]).

[pnpm]: https://pnpm.io/settings#minimumreleaseage
[dependabot]: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-