### PR TITLE
Result,Task: add `orThrow` and `orThrowWith` helpers

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -381,6 +381,78 @@ class ResultImpl<T, E> {
     return this.andThen(identity);
   }
 
+  /**
+    Given a `Result` whose `Err` variant is an `Error` (including any subclass
+    of `Error`), return the wrapped `Ok` value or throw the `Err` value.
+
+    > [!NOTE]
+    > Idiomatic code using True Myth will rarely use this helper. It exists for
+    > interopability with the broader JavaScript/TypeScript ecosystem, where some
+    > libraries use thrown exceptions for control flow or important semantics. For
+    > example, some ORMs use thrown exceptions as a primary (and sometimes the
+    > only) way to abort a transaction.
+
+    ```ts
+    import Result, * as result from 'true-myth/result';
+
+    class TooLow extends Error {
+      constructor(value: number) {
+        super(`The value was too low: ${value}`);
+      }
+    }
+
+    function getNumber(): Result<number, TooLow> {
+      let value = Math.random();
+      return value > 0.5 ? result.ok(value) : result.err(new TooLow(value));
+    }
+
+    let result = getNumber().orThrow();
+    ```
+   */
+  orThrow(this: Result<T, Error>): T {
+    if (this.isErr) {
+      throw this.error;
+    }
+
+    return this.value;
+  }
+
+  /**
+    Given a `Result`, return its wrapped value or throw an `Error`.
+
+    > [!NOTE]
+    > Idiomatic code using True Myth will rarely use this helper. It exists for
+    > interopability with the broader JavaScript/TypeScript ecosystem, where
+    > some libraries use thrown exceptions for control flow or important
+    > semantics. For example, some ORMs use thrown exceptions as a primary (and
+    > sometimes the only) way to abort a transaction.
+
+    ```ts
+    import * as result from 'true-myth/result';
+
+    class OrmError extends Error {
+      readonly name = "MyLib.OrmError";
+
+      constructor(err: unknown) {
+        super("True Myth `Result` was an `Err`", { cause: err });
+      }
+    }
+
+    function someOrmTransaction() {
+      let output = doSomeResultReturningOperation()
+        .orThrowWith((err) => new OrmError(err));
+      // ...
+    }
+    ```
+   */
+  orThrowWith<Thrown extends Error>(build: (err: E) => Thrown): T {
+    if (this.repr[0] === 'Err') {
+      throw build(this.repr[1]);
+    }
+
+    return this.repr[1];
+  }
+
   cast() {
     return this;
   }
@@ -1674,7 +1746,7 @@ export function ap<A, B, E>(
   can use this `safe` method to transform it into a form which will *not* throw:
 
   ```ts
-  import { safe } from 'true-myth/task';
+  import { safe } from 'true-myth/result';
   const parse = safe(JSON.parse);
 
   let result = parse(`"ill-formed gobbledygook'`);
@@ -1709,7 +1781,7 @@ export function safe<F extends AnyFunction, P extends Parameters<F>, R extends R
   wrapping it in a custom error :
 
   ```ts
-  import { safe } from 'true-myth/task';
+  import { safe } from 'true-myth/result';
 
   class ParsingError extends Error {
     name = 'ParsingError';
@@ -1978,6 +2050,120 @@ export function transposeAny(
   }
 
   return Result.err(errs);
+}
+
+/**
+  Given a `Result` whose `Err` variant is an `Error` (including any subclass of
+  `Error`), return the wrapped `Ok` value or throw the `Err` value.
+
+  > [!NOTE]
+  > Idiomatic code using True Myth will rarely use this helper. It exists for
+  > interopability with the broader JavaScript/TypeScript ecosystem, where some
+  > libraries use thrown exceptions for control flow or important semantics. For
+  > example, some ORMs use thrown exceptions as a primary (and sometimes the
+  > only) way to abort a transaction.
+
+  ```ts
+  import Result, * as result from 'true-myth/result';
+
+  class TooLow extends Error {
+    constructor(value: number) {
+      super(`The value was too low: ${value}`);
+    }
+  }
+
+  function getNumber(): Result<number, TooLow> {
+    let value = Math.random();
+    return value > 0.5 ? result.ok(value) : result.err(new TooLow(value));
+  }
+
+  function useIt() {
+    let result = result.orThrow(getNumber());
+  }
+  ```
+ */
+export function orThrow<T, E extends Error>(result: Result<T, E>): T {
+  return result.orThrow();
+}
+
+/**
+  Given a `Result`, return its wrapped value or build an `Error` and throw it.
+
+  > [!NOTE]
+  > Idiomatic code using True Myth will rarely use this helper. It exists for
+  > interopability with the broader JavaScript/TypeScript ecosystem, where some
+  > libraries use thrown exceptions for control flow or important semantics. For
+  > example, some ORMs use thrown exceptions as a primary (and sometimes the
+  > only) way to abort a transaction.
+
+  This is the main form, which takes both the exception builder and the `Result`.
+  A curried form exists as well.
+
+  ```ts
+  import * as result from 'true-myth/result';
+
+  class OrmError extends Error {
+    readonly name = "MyLib.OrmError";
+
+    constructor(err: unknown) {
+      super("True Myth `Result` was an `Err`", { cause: err });
+    }
+  }
+
+  function someOrmTransaction() {
+    let output = result.orThrowWith(
+      (err) => new OrmError(err),
+      doSomeResultReturningOperation(),
+    );
+    // ...
+  }
+  ```
+ */
+export function orThrowWith<T, E, Thrown extends Error>(
+  buildError: (err: E) => Thrown,
+  result: Result<T, E>
+): T;
+/**
+  Given a `Result`, return its wrapped value or throw an `Error`.
+
+  > [!NOTE]
+  > Idiomatic code using True Myth will rarely use this helper. It exists for
+  > interopability with the broader JavaScript/TypeScript ecosystem, where some
+  > libraries use thrown exceptions for control flow or important semantics. For
+  > example, some ORMs use thrown exceptions as a primary (and sometimes the
+  > only) way to abort a transaction.
+
+  This is the curried form, which allows you to create a standalone function
+  easily and pass any `Result` to it later. A form that accepts both the error
+  builder and the result at once exists as well.
+
+  ```ts
+  import * as result from 'true-myth/result';
+
+  class OrmError extends Error {
+    readonly name = "MyLib.OrmError";
+
+    constructor(err: unknown) {
+      super("True Myth `Result` was an `Err`", { cause: err });
+    }
+  }
+
+  const abortable = result.orThrowWith((err) => new OrmError(err));
+
+  function someOrmTransaction() {
+    let output = abortable(doSomeResultReturningOperation());
+    // ...
+  }
+  ```
+ */
+export function orThrowWith<T, E, Thrown extends Error>(
+  buildError: (err: E) => Thrown
+): (result: Result<T, E>) => T;
+export function orThrowWith<T, E, Thrown extends Error>(
+  buildError: (err: E) => Thrown,
+  result?: Result<T, E>
+): T | ((result: Result<T, E>) => T) {
+  return result ? result.orThrowWith(buildError) : (result) => result.orThrowWith(buildError);
 }
 
 /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -801,6 +801,71 @@ class TaskImpl<T, E> implements PromiseLike<Result<T, E>> {
   }
 
   /**
+    Given a {@linkcode Task}, return a `Promise` of its wrapped value or throw
+    an `Error`.
+
+    > [!NOTE]
+    > Idiomatic code using True Myth will rarely use this helper. It exists for
+    > interoperability with the broader JavaScript/TypeScript ecosystem, where
+    > some libraries use thrown exceptions for control flow or important
+    > semantics. For example, some ORMs use thrown exceptions as a primary (and
+    > sometimes the only) way to abort a transaction.
+
+    ```ts
+    import Task from ‘true-myth/task’;
+
+    class TooLow extends Error {
+      constructor(value: number) {
+        super(`The value was too low: ${value}`);
+      }
+    }
+
+    async function getNumber(): Promise<Task<number, TooLow>> {
+      let value = Math.random();
+      return value > 0.5 ? Task.resolve(value) : Task.reject(new TooLow(value));
+    }
+
+    let value = await (await getNumber()).orThrow();
+    ```
+   */
+  orThrow(this: Task<T, Error>): Promise<T> {
+    return this.toPromise().then(result.orThrow);
+  }
+
+  /**
+    Given a {@linkcode Task}, return a `Promise` of its wrapped value or build
+    an `Error` and throw it.
+
+    > [!NOTE]
+    > Idiomatic code using True Myth will rarely use this helper. It exists for
+    > interoperability with the broader JavaScript/TypeScript ecosystem, where
+    > some libraries use thrown exceptions for control flow or important
+    > semantics. For example, some ORMs use thrown exceptions as a primary (and
+    > sometimes the only) way to abort a transaction.
+
+    ```ts
+    import Task from ‘true-myth/task’;
+
+    class OrmError extends Error {
+      readonly name = "MyLib.OrmError";
+
+      constructor(err: unknown) {
+        super("True Myth `Task` was `Rejected`", { cause: err });
+      }
+    }
+
+    async function someOrmTransaction() {
+      let output = await doSomeTaskReturningOperation()
+        .orThrowWith((reason) => new OrmError(reason));
+      // ...
+    }
+    ```
+   */
+  orThrowWith<Thrown extends Error>(build: (reason: E) => Thrown): Promise<T> {
+    return this.#promise.then(result.orThrowWith(build));
+  }
+
+  /**
     Allows you to produce a new value by providing functions to operate against
     both the {@linkcode Resolved} and {@linkcode Rejected} states once the
     {@linkcode Task} resolves.
@@ -2584,6 +2649,125 @@ export function orElse<T, E, F, U = T>(
   task?: Task<T, E>
 ): Task<T | U, F> | ((task: Task<T, E>) => Task<T | U, F>) {
   return curry1((task) => task.orElse(elseFn), task);
+}
+
+/**
+  Given a `Task` whose rejection type is an `Error` (including any subclass of
+  `Error`), return a `Promise` of the resolved value or throw the rejection
+  reason.
+
+  > [!NOTE]
+  > Idiomatic code using True Myth will rarely use this helper. It exists for
+  > interoperability with the broader JavaScript/TypeScript ecosystem, where
+  > some libraries use thrown exceptions for control flow or important
+  > semantics. For example, some ORMs use thrown exceptions as a primary (and
+  > sometimes the only) way to abort a transaction.
+
+  ```ts
+  import * as task from 'true-myth/task';
+
+  class TooLow extends Error {
+    constructor(value: number) {
+      super(`The value was too low: ${value}`);
+    }
+  }
+
+  function getNumber(): task.Task<number, TooLow> {
+    let value = Math.random();
+    return value > 0.5 ? task.resolve(value) : task.reject(new TooLow(value));
+  }
+
+  async function useIt() {
+    let value = await task.orThrow(getNumber());
+  }
+  ```
+
+  @template T The type of the value when the `Task` resolves successfully.
+  @template E The type of the rejection reason when the `Task` rejects.
+ */
+export function orThrow<T, E extends Error>(task: Task<T, E>): Promise<T> {
+  return task.orThrow();
+}
+
+/**
+  Given a `Task`, return a `Promise` of the resolved value or build an `Error`
+  and throw it.
+
+  > [!NOTE]
+  > Idiomatic code using True Myth will rarely use this helper. It exists for
+  > interoperability with the broader JavaScript/TypeScript ecosystem, where
+  > some libraries use thrown exceptions for control flow or important
+  > semantics. For example, some ORMs use thrown exceptions as a primary (and
+  > sometimes the only) way to abort a transaction.
+
+  This is the main form, which takes both the eeption builder and the `Task`. A
+  curried form exists as well.
+
+  ```ts
+  import * as task from 'true-myth/task';
+
+  class OrmError extends Error {
+    readonly name = "MyLib.OrmError";
+
+    constructor(err: unknown) {
+      super("True Myth `Task` was `Rejected`", { cause: err });
+    }
+  }
+
+  async function someOrmTransaction() {
+    let output = await task.orThrowWith(
+      (reason) => new OrmError(reason),
+      doSomeTaskReturningOperation(),
+    );
+    // ...
+  }
+  ```
+ */
+export function orThrowWith<T, E, Thrown extends Error>(
+  buildError: (reason: E) => Thrown,
+  task: Task<T, E>
+): Promise<T>;
+/**
+  Given a `Task`, return a `Promise` of the resolved value or throw an `Error`.
+
+  > [!NOTE]
+  > Idiomatic code using True Myth will rarely use this helper. It exists for
+  > interoperability with the broader JavaScript/TypeScript ecosystem, where
+  > some libraries use thrown exceptions for control flow or important
+  > semantics. For example, some ORMs use thrown exceptions as a primary (and
+  > sometimes the only) way to abort a transaction.
+
+  This is the curried form, which allows you to create a standalone function
+  easily and pass any `Task` to it later. A form that accepts both the error
+  builder and the task at once exists as well.
+
+  ```ts
+  import * as task from 'true-myth/task';
+
+  class OrmError extends Error {
+    readonly name = "MyLib.OrmError";
+
+    constructor(err: unknown) {
+      super("True Myth `Task` was `Rejected`", { cause: err });
+    }
+  }
+
+  const abortable = task.orThrowWith((reason) => new OrmError(reason));
+
+  async function someOrmTransaction() {
+    let output = await abortable(doSomeTaskReturningOperation());
+    // ...
+  }
+  ```
+ */
+export function orThrowWith<T, E, Thrown extends Error>(
+  buildError: (reason: E) => Thrown
+): (task: Task<T, E>) => Promise<T>;
+export function orThrowWith<T, E, Thrown extends Error>(
+  buildError: (reason: E) => Thrown,
+  task?: Task<T, E>
+): Promise<T> | ((task: Task<T, E>) => Promise<T>) {
+  return task ? task.orThrowWith(buildError) : (task) => task.orThrowWith(buildError);
 }
 
 /**

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -837,6 +837,49 @@ describe('`Result` pure functions', () => {
     });
   });
 
+  describe('`orThrow` function', () => {
+    test('with `Ok`', () => {
+      const theOk = result.ok(123);
+      expect(result.orThrow(theOk)).toBe(123);
+    });
+
+    test('with `Err`', () => {
+      const theError = new Error('oh no');
+      const theErr = result.err(theError);
+      expect(() => result.orThrow(theErr)).toThrow(theError);
+    });
+  });
+
+  describe('`orThrowWith` function', () => {
+    class WrappedError extends Error {
+      constructor(readonly cause: unknown) {
+        super('WrappedError', { cause });
+      }
+    }
+
+    test('with `Ok` (direct form)', () => {
+      const theOk = result.ok(123);
+      expect(result.orThrowWith((e) => new WrappedError(e), theOk)).toBe(123);
+    });
+
+    test('with `Err` (direct form)', () => {
+      const theErr = result.err('oh no');
+      expect(() => result.orThrowWith((e) => new WrappedError(e), theErr)).toThrow(WrappedError);
+    });
+
+    test('with `Ok` (curried form)', () => {
+      const theOk = result.ok(123);
+      const throwWrapped = result.orThrowWith((e: string) => new WrappedError(e));
+      expect(throwWrapped(theOk)).toBe(123);
+    });
+
+    test('with `Err` (curried form)', () => {
+      const theErr = result.err('oh no');
+      const throwWrapped = result.orThrowWith((e: string) => new WrappedError(e));
+      expect(() => throwWrapped(theErr)).toThrow(WrappedError);
+    });
+  });
+
   describe('`flatten` function', () => {
     test('with `Ok(Ok(value))`', () => {
       let wrapped = result.ok(result.ok(123));
@@ -1261,6 +1304,24 @@ describe('`Ok` instance', () => {
     expect(result.toString()).toEqual(`Ok(5)`);
   });
 
+  test('`orThrow` method', () => {
+    const theOk = Result.ok<number, Error>(123);
+    expect(theOk.orThrow()).toBe(123);
+  });
+
+  describe('`orThrowWith` method', () => {
+    class WrappedError extends Error {
+      constructor(readonly cause: unknown) {
+        super('WrappedError', { cause });
+      }
+    }
+
+    test('returns the value', () => {
+      const theOk = Result.ok<number, string>(123);
+      expect(theOk.orThrowWith((e) => new WrappedError(e))).toBe(123);
+    });
+  });
+
   test('`cast` method', () => {
     const val = Result.ok<string, string>('hello');
 
@@ -1575,6 +1636,37 @@ describe('`result.Err` class', () => {
     const result = fn.ap(val);
 
     expect(result.toString()).toEqual(`Err("ERR_ALLURBASE")`);
+  });
+
+  test('`orThrow` method', () => {
+    const theError = new Error('oh no');
+    const theErr = Result.err<number, Error>(theError);
+    expect(() => theErr.orThrow()).toThrow(theError);
+  });
+
+  describe('`orThrowWith` method', () => {
+    class WrappedError extends Error {
+      constructor(readonly cause: unknown) {
+        super('WrappedError', { cause });
+      }
+    }
+
+    test('throws the built error', () => {
+      const theErr = Result.err<number, string>('oh no');
+      expect(() => theErr.orThrowWith((e) => new WrappedError(e))).toThrow(WrappedError);
+    });
+
+    test('passes the error to the builder', () => {
+      const theErr = Result.err<number, string>('oh no');
+      let caught: unknown;
+      try {
+        theErr.orThrowWith((e) => new WrappedError(e));
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(WrappedError);
+      expect((caught as WrappedError).cause).toBe('oh no');
+    });
   });
 });
 

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -27,6 +27,8 @@ import Task, {
   reject,
   withResolvers,
   orElse,
+  orThrow,
+  orThrowWith,
   match,
   or,
   andThen,
@@ -1299,6 +1301,43 @@ describe('`Task`', () => {
         expect(theTask.isResolved).toBe(false);
         expect(theTask.isRejected).toBe(true);
       }
+    });
+  });
+
+  describe('`orThrow` method', () => {
+    test('when the task resolves, returns the value', async () => {
+      await expect(Task.resolve(123).orThrow()).resolves.toBe(123);
+    });
+
+    test('when the task rejects, throws the error', async () => {
+      const theError = new Error('oh no');
+      await expect(Task.reject(theError).orThrow()).rejects.toThrow(theError);
+    });
+  });
+
+  describe('`orThrowWith` method', () => {
+    class WrappedError extends Error {
+      constructor(readonly cause: unknown) {
+        super('WrappedError', { cause });
+      }
+    }
+
+    test('when the task resolves, returns the value', async () => {
+      await expect(Task.resolve(123).orThrowWith((e) => new WrappedError(e))).resolves.toBe(123);
+    });
+
+    test('when the task rejects, throws the built error', async () => {
+      await expect(
+        Task.reject('oh no').orThrowWith((e) => new WrappedError(e))
+      ).rejects.toBeInstanceOf(WrappedError);
+    });
+
+    test('passes the rejection reason to the builder', async () => {
+      await expect(
+        Task.reject('oh no').orThrowWith((e) => new WrappedError(e))
+      ).rejects.toMatchObject({
+        cause: 'oh no',
+      });
     });
   });
 
@@ -3296,6 +3335,57 @@ describe('module-scope functions', () => {
         // Does *not* absorb initial type.
         expectTypeOf(theTask.reason).toEqualTypeOf<RejA | RejB>();
       }
+    });
+  });
+
+  describe('orThrow', () => {
+    test('when the task resolves, returns the value', async () => {
+      await expect(orThrow(Task.resolve(123))).resolves.toBe(123);
+    });
+
+    test('when the task rejects, throws the error', async () => {
+      const theError = new Error('oh no');
+      await expect(orThrow(Task.reject(theError))).rejects.toThrow(theError);
+    });
+  });
+
+  describe('orThrowWith', () => {
+    class WrappedError extends Error {
+      constructor(readonly cause: unknown) {
+        super('WrappedError', { cause });
+      }
+    }
+
+    describe('with both arguments', () => {
+      test('when the task resolves, returns the value', async () => {
+        await expect(orThrowWith((e) => new WrappedError(e), Task.resolve(123))).resolves.toBe(123);
+      });
+
+      test('when the task rejects, throws the built error', async () => {
+        await expect(
+          orThrowWith((e) => new WrappedError(e), Task.reject('oh no'))
+        ).rejects.toBeInstanceOf(WrappedError);
+      });
+
+      test('passes the rejection reason to the builder', async () => {
+        await expect(
+          orThrowWith((e) => new WrappedError(e), Task.reject('oh no'))
+        ).rejects.toMatchObject({
+          cause: 'oh no',
+        });
+      });
+    });
+
+    describe('with curried form', () => {
+      test('when the task resolves, returns the value', async () => {
+        const throwWrapped = orThrowWith((e: string) => new WrappedError(e));
+        await expect(throwWrapped(Task.resolve(123))).resolves.toBe(123);
+      });
+
+      test('when the task rejects, throws the built error', async () => {
+        const throwWrapped = orThrowWith((e: string) => new WrappedError(e));
+        await expect(throwWrapped(Task.reject('oh no'))).rejects.toBeInstanceOf(WrappedError);
+      });
     });
   });
 


### PR DESCRIPTION
Some third-party libraries use thrown exceptions for control flow or important semantics. ORMs, for example, may use thrown exceptions to abort a transaction. Add `toThrow` and `toThrowWith` methods and helper functions to `Result` and `Task` to support straightforward interop between True Myth and those libraries. These helpers are dual to the `try` family of functions: the `try` functions translate from exception-throwing APIs into True Myth's `Result` and Task APIs; the `orThrow` APIs do the opposite.

Fixes #1313