### PR TITLE
Set pnpm minimumReleaseAge explicitly

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ allowBuilds:
   esbuild: true
   sharp: false
   workerd: true
+minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - tar@7.5.7
   - tar@7.5.3


### PR DESCRIPTION
Dependabot appears to be using pnpm v10 (and it's not clear how to override it) and as of today only to *support* up through v10. Whereas pnpm v11 sets a `minimumReleaseAge` of `1440` minutes by default, v10 does not. This means that transitive dependencies can get bumped even past Dependabot's `cooldown` rules. Setting the rule explicitly avoids that: pnpm will not resolve *any* dependency, direct or transitive, that does not match its `minimumReleaseAge` criterion, on both v10 and v11.